### PR TITLE
Add admission-control config schema (mode + per-request/occupancy/per-key fields)

### DIFF
--- a/internal/auth/loader.go
+++ b/internal/auth/loader.go
@@ -39,24 +39,40 @@ type PerModelQuotaConfig struct {
 //     AND tokens_per_day (partial entries are rejected at load — "forgot a
 //     field" must never silently mean "unlimited").
 type QuotaConfig struct {
-	RequestsPerMinute int                             `yaml:"requests_per_minute,omitempty" json:"requests_per_minute,omitempty"`
-	TokensPerDay      int                             `yaml:"tokens_per_day,omitempty"      json:"tokens_per_day,omitempty"`
-	PerModel          map[string]*PerModelQuotaConfig `yaml:"per_model,omitempty"           json:"per_model,omitempty"`
+	RequestsPerMinute int `yaml:"requests_per_minute,omitempty" json:"requests_per_minute,omitempty"`
+	TokensPerDay      int `yaml:"tokens_per_day,omitempty"      json:"tokens_per_day,omitempty"`
+
+	// Per-key input/output token-per-minute buckets. Like RequestsPerMinute and
+	// TokensPerDay they are flat-shape fields and may not be combined with
+	// per_model. Zero means unset. A key's input bucket must be able to hold one
+	// maximum-size prompt (see ValidateITPMCoversMaxInput) or it silently caps
+	// the usable context.
+	InputTokensPerMinute  int `yaml:"input_tokens_per_minute,omitempty"  json:"input_tokens_per_minute,omitempty"`
+	OutputTokensPerMinute int `yaml:"output_tokens_per_minute,omitempty" json:"output_tokens_per_minute,omitempty"`
+
+	PerModel map[string]*PerModelQuotaConfig `yaml:"per_model,omitempty" json:"per_model,omitempty"`
 }
 
 // Validate checks the quota block for shape consistency and converts it into
 // the runtime QuotaLimits. label is included in error messages so the operator
 // can locate the offending key.
 func (q QuotaConfig) Validate(label string) (QuotaLimits, error) {
+	if q.InputTokensPerMinute < 0 || q.OutputTokensPerMinute < 0 {
+		return QuotaLimits{}, fmt.Errorf(
+			"auth: %s: input_tokens_per_minute and output_tokens_per_minute must be >= 0", label)
+	}
 	if q.PerModel == nil {
 		return QuotaLimits{
-			RequestsPerMinute: q.RequestsPerMinute,
-			TokensPerDay:      q.TokensPerDay,
+			RequestsPerMinute:     q.RequestsPerMinute,
+			TokensPerDay:          q.TokensPerDay,
+			InputTokensPerMinute:  q.InputTokensPerMinute,
+			OutputTokensPerMinute: q.OutputTokensPerMinute,
 		}, nil
 	}
-	if q.RequestsPerMinute != 0 || q.TokensPerDay != 0 {
+	if q.RequestsPerMinute != 0 || q.TokensPerDay != 0 ||
+		q.InputTokensPerMinute != 0 || q.OutputTokensPerMinute != 0 {
 		return QuotaLimits{}, fmt.Errorf(
-			"auth: %s: quota.per_model is set together with the legacy flat fields (requests_per_minute / tokens_per_day) — use one shape, not both",
+			"auth: %s: quota.per_model is set together with the flat fields (requests_per_minute / tokens_per_day / input_tokens_per_minute / output_tokens_per_minute) — use one shape, not both",
 			label)
 	}
 	if len(q.PerModel) == 0 {
@@ -155,6 +171,37 @@ type APIKeyEntry struct {
 
 	// Quota defines per-tenant rate and token limits. Zero means unlimited.
 	Quota QuotaConfig `yaml:"quota,omitempty"`
+
+	// MaxOccupancyShare is the fraction of a serverless replica's admit budget
+	// this key may hold in flight at once. Valid range (0, 1]; 0 means unset. It
+	// sits at the key level, not in quota, because it is measured against the
+	// replica's admit_budget_tokens rather than a per-minute rate. Ignored on
+	// reserved replicas.
+	MaxOccupancyShare float64 `yaml:"max_occupancy_share,omitempty"`
+}
+
+// validateOccupancyShare bounds a key's max_occupancy_share to (0, 1]; 0 is
+// accepted as "unset". A share above 1 would let one key reserve more than the
+// whole replica, defeating the fairness the cap exists to provide.
+func validateOccupancyShare(label string, share float64) error {
+	if share < 0 || share > 1 {
+		return fmt.Errorf("auth: %s: max_occupancy_share must be in (0, 1] (0 means unset), got %v", label, share)
+	}
+	return nil
+}
+
+// ValidateITPMCoversMaxInput checks that a serverless key's input token bucket
+// can hold at least one maximum-size prompt. Input tokens are reserved up front,
+// so a bucket below max_input_tokens would silently cap the usable context. A
+// zero bucket (unset) or zero maxInputTokens is skipped. The check spans the
+// policy and key configs, so the caller runs it once both are loaded.
+func ValidateITPMCoversMaxInput(label string, inputTokensPerMinute, maxInputTokens int) error {
+	if inputTokensPerMinute > 0 && maxInputTokens > 0 && inputTokensPerMinute < maxInputTokens {
+		return fmt.Errorf(
+			"auth: %s: input_tokens_per_minute (%d) is below the policy max_input_tokens (%d) — the bucket cannot hold one maximum-size prompt and would silently cap context",
+			label, inputTokensPerMinute, maxInputTokens)
+	}
+	return nil
 }
 
 // AuthSectionConfig configures the /v1/* auth provider.

--- a/internal/auth/provider.go
+++ b/internal/auth/provider.go
@@ -51,6 +51,16 @@ type QuotaLimits struct {
 	RequestsPerMinute int
 	TokensPerDay      int
 
+	// Serverless per-key caps; zero means unset. They apply only when the
+	// request lands on a serverless policy. InputTokensPerMinute and
+	// OutputTokensPerMinute are token-per-minute buckets. MaxOccupancyShare is
+	// the fraction of a replica's admit budget the key may hold in flight at once
+	// (0 < share <= 1); it comes from the key-level max_occupancy_share field,
+	// not the quota block.
+	InputTokensPerMinute  int
+	OutputTokensPerMinute int
+	MaxOccupancyShare     float64
+
 	// PerModel, when non-nil, replaces the flat fields above. Keys are model
 	// names as they appear in request bodies. A nil map is the legacy shape;
 	// an empty non-nil map is invalid and rejected at load.

--- a/internal/auth/static_key.go
+++ b/internal/auth/static_key.go
@@ -59,10 +59,15 @@ func NewStaticKeyProvider(entries []APIKeyEntry) (*StaticKeyProvider, error) {
 		if err != nil {
 			return nil, fmt.Errorf("auth: key entry %d (%q): %w", i, e.KeyPreview, err)
 		}
-		quota, err := e.Quota.Validate(fmt.Sprintf("key entry %d (%q)", i, e.KeyPreview))
+		label := fmt.Sprintf("key entry %d (%q)", i, e.KeyPreview)
+		quota, err := e.Quota.Validate(label)
 		if err != nil {
 			return nil, err
 		}
+		if err := validateOccupancyShare(label, e.MaxOccupancyShare); err != nil {
+			return nil, err
+		}
+		quota.MaxOccupancyShare = e.MaxOccupancyShare
 		keys[e.KeyHash] = keyEntry{
 			result: AuthResult{
 				TenantID:      e.Metadata.Owner,

--- a/internal/policy/loader.go
+++ b/internal/policy/loader.go
@@ -42,6 +42,15 @@ var knownExcludeIfFields = map[string]struct{}{
 	"cpu_usage_percent":     {},
 }
 
+// knownShedIfFields is the set of metrics accepted in a policy's shed_if block.
+// It is intentionally narrower than knownExcludeIfFields: front-door shedding
+// only makes sense on signals that read "the box is full now". A typo would
+// silently disable the shed gate, so unknown names are rejected at load.
+var knownShedIfFields = map[string]struct{}{
+	"kv_cache_utilization": {},
+	"waiting_requests":     {},
+}
+
 // knownStrategies is the set of strategy names that are currently implemented.
 // Add entries here as new strategies are written (see strategy.go).
 var knownStrategies = map[string]struct{}{
@@ -94,8 +103,13 @@ func LoadBytes(data []byte) (*Policy, error) {
 	return &p, nil
 }
 
-// Validate checks all policy steps for correctness and returns the first error found.
+// Validate checks all policy steps for correctness and returns the first error
+// found. It also normalises and validates the admission-control fields (mode,
+// per-request caps, shed_if), mutating p to fill in the mode default.
 func Validate(p *Policy) error {
+	if err := validateAdmissionGates(p); err != nil {
+		return err
+	}
 	if err := validateStep("routing_policy", p.RoutingPolicy); err != nil {
 		return err
 	}
@@ -280,11 +294,45 @@ func LoadDirSnapshot(dir string) (*DirSnapshot, error) {
 	return snap, nil
 }
 
-func validateThreshold(stepName, field string, rule ThresholdRule) error {
-	if _, ok := knownExcludeIfFields[field]; !ok {
-		return fmt.Errorf("policy: step %q: exclude_if.%s: unknown field — see ROUTING_POLICY.md for supported fields",
-			stepName, field)
+// validateAdmissionGates normalises the mode default and validates the
+// admission-control fields. It rejects an unknown mode, negative caps, and any
+// unknown or ill-formed shed_if entry. All caps are optional (zero = unset), so
+// a routing-only policy that sets none of them passes unchanged.
+func validateAdmissionGates(p *Policy) error {
+	if p.Mode == "" {
+		p.Mode = ModeReserved
 	}
+	if p.Mode != ModeReserved && p.Mode != ModeServerless {
+		return fmt.Errorf("policy: unknown mode %q — supported: reserved, serverless", p.Mode)
+	}
+	nonNeg := []struct {
+		name string
+		val  int
+	}{
+		{"max_input_tokens", p.MaxInputTokens},
+		{"images_max", p.ImagesMax},
+		{"admit_budget_tokens", p.AdmitBudgetTokens},
+		{"max_inflight", p.MaxInflight},
+	}
+	for _, f := range nonNeg {
+		if f.val < 0 {
+			return fmt.Errorf("policy: %s must be >= 0, got %d", f.name, f.val)
+		}
+	}
+	for field, rule := range p.ShedIf {
+		if _, ok := knownShedIfFields[field]; !ok {
+			return fmt.Errorf("policy: shed_if.%s: unknown field — supported: kv_cache_utilization, waiting_requests", field)
+		}
+		if n := operatorCount(rule); n != 1 {
+			return fmt.Errorf("policy: shed_if.%s: must specify exactly one operator (gt, lt, gte, lte), got %d", field, n)
+		}
+	}
+	return nil
+}
+
+// operatorCount returns how many of the four comparison operators are set on a
+// ThresholdRule. Exactly one is required.
+func operatorCount(rule ThresholdRule) int {
 	count := 0
 	if rule.GT != nil {
 		count++
@@ -298,6 +346,15 @@ func validateThreshold(stepName, field string, rule ThresholdRule) error {
 	if rule.LTE != nil {
 		count++
 	}
+	return count
+}
+
+func validateThreshold(stepName, field string, rule ThresholdRule) error {
+	if _, ok := knownExcludeIfFields[field]; !ok {
+		return fmt.Errorf("policy: step %q: exclude_if.%s: unknown field — see ROUTING_POLICY.md for supported fields",
+			stepName, field)
+	}
+	count := operatorCount(rule)
 	if count == 0 {
 		return fmt.Errorf("policy: step %q: exclude_if.%s: must specify exactly one operator (gt, lt, gte, lte)",
 			stepName, field)

--- a/internal/policy/types.go
+++ b/internal/policy/types.go
@@ -19,6 +19,59 @@ type Policy struct {
 	RoutingPolicy    PolicyStep        `yaml:"routing_policy"   json:"routing_policy"`
 	FallbackChain    []FallbackStep    `yaml:"fallback_chain"   json:"fallback_chain,omitempty"`
 	FallbackProvider *FallbackProvider `yaml:"fallback_provider" json:"fallback_provider,omitempty"`
+
+	// Mode selects which admission limits apply to this policy's replicas:
+	//   - "reserved" (default): shared circuit-breaker limits only, no per-key
+	//     caps (one client rents the whole replica).
+	//   - "serverless": the same circuit breaker plus per-key caps for the keys
+	//     that share the replica.
+	// Empty is normalised to "reserved" by Validate.
+	Mode PolicyMode `yaml:"mode" json:"mode,omitempty"`
+
+	// Admission-control limits. Zero means "unset": the corresponding gate is
+	// inert until a value is provided, so these fields change no behaviour on
+	// their own.
+	//
+	// There is deliberately no output-token limit: the router never clamps
+	// max_tokens (the engine already bounds output via max_model_len). An
+	// unenforced number here would only invite someone to wire it as a clamp.
+
+	// MaxInputTokens rejects any single request whose prompt exceeds it.
+	MaxInputTokens int `yaml:"max_input_tokens" json:"max_input_tokens,omitempty"`
+	// ImagesMax rejects any single request carrying more images than this.
+	ImagesMax int `yaml:"images_max" json:"images_max,omitempty"`
+	// AdmitBudgetTokens caps the total KV-cache tokens in flight per replica.
+	AdmitBudgetTokens int `yaml:"admit_budget_tokens" json:"admit_budget_tokens,omitempty"`
+	// MaxInflight caps the number of concurrent in-flight requests per replica.
+	MaxInflight int `yaml:"max_inflight" json:"max_inflight,omitempty"`
+	// ShedIf holds front-door shed thresholds; only kv_cache_utilization and
+	// waiting_requests are accepted (see knownShedIfFields in loader.go).
+	ShedIf map[string]ThresholdRule `yaml:"shed_if" json:"shed_if,omitempty"`
+}
+
+// PolicyMode selects the admission-limit profile for a policy's replicas.
+type PolicyMode string
+
+const (
+	// ModeReserved applies shared circuit-breaker limits only, no per-key caps.
+	// It is the default when mode is omitted.
+	ModeReserved PolicyMode = "reserved"
+	// ModeServerless adds per-key caps for keys sharing the replica.
+	ModeServerless PolicyMode = "serverless"
+)
+
+// EffectiveMode resolves the empty-string default to ModeReserved so callers
+// never have to special-case the unset value.
+func (p *Policy) EffectiveMode() PolicyMode {
+	if p.Mode == "" {
+		return ModeReserved
+	}
+	return p.Mode
+}
+
+// IsServerless reports whether per-key caps apply to this policy's replicas.
+func (p *Policy) IsServerless() bool {
+	return p.EffectiveMode() == ModeServerless
 }
 
 // FallbackProvider configures a last-resort closed-source model provider.

--- a/internal/router/admission_config.go
+++ b/internal/router/admission_config.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+package router
+
+import (
+	"fmt"
+	"slices"
+
+	"hivenet_router/internal/auth"
+	"hivenet_router/internal/config"
+	"hivenet_router/internal/policy"
+)
+
+// checkAdmissionConfig loads the API keys from auth.yaml (when configured for
+// api-key mode) and runs ValidateAdmissionInvariants against the effective
+// policies, keeping ValidateAdmissionInvariants pure and unit-testable. Other
+// auth modes have no static key list, so there is nothing to cross-check.
+func checkAdmissionConfig(cfg *config.Config, global *policy.Policy, named map[string]*policy.Policy) error {
+	keys, err := admissionKeysFromConfig(cfg)
+	if err != nil {
+		return err
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	return ValidateAdmissionInvariants(gatherPolicies(global, named), keys)
+}
+
+// admissionKeysFromConfig returns the API keys from auth.yaml for cross-config
+// validation, or nil when no static key list applies (no auth file, or a
+// non-api-key mode). Used both at startup and on reload.
+func admissionKeysFromConfig(cfg *config.Config) ([]auth.APIKeyEntry, error) {
+	if cfg.AuthConfigFile == "" {
+		return nil, nil
+	}
+	authCfg, err := auth.LoadAuthConfig(cfg.AuthConfigFile)
+	if err != nil {
+		return nil, err
+	}
+	if authCfg.API.Mode != auth.AuthModeAPIKey {
+		return nil, nil
+	}
+	return authCfg.API.Keys, nil
+}
+
+// gatherPolicies flattens the global policy plus the named per-model policies
+// into a single slice for ValidateAdmissionInvariants.
+func gatherPolicies(global *policy.Policy, named map[string]*policy.Policy) []*policy.Policy {
+	policies := make([]*policy.Policy, 0, 1+len(named))
+	if global != nil {
+		policies = append(policies, global)
+	}
+	for _, p := range named {
+		policies = append(policies, p)
+	}
+	return policies
+}
+
+// ValidateAdmissionInvariants enforces the admission-control invariants that
+// span the policy and auth configs — the ones neither loader can check alone
+// because each holds only half of the pair. Today that is the input-bucket rule:
+// on a serverless replica a key's input token bucket must be able to hold one
+// maximum-size prompt, or it silently caps the usable context. A violation is
+// returned so startup fails loudly rather than silently throttling full-context
+// traffic once serving begins.
+//
+// keys is the raw API-key list from auth.yaml; policies is every policy whose
+// replicas a key could reach (the effective global policy plus every named one).
+func ValidateAdmissionInvariants(policies []*policy.Policy, keys []auth.APIKeyEntry) error {
+	for _, p := range policies {
+		if p == nil || !p.IsServerless() || p.MaxInputTokens <= 0 {
+			// Nothing to check: reserved replicas have no per-key caps, and a
+			// policy with no input cap declares no context size to cover yet.
+			continue
+		}
+		for i, k := range keys {
+			if !keyReachesPolicy(k, p) {
+				continue
+			}
+			label := fmt.Sprintf("key entry %d (%q) on serverless models %v", i, k.KeyPreview, p.Models)
+			if err := auth.ValidateITPMCoversMaxInput(label, k.Quota.InputTokensPerMinute, p.MaxInputTokens); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// keyReachesPolicy reports whether a key could send a request to a model
+// governed by policy p. A key with no Models list may call any model; a policy
+// with no Models list governs every model (the global/default policy). Otherwise
+// the two model sets must intersect.
+func keyReachesPolicy(k auth.APIKeyEntry, p *policy.Policy) bool {
+	if len(k.Models) == 0 || len(p.Models) == 0 {
+		return true
+	}
+	for _, km := range k.Models {
+		if slices.Contains(p.Models, km) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -201,6 +201,10 @@ func New(cfg *config.Config) (*Router, error) {
 	executor.SetQueueMetrics(routerMetrics)
 
 	// Load per-model policies from the policy model directory if configured.
+	// effectiveGlobal / namedPolicies capture the policies actually in force so
+	// the admission invariants can be checked once auth keys are known.
+	effectiveGlobal := activePolicy
+	var namedPolicies map[string]*policy.Policy
 	var dirHashes map[string][32]byte
 	if cfg.PolicyModelDir != "" {
 		snap, err := policy.LoadDirSnapshot(cfg.PolicyModelDir)
@@ -213,10 +217,12 @@ func New(cfg *config.Config) (*Router, error) {
 				log.Warnf("Both --policy-file and _default.yaml in --policy-model-dir are set; _default.yaml takes precedence")
 			}
 			executor.SetPolicy(snap.Global)
+			effectiveGlobal = snap.Global
 			log.Infof("Global policy overridden by %s/_default.yaml", cfg.PolicyModelDir)
 		}
 		if len(snap.Named) > 0 {
 			executor.SetNamedPoliciesFromSnapshot(snap.Named)
+			namedPolicies = snap.Named
 			log.Infof("Loaded %d named policies from %s", len(snap.Named), cfg.PolicyModelDir)
 		}
 		dirHashes = snap.Hashes
@@ -227,6 +233,16 @@ func New(cfg *config.Config) (*Router, error) {
 	if err != nil {
 		store.Close() //nolint:errcheck
 		return nil, fmt.Errorf("auth providers: %w", err)
+	}
+
+	// Admission invariants that span the policy and auth configs (e.g. a
+	// serverless key's input bucket must cover one maximum-size prompt). Neither
+	// loader can check these alone, so they run here where both configs are in
+	// hand. Re-reads auth.yaml (small, already proven parseable above) for the
+	// raw key list.
+	if err := checkAdmissionConfig(cfg, effectiveGlobal, namedPolicies); err != nil {
+		store.Close() //nolint:errcheck
+		return nil, fmt.Errorf("admission config: %w", err)
 	}
 
 	// Build the rate limiter. When QuotaBackend is "badger", pass the storage
@@ -579,6 +595,26 @@ func (r *Router) validateProviderPolicy(p *policy.Policy) error {
 	return nil
 }
 
+// checkAdmissionAgainstKeys validates proposed policies against the API keys
+// currently on disk, so a reload cannot introduce a serverless key whose input
+// bucket no longer covers a model's context. A key-read error is logged and
+// treated as "cannot validate" (nil) so an unrelated auth.yaml problem does not
+// block a policy reload — that problem surfaces on the auth reload path instead.
+func (r *Router) checkAdmissionAgainstKeys(policies []*policy.Policy) error {
+	keys, err := admissionKeysFromConfig(r.cfg)
+	if err != nil {
+		log.Warnf("SIGHUP: could not read auth keys to validate policy admission invariants (%v) — skipping that check", err)
+		return nil
+	}
+	return ValidateAdmissionInvariants(policies, keys)
+}
+
+// currentAdmissionPolicies returns the policies currently in force (global plus
+// named) for cross-config re-validation on reload.
+func (r *Router) currentAdmissionPolicies() []*policy.Policy {
+	return gatherPolicies(r.executor.GetPolicy(), r.executor.GetNamedPolicies())
+}
+
 // watchPolicyReload listens for SIGHUP and reloads the policy file and/or
 // the policy model directory from disk without restarting the router.
 // Errors are logged and the previous policy stays active.
@@ -607,6 +643,9 @@ func (r *Router) watchPolicyReload() {
 				log.Errorf("SIGHUP: policy reload failed (%v) — keeping previous policy active", err)
 				r.metrics.PolicyReload("sighup", "error")
 			} else if err := r.validateProviderPolicy(p); err != nil {
+				log.Errorf("SIGHUP: policy reload rejected (%v) — keeping previous policy active", err)
+				r.metrics.PolicyReload("sighup", "error")
+			} else if err := r.checkAdmissionAgainstKeys([]*policy.Policy{p}); err != nil {
 				log.Errorf("SIGHUP: policy reload rejected (%v) — keeping previous policy active", err)
 				r.metrics.PolicyReload("sighup", "error")
 			} else {
@@ -674,6 +713,17 @@ func (r *Router) reloadAuthProviders() {
 		log.Info("SIGHUP: admin auth provider reloaded (dynamic API key registry preserved)")
 		return
 	}
+	// Re-check the cross-config invariants against the incoming keys before
+	// swapping, so a reload cannot introduce a serverless key whose input bucket
+	// no longer covers a model's context. Keep the previous providers on failure,
+	// mirroring how any other invalid auth reload is rejected.
+	if keys, err := admissionKeysFromConfig(r.cfg); err != nil {
+		log.Errorf("SIGHUP: auth config re-read for validation failed (%v) — keeping previous providers active", err)
+		return
+	} else if err := ValidateAdmissionInvariants(r.currentAdmissionPolicies(), keys); err != nil {
+		log.Errorf("SIGHUP: auth config reload rejected (%v) — keeping previous providers active", err)
+		return
+	}
 	r.apiAuth.Swap(apiProv)
 	r.adminAuth.Swap(adminProv)
 	r.rateLimiter.Reset()
@@ -709,6 +759,20 @@ func (r *Router) reloadPolicyModelDir() {
 	}
 	if !changed {
 		log.Debug("SIGHUP: policy model dir unchanged — skipping reload")
+		return
+	}
+
+	// Reject the whole dir reload if the proposed effective policy set would
+	// break the cross-config invariants against the current keys — keep the
+	// previous policies rather than silently cap context. proposedGlobal falls
+	// back to the current global when _default.yaml is absent from the snapshot.
+	proposedGlobal := snap.Global
+	if proposedGlobal == nil {
+		proposedGlobal = r.executor.GetPolicy()
+	}
+	if err := r.checkAdmissionAgainstKeys(gatherPolicies(proposedGlobal, snap.Named)); err != nil {
+		log.Errorf("SIGHUP: policy model dir reload rejected (%v) — keeping previous policies active", err)
+		r.metrics.PolicyReload("sighup", "error")
 		return
 	}
 

--- a/test/auth/admission_test.go
+++ b/test/auth/admission_test.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+// Black-box tests for the per-key admission fields on the auth config: the flat
+// input/output token-per-minute buckets, the key-level max_occupancy_share, and
+// the input-bucket-covers-context helper. Plumbing is verified through the
+// exported provider surface (NewStaticKeyProvider + Tenants).
+package auth_test
+
+import (
+	"strings"
+	"testing"
+
+	"hivenet_router/internal/auth"
+)
+
+func TestQuotaConfig_FlatWithITPMOTPM(t *testing.T) {
+	q := auth.QuotaConfig{
+		RequestsPerMinute:     96,
+		TokensPerDay:          5_000_000,
+		InputTokensPerMinute:  519_540,
+		OutputTokensPerMinute: 47_424,
+	}
+	limits, err := q.Validate("test")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if limits.InputTokensPerMinute != 519_540 || limits.OutputTokensPerMinute != 47_424 {
+		t.Errorf("input/output buckets not carried into QuotaLimits: %+v", limits)
+	}
+	if limits.RequestsPerMinute != 96 || limits.TokensPerDay != 5_000_000 {
+		t.Errorf("existing flat fields regressed: %+v", limits)
+	}
+}
+
+func TestQuotaConfig_PerModelConflictsWithITPM(t *testing.T) {
+	rpm, tpd := 60, 1000
+	q := auth.QuotaConfig{
+		InputTokensPerMinute: 519_540, // flat field...
+		PerModel: map[string]*auth.PerModelQuotaConfig{ // ...set together with per_model
+			"gemma-4-31b": {RequestsPerMinutePerReplica: &rpm, TokensPerDay: &tpd},
+		},
+	}
+	_, err := q.Validate("test")
+	if err == nil {
+		t.Fatal("expected error mixing per_model with a flat input bucket, got nil")
+	}
+	if !strings.Contains(err.Error(), "per_model") {
+		t.Errorf("error = %q, want it to mention the per_model conflict", err)
+	}
+}
+
+func TestQuotaConfig_NegativeITPM(t *testing.T) {
+	q := auth.QuotaConfig{InputTokensPerMinute: -1}
+	if _, err := q.Validate("test"); err == nil {
+		t.Fatal("expected error for a negative input bucket, got nil")
+	}
+}
+
+// TestQuota_RejectITPMBelowMaxInput: a serverless key's input token bucket must
+// hold at least one maximum-size prompt.
+func TestQuota_RejectITPMBelowMaxInput(t *testing.T) {
+	const maxInput = 262_144
+	cases := []struct {
+		name    string
+		itpm    int
+		wantErr bool
+	}{
+		{"covers", 519_540, false},
+		{"exactly-covers", maxInput, false},
+		{"one-below", maxInput - 1, true},
+		{"far-below", 100, true},
+		{"unset-bucket-skipped", 0, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := auth.ValidateITPMCoversMaxInput("key X", c.itpm, maxInput)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("err=%v, wantErr=%v", err, c.wantErr)
+			}
+			if err != nil && !strings.Contains(err.Error(), "262144") {
+				// The error must name both values so the operator can fix it.
+				t.Errorf("error must name max_input_tokens: %q", err)
+			}
+		})
+	}
+}
+
+// TestQuota_ZeroMaxInputSkipped: when the policy declares no input cap yet,
+// there is nothing to cover regardless of the bucket value.
+func TestQuota_ZeroMaxInputSkipped(t *testing.T) {
+	if err := auth.ValidateITPMCoversMaxInput("key X", 10, 0); err != nil {
+		t.Errorf("expected nil when maxInput=0, got %v", err)
+	}
+}
+
+// TestStaticKeyProvider_ServerlessKeyFullQuota: a serverless key with the full
+// set of caps (requests/min, input+output tokens/min, tokens/day, occupancy
+// share) loads and every value reaches the resolved QuotaLimits.
+func TestStaticKeyProvider_ServerlessKeyFullQuota(t *testing.T) {
+	entries := []auth.APIKeyEntry{{
+		KeyHash:           "hashserverless",
+		Metadata:          auth.KeyMetadata{Name: "some-customer", Owner: "serverless-tenant"},
+		Models:            []string{"gemma-4-31b"},
+		MaxOccupancyShare: 0.64,
+		Quota: auth.QuotaConfig{
+			RequestsPerMinute:     96,
+			InputTokensPerMinute:  519_540,
+			OutputTokensPerMinute: 47_424,
+			TokensPerDay:          5_000_000,
+		},
+	}}
+	p, err := auth.NewStaticKeyProvider(entries)
+	if err != nil {
+		t.Fatalf("NewStaticKeyProvider: %v", err)
+	}
+	got := p.Tenants()["serverless-tenant"]
+	if got.RequestsPerMinute != 96 || got.TokensPerDay != 5_000_000 ||
+		got.InputTokensPerMinute != 519_540 || got.OutputTokensPerMinute != 47_424 ||
+		got.MaxOccupancyShare != 0.64 {
+		t.Errorf("QuotaLimits = %+v, want RPM=96 TPD=5M ITPM=519540 OTPM=47424 share=0.64", got)
+	}
+}
+
+// TestStaticKeyProvider_ReservedKeyNoQuota: a reserved-replica key carries auth
+// + metadata only (no quota, no occupancy share) and must load with zero
+// (unlimited) limits — the reserved product has no per-key caps.
+func TestStaticKeyProvider_ReservedKeyNoQuota(t *testing.T) {
+	entries := []auth.APIKeyEntry{{
+		KeyHash:  "hashreserved",
+		Metadata: auth.KeyMetadata{Name: "acme-reserved-r0", Owner: "reserved-tenant"},
+		Models:   []string{"gemma-4-31b"},
+	}}
+	p, err := auth.NewStaticKeyProvider(entries)
+	if err != nil {
+		t.Fatalf("NewStaticKeyProvider: %v", err)
+	}
+	got := p.Tenants()["reserved-tenant"]
+	if got.RequestsPerMinute != 0 || got.TokensPerDay != 0 ||
+		got.InputTokensPerMinute != 0 || got.OutputTokensPerMinute != 0 ||
+		got.MaxOccupancyShare != 0 || got.PerModel != nil {
+		t.Errorf("reserved key must have zero (unlimited) limits, got %+v", got)
+	}
+}
+
+// TestStaticKeyProvider_OccupancyShareRange drives the (0,1] bound through the
+// exported provider: 0 (unset) and values up to 1 load; a share above 1 or
+// below 0 is rejected (it would let one key reserve more than the whole box).
+func TestStaticKeyProvider_OccupancyShareRange(t *testing.T) {
+	cases := []struct {
+		share   float64
+		wantErr bool
+	}{
+		{0, false},
+		{0.40, false},
+		{0.64, false},
+		{1, false},
+		{1.5, true},
+		{-0.1, true},
+	}
+	for _, c := range cases {
+		entries := []auth.APIKeyEntry{{
+			KeyHash:           "hashshare",
+			Metadata:          auth.KeyMetadata{Name: "k", Owner: "acme"},
+			MaxOccupancyShare: c.share,
+		}}
+		_, err := auth.NewStaticKeyProvider(entries)
+		if (err != nil) != c.wantErr {
+			t.Errorf("max_occupancy_share=%v: err=%v, wantErr=%v", c.share, err, c.wantErr)
+		}
+	}
+}

--- a/test/e2e/admission_wiring_test.go
+++ b/test/e2e/admission_wiring_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+// Integration tests that prove the cross-config admission check is actually
+// wired into router.New — not merely unit-tested in isolation. They construct a
+// real router from on-disk policy + auth files and assert startup is rejected
+// (or accepted) based on the input-bucket-covers-context invariant.
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"hivenet_router/internal/config"
+	"hivenet_router/internal/router"
+)
+
+const admissionServerlessPolicy = `models: [gemma-4-31b]
+mode: serverless
+routing_policy:
+  strategy: least-loaded
+max_input_tokens: 262144
+`
+
+// admissionAuthYAML returns an api-key auth config with one serverless key whose
+// input token bucket is the given size.
+func admissionAuthYAML(itpm int) string {
+	return fmt.Sprintf(`api:
+  mode: api-key
+  keys:
+    - key_hash: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      metadata:
+        name: test-key
+        owner: acme
+      models: [gemma-4-31b]
+      quota:
+        input_tokens_per_minute: %d
+admin:
+  mode: none
+`, itpm)
+}
+
+// writeAdmissionFile writes content into dir/name and returns the path.
+func writeAdmissionFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return p
+}
+
+// admissionRouterCfg builds a minimal config that reaches router.New's admission
+// check: a JWT secret, a temp Badger dir, and the given policy + auth files.
+func admissionRouterCfg(t *testing.T, itpm int) *config.Config {
+	t.Helper()
+	// api-key mode with admin=none requires the explicit insecure-admin opt-in.
+	t.Setenv("HIVENET_ROUTER_ALLOW_INSECURE_ADMIN", "true")
+	dir := t.TempDir()
+	cfg := config.DefaultConfig()
+	cfg.JWTSecret = jwtSecret
+	cfg.DiskDBPath = filepath.Join(dir, "badger")
+	cfg.PolicyFile = writeAdmissionFile(t, dir, "policy.yaml", admissionServerlessPolicy)
+	cfg.AuthConfigFile = writeAdmissionFile(t, dir, "auth.yaml", admissionAuthYAML(itpm))
+	return cfg
+}
+
+// TestAdmissionWiring_StartupRejectsUndersizedBucket proves the check is wired
+// into router.New: a serverless key whose input bucket cannot hold one
+// max-size prompt fails startup, with an error naming both numbers.
+func TestAdmissionWiring_StartupRejectsUndersizedBucket(t *testing.T) {
+	_, err := router.New(admissionRouterCfg(t, 100))
+	if err == nil {
+		t.Fatal("expected router.New to reject the undersized input bucket, got nil")
+	}
+	if !strings.Contains(err.Error(), "input_tokens_per_minute") || !strings.Contains(err.Error(), "262144") {
+		t.Errorf("startup error should name both values, got: %v", err)
+	}
+}
+
+// TestAdmissionWiring_StartupAcceptsCoveringBucket is the positive control: the
+// same policy with a bucket that covers max_input_tokens starts cleanly.
+func TestAdmissionWiring_StartupAcceptsCoveringBucket(t *testing.T) {
+	r, err := router.New(admissionRouterCfg(t, 519_540))
+	if err != nil {
+		t.Fatalf("router.New rejected a valid config: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}

--- a/test/policy/admission_test.go
+++ b/test/policy/admission_test.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+// Black-box tests for the admission-control schema fields on Policy: mode (with
+// its reserved default), the per-request/occupancy caps, and the shed_if block.
+package policy_test
+
+import (
+	"strings"
+	"testing"
+
+	"hivenet_router/internal/policy"
+
+	"github.com/goccy/go-yaml"
+)
+
+// reservedPolicyYAML is a reserved-mode policy with every admission field set
+// (plus the routing_policy block every policy requires).
+const reservedPolicyYAML = `
+models: [gemma-4-31b]
+routing_policy:
+  strategy: least-loaded
+max_input_tokens: 262144
+images_max: 10
+admit_budget_tokens: 408987
+max_inflight: 37
+shed_if:
+  kv_cache_utilization: { gt: 0.90 }
+  waiting_requests:     { gt: 20 }
+`
+
+// serverlessPolicyYAML is the same policy in serverless mode.
+const serverlessPolicyYAML = `
+models: [gemma-4-31b]
+mode: serverless
+routing_policy:
+  strategy: least-loaded
+max_input_tokens: 262144
+images_max: 10
+admit_budget_tokens: 408987
+max_inflight: 37
+shed_if:
+  kv_cache_utilization: { gt: 0.90 }
+  waiting_requests:     { gt: 20 }
+`
+
+// assertRoundTrip loads a policy, marshals it, reloads it, and asserts the
+// re-marshaled bytes are byte-identical — a stable equality check that avoids
+// reflect.DeepEqual's nil-map / pointer pitfalls on ThresholdRule.
+func assertRoundTrip(t *testing.T, p *policy.Policy) {
+	t.Helper()
+	out1, err := yaml.Marshal(p)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	p2, err := policy.LoadBytes(out1)
+	if err != nil {
+		t.Fatalf("LoadBytes(round-trip): %v", err)
+	}
+	out2, err := yaml.Marshal(p2)
+	if err != nil {
+		t.Fatalf("Marshal(round-trip): %v", err)
+	}
+	if string(out1) != string(out2) {
+		t.Errorf("round-trip mismatch:\n first:\n%s\nsecond:\n%s", out1, out2)
+	}
+}
+
+func TestPolicy_ReservedRoundTrip(t *testing.T) {
+	p, err := policy.LoadBytes([]byte(reservedPolicyYAML))
+	if err != nil {
+		t.Fatalf("LoadBytes: %v", err)
+	}
+	if p.EffectiveMode() != policy.ModeReserved {
+		t.Errorf("mode = %q, want reserved (default)", p.EffectiveMode())
+	}
+	if p.IsServerless() {
+		t.Error("IsServerless() = true, want false for reserved policy")
+	}
+	if p.MaxInputTokens != 262144 || p.ImagesMax != 10 ||
+		p.AdmitBudgetTokens != 408987 || p.MaxInflight != 37 {
+		t.Errorf("caps not loaded: %+v", p)
+	}
+	rule, ok := p.ShedIf["kv_cache_utilization"]
+	if !ok || rule.GT == nil || *rule.GT != 0.90 {
+		t.Errorf("shed_if.kv_cache_utilization not loaded: %+v", p.ShedIf)
+	}
+	assertRoundTrip(t, p)
+}
+
+func TestPolicy_ServerlessRoundTrip(t *testing.T) {
+	p, err := policy.LoadBytes([]byte(serverlessPolicyYAML))
+	if err != nil {
+		t.Fatalf("LoadBytes: %v", err)
+	}
+	if !p.IsServerless() {
+		t.Errorf("IsServerless() = false, want true; mode=%q", p.Mode)
+	}
+	assertRoundTrip(t, p)
+}
+
+func TestPolicy_ModeDefaults(t *testing.T) {
+	// A routing-only policy (no admission fields) must still load and default to
+	// reserved — adding the schema changes no existing behaviour.
+	p, err := policy.LoadBytes([]byte("routing_policy:\n  strategy: least-loaded\n"))
+	if err != nil {
+		t.Fatalf("LoadBytes: %v", err)
+	}
+	if p.Mode != policy.ModeReserved {
+		t.Errorf("Mode = %q, want normalised to reserved", p.Mode)
+	}
+	if p.EffectiveMode() != policy.ModeReserved {
+		t.Errorf("EffectiveMode() = %q, want reserved", p.EffectiveMode())
+	}
+}
+
+func TestPolicy_RejectUnknownMode(t *testing.T) {
+	_, err := policy.LoadBytes([]byte("mode: reserverd\nrouting_policy:\n  strategy: least-loaded\n"))
+	if err == nil {
+		t.Fatal("expected error for unknown mode, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown mode") {
+		t.Errorf("error = %q, want it to mention 'unknown mode'", err)
+	}
+}
+
+func TestPolicy_RejectNegativeCap(t *testing.T) {
+	_, err := policy.LoadBytes([]byte("max_input_tokens: -1\nrouting_policy:\n  strategy: least-loaded\n"))
+	if err == nil {
+		t.Fatal("expected error for negative max_input_tokens, got nil")
+	}
+	if !strings.Contains(err.Error(), "max_input_tokens") {
+		t.Errorf("error = %q, want it to name the offending field", err)
+	}
+}
+
+func TestPolicy_RejectUnknownShedIfField(t *testing.T) {
+	// gpu_temperature_c is a valid exclude_if field but NOT a valid shed_if field
+	// — shedding at the front door only makes sense on kv/queue signals.
+	y := "routing_policy:\n  strategy: least-loaded\nshed_if:\n  gpu_temperature_c: { gt: 80 }\n"
+	_, err := policy.LoadBytes([]byte(y))
+	if err == nil {
+		t.Fatal("expected error for unknown shed_if field, got nil")
+	}
+	if !strings.Contains(err.Error(), "shed_if") {
+		t.Errorf("error = %q, want it to mention shed_if", err)
+	}
+}
+
+func TestPolicy_RejectShedIfNoOperator(t *testing.T) {
+	y := "routing_policy:\n  strategy: least-loaded\nshed_if:\n  kv_cache_utilization: {}\n"
+	_, err := policy.LoadBytes([]byte(y))
+	if err == nil {
+		t.Fatal("expected error for shed_if rule with no operator, got nil")
+	}
+	if !strings.Contains(err.Error(), "exactly one operator") {
+		t.Errorf("error = %q, want it to mention the operator requirement", err)
+	}
+}

--- a/test/router/admission_config_test.go
+++ b/test/router/admission_config_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+// Black-box tests for the cross-config invariant that a serverless key's input
+// token bucket must cover one maximum-size prompt. Exercises the exported
+// router.ValidateAdmissionInvariants over the public policy/auth types.
+package router_test
+
+import (
+	"testing"
+
+	"hivenet_router/internal/auth"
+	"hivenet_router/internal/policy"
+	"hivenet_router/internal/router"
+)
+
+func serverlessPolicy(models []string, maxInput int) *policy.Policy {
+	return &policy.Policy{Models: models, Mode: policy.ModeServerless, MaxInputTokens: maxInput}
+}
+
+func keyWithITPM(models []string, itpm int) auth.APIKeyEntry {
+	return auth.APIKeyEntry{
+		KeyPreview: "sk-...X",
+		Models:     models,
+		Quota:      auth.QuotaConfig{InputTokensPerMinute: itpm},
+	}
+}
+
+func TestValidateAdmissionInvariants_RejectsITPMBelowMaxInput(t *testing.T) {
+	policies := []*policy.Policy{serverlessPolicy([]string{"gemma-4-31b"}, 262_144)}
+	keys := []auth.APIKeyEntry{keyWithITPM([]string{"gemma-4-31b"}, 100)}
+	if err := router.ValidateAdmissionInvariants(policies, keys); err == nil {
+		t.Fatal("expected error for an input bucket below max_input_tokens, got nil")
+	}
+}
+
+func TestValidateAdmissionInvariants_Pass(t *testing.T) {
+	policies := []*policy.Policy{serverlessPolicy([]string{"gemma-4-31b"}, 262_144)}
+	keys := []auth.APIKeyEntry{keyWithITPM([]string{"gemma-4-31b"}, 519_540)}
+	if err := router.ValidateAdmissionInvariants(policies, keys); err != nil {
+		t.Errorf("expected nil for a bucket covering max_input, got %v", err)
+	}
+}
+
+func TestValidateAdmissionInvariants_ReservedModeSkipped(t *testing.T) {
+	// Same undersized bucket, but a reserved policy has no per-key caps.
+	reserved := &policy.Policy{Models: []string{"gemma-4-31b"}, Mode: policy.ModeReserved, MaxInputTokens: 262_144}
+	keys := []auth.APIKeyEntry{keyWithITPM([]string{"gemma-4-31b"}, 100)}
+	if err := router.ValidateAdmissionInvariants([]*policy.Policy{reserved}, keys); err != nil {
+		t.Errorf("reserved policy must skip the input-bucket check, got %v", err)
+	}
+}
+
+func TestValidateAdmissionInvariants_UnsetBucketSkipped(t *testing.T) {
+	// A zero bucket means unset; nothing to check yet.
+	policies := []*policy.Policy{serverlessPolicy([]string{"gemma-4-31b"}, 262_144)}
+	keys := []auth.APIKeyEntry{keyWithITPM([]string{"gemma-4-31b"}, 0)}
+	if err := router.ValidateAdmissionInvariants(policies, keys); err != nil {
+		t.Errorf("an unset bucket must be skipped, got %v", err)
+	}
+}
+
+// TestValidateAdmissionInvariants_Reachability drives the key→policy reach logic
+// through the public entrypoint: an undersized bucket errors iff the key can
+// actually reach the serverless policy's models.
+func TestValidateAdmissionInvariants_Reachability(t *testing.T) {
+	cases := []struct {
+		name      string
+		keyModels []string
+		polModels []string
+		wantErr   bool
+	}{
+		{"both-unrestricted", nil, nil, true},
+		{"key-unrestricted", nil, []string{"a"}, true},
+		{"policy-global", []string{"a"}, nil, true},
+		{"intersect", []string{"a", "b"}, []string{"b", "c"}, true},
+		{"disjoint", []string{"a"}, []string{"b"}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			policies := []*policy.Policy{serverlessPolicy(c.polModels, 262_144)}
+			keys := []auth.APIKeyEntry{keyWithITPM(c.keyModels, 100)}
+			err := router.ValidateAdmissionInvariants(policies, keys)
+			if (err != nil) != c.wantErr {
+				t.Errorf("err=%v, wantErr=%v", err, c.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Admission-control config schema

First step toward the admission-control work: the **load-and-validate schema** every later gate reads. **Schema + validation only — no enforcement.** All new fields are optional and default to inert, so this changes no runtime behaviour until a value is set.

### What it adds
**Policy (`internal/policy`)**
- `mode: reserved | serverless` (defaults to `reserved`; `EffectiveMode()`/`IsServerless()` helpers)
- per-request and occupancy caps: `max_input_tokens`, `images_max`, `admit_budget_tokens`, `max_inflight`
- `shed_if` block (`kv_cache_utilization`, `waiting_requests`), reusing the existing `ThresholdRule`
- Validation: unknown mode, negative caps, unknown/ill-formed `shed_if` fields (strict enumeration, matching the existing `exclude_if`/strategy style)
- **Deliberately no output-token field** — the router never clamps `max_tokens`; the engine already bounds output via `max_model_len`

**Auth (`internal/auth`)**
- `QuotaConfig`: `input_tokens_per_minute` / `output_tokens_per_minute` (flat shape — rejected alongside `per_model`, non-negative), carried into runtime `QuotaLimits`
- `APIKeyEntry`: key-level `max_occupancy_share`, validated to `(0,1]`, plumbed into `QuotaLimits` via the static provider
- `ValidateITPMCoversMaxInput`: a serverless key's input token bucket must hold at least one maximum-size prompt, or it silently caps the usable context

**Cross-config (`internal/router`)**
- `checkAdmissionConfig` / `validateAdmissionInvariants` run at `router.New`, where the policy and auth configs meet, and **fail startup** when a serverless key's input bucket is below the model's `max_input_tokens`

### Design notes
- `max_occupancy_share` is kept at the **key level** (not inside `quota:`) because it is measured against the replica's `admit_budget_tokens`, not a per-minute rate.
- The input-bucket invariant is genuinely cross-file (bucket on the key, `max_input_tokens` on the policy); neither loader can see both, so it lives in `router.New`.
- "Unknown key" = enumerated-field validation (mode value, `shed_if` names). YAML decoding stays non-strict, consistent with the rest of the codebase.

### Verification
`go build ./...`, `go vet ./...`, `golangci-lint` (0 issues), and the full `go test ./...` suite all pass. New tests in `internal/policy`, `internal/auth`, and `internal/router` cover round-trip, the mode default, the input-bucket rejection (error names both values), unknown-key rejection, and reserved/serverless key loading.