### PR TITLE
Add KV-occupancy admit budget

### DIFF
--- a/internal/admission/controller.go
+++ b/internal/admission/controller.go
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+// Package admission implements the KV-occupancy admit budget: a token-weighted
+// count of in-flight work per model. A request's footprint is its input tokens
+// plus its output — the declared max_tokens reserved up front, or, when the
+// output is undeclared, a live count that grows as the response streams. A new
+// request is admitted only while the running weighted sum plus its own footprint
+// stays within the budget, so a burst of large requests degrades to a clean 429
+// rather than overcommitting the engine's KV cache and inflating everyone's
+// latency. The budget is the engine's per-replica token capacity scaled by an
+// operator admit fraction; both are supplied by the caller per request.
+//
+// The accounting is pure and engine-agnostic: it counts tokens the router
+// already estimates and never reads engine internals. All state is per model
+// name; nothing here knows about replicas, agents, or a specific engine.
+package admission
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Controller holds the per-model weighted in-flight state and applies the admit
+// fraction to each request's budget. It is safe for concurrent use.
+type Controller struct {
+	admitFraction float64       // scales the caller's budget tokens; (0,1]
+	parkFor       time.Duration // how long an over-budget request waits for room before 429
+
+	mu     sync.Mutex
+	models map[string]*modelState
+}
+
+// NewController returns a Controller. admitFraction scales every request's
+// budget (e.g. 0.85 admits up to 85% of the engine's KV token capacity); values
+// outside (0,1] are clamped to 1. parkFor bounds how long an over-budget request
+// waits for capacity to free before it is rejected; 0 means reject immediately.
+func NewController(admitFraction float64, parkFor time.Duration) *Controller {
+	if admitFraction <= 0 || admitFraction > 1 {
+		admitFraction = 1
+	}
+	return &Controller{
+		admitFraction: admitFraction,
+		parkFor:       parkFor,
+		models:        make(map[string]*modelState),
+	}
+}
+
+// modelState is the weighted in-flight accounting for one model. Its own mutex
+// guards the counters and the broadcast channel; the Controller mutex guards
+// only the map that hands these out.
+type modelState struct {
+	mu     sync.Mutex
+	sumW   int64         // Σ footprint over in-flight requests for this model
+	count  int           // number of in-flight requests (the max_inflight backstop)
+	notify chan struct{} // closed-and-replaced on every release to wake parked waiters
+}
+
+func (c *Controller) stateFor(model string) *modelState {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	s := c.models[model]
+	if s == nil {
+		s = &modelState{notify: make(chan struct{})}
+		c.models[model] = s
+	}
+	return s
+}
+
+// Admit reserves footprint tokens for a request against model's budget, parking
+// up to the configured park duration if there is no room yet, until capacity
+// frees or ctx is done.
+//
+//   - footprint is the weight to charge now: input + declared max_tokens for a
+//     declared request, or just input for an undeclared one.
+//   - grows marks an undeclared request whose reservation is grown via
+//     Reservation.Grow as output streams; a declared request passes false.
+//   - budgetTokens is the model's per-replica KV token capacity; the admit
+//     fraction is applied here. budgetTokens <= 0 disables the budget check.
+//   - maxInflight caps concurrent in-flight requests; <= 0 disables the backstop.
+//
+// It returns a Reservation to release exactly once when the request finishes, or
+// nil if the request could not be admitted within the park window. The caller
+// owns release (a single deferred Release on every exit path); the reservation
+// is never released here.
+func (c *Controller) Admit(ctx context.Context, model string, footprint int, grows bool, budgetTokens, maxInflight int) *Reservation {
+	s := c.stateFor(model)
+	w := int64(footprint)
+	budget := c.effectiveBudget(budgetTokens)
+
+	if s.tryReserve(w, budget, maxInflight) {
+		return &Reservation{state: s, weight: w, grows: grows}
+	}
+	// A request whose own footprint exceeds the budget can never fit — releases
+	// only lower the in-flight sum toward zero — so reject it now rather than
+	// parking a doomed request for the full window. The max_inflight dimension is
+	// deliberately not short-circuited: a release frees a count slot, so parking
+	// for one is worthwhile.
+	if budget > 0 && w > budget {
+		return nil
+	}
+	if c.parkFor <= 0 {
+		return nil
+	}
+
+	timer := time.NewTimer(c.parkFor)
+	defer timer.Stop()
+	for {
+		// Grab the current wake channel BEFORE re-checking, so a release that
+		// happens between the check and the wait cannot be missed.
+		ch := s.notifyCh()
+		if s.tryReserve(w, budget, maxInflight) {
+			return &Reservation{state: s, weight: w, grows: grows}
+		}
+		select {
+		case <-ch:
+			// A request released; loop and retry.
+		case <-timer.C:
+			return nil
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+// effectiveBudget applies the admit fraction. A non-positive budget disables the
+// check (tryReserve treats <= 0 as "no budget limit"). A positive budget is
+// floored at 1 so the fraction can never truncate it to 0 — which tryReserve
+// would read as "unlimited", admitting everything, the exact opposite of what a
+// small budget should do.
+func (c *Controller) effectiveBudget(budgetTokens int) int64 {
+	if budgetTokens <= 0 {
+		return 0
+	}
+	b := int64(c.admitFraction * float64(budgetTokens))
+	if b < 1 {
+		b = 1
+	}
+	return b
+}
+
+// Occupancy returns the current weighted in-flight sum and request count for a
+// model, for metrics and tests. A model never seen returns zero.
+func (c *Controller) Occupancy(model string) (sumW int64, count int) {
+	c.mu.Lock()
+	s := c.models[model]
+	c.mu.Unlock()
+	if s == nil {
+		return 0, 0
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sumW, s.count
+}
+
+// tryReserve adds weight if it fits both the budget and the in-flight backstop,
+// reporting whether it did. A budget or backstop of <= 0 disables that check.
+func (s *modelState) tryReserve(weight, budget int64, maxInflight int) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if budget > 0 && s.sumW+weight > budget {
+		return false
+	}
+	if maxInflight > 0 && s.count+1 > maxInflight {
+		return false
+	}
+	s.sumW += weight
+	s.count++
+	return true
+}
+
+// release returns weight to the budget and wakes every parked waiter by closing
+// the current notify channel and installing a fresh one.
+func (s *modelState) release(weight int64) {
+	s.mu.Lock()
+	s.sumW -= weight
+	if s.sumW < 0 {
+		s.sumW = 0
+	}
+	s.count--
+	if s.count < 0 {
+		s.count = 0
+	}
+	ch := s.notify
+	s.notify = make(chan struct{})
+	s.mu.Unlock()
+	close(ch)
+}
+
+// grow tightens occupancy as an undeclared request produces output. It never
+// frees capacity, so it does not wake waiters.
+func (s *modelState) grow(delta int64) {
+	s.mu.Lock()
+	s.sumW += delta
+	s.mu.Unlock()
+}
+
+func (s *modelState) notifyCh() chan struct{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.notify
+}

--- a/internal/admission/reservation.go
+++ b/internal/admission/reservation.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+package admission
+
+import "sync"
+
+// Reservation is the budget a request holds for its lifetime. The handler owns
+// it: it holds the footprint charged at admission, grows it as undeclared output
+// streams, and must Release it exactly once when the request finishes — on every
+// exit path (success, error, timeout, disconnect, failover). Release is
+// idempotent, and Grow after Release is a no-op, so a late streaming callback
+// cannot leak budget.
+type Reservation struct {
+	state *modelState
+	grows bool // only undeclared requests grow; declared reserved max_tokens up front
+
+	mu       sync.Mutex
+	weight   int64
+	released bool
+}
+
+// Grow adds streamed output tokens to an undeclared request's footprint so the
+// occupancy sum reflects live output. It is a no-op for a declared request
+// (which reserved its max_tokens up front), after Release, or for a nil
+// reservation, so the caller can invoke it unconditionally per output chunk.
+func (r *Reservation) Grow(tokens int) {
+	if r == nil || tokens <= 0 {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.released || !r.grows {
+		return
+	}
+	r.weight += int64(tokens)
+	r.state.grow(int64(tokens))
+}
+
+// Release returns the reservation's full footprint to the budget. It is safe to
+// call more than once and on a nil reservation; only the first call has effect.
+func (r *Reservation) Release() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	if r.released {
+		r.mu.Unlock()
+		return
+	}
+	r.released = true
+	w := r.weight
+	r.mu.Unlock()
+	r.state.release(w)
+}
+
+// Weight returns the footprint currently charged, for tests and metrics.
+func (r *Reservation) Weight() int64 {
+	if r == nil {
+		return 0
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.weight
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"hivenet_router/internal/admission"
 	"hivenet_router/internal/auth"
 	"hivenet_router/internal/domain"
 	"hivenet_router/internal/policy"
@@ -223,6 +224,11 @@ type Handlers struct {
 	// handler on /admin/registration-stream consumes. Nil-safe: the handler
 	// returns 501 when no feed is wired (e.g. tests).
 	registrationFeed RegistrationFeed
+
+	// admission enforces the per-model KV-occupancy admit budget before a request
+	// is queued. Nil disables the gate (e.g. tests, or when no policy declares a
+	// budget). Reservations it hands out are released on every request exit path.
+	admission *admission.Controller
 }
 
 // NewHandlers initializes a Handlers instance with all required dependencies.
@@ -246,6 +252,7 @@ func NewHandlers(
 	resetMetrics func() error,
 	healthyAgentCount func(model string) int,
 	registrationFeed RegistrationFeed,
+	admissionController *admission.Controller,
 ) *Handlers {
 	return &Handlers{
 		storage:              storage,
@@ -264,6 +271,7 @@ func NewHandlers(
 		resetMetrics:         resetMetrics,
 		healthyAgentCount:    healthyAgentCount,
 		registrationFeed:     registrationFeed,
+		admission:            admissionController,
 	}
 }
 
@@ -353,6 +361,14 @@ func (h *Handlers) Passthrough(c *gin.Context) {
 	if !h.enforceRequestCaps(c, &req) {
 		return
 	}
+	// Occupancy admit budget. The reservation is released on every exit path
+	// below via this single defer — success, error, timeout, disconnect, and the
+	// daily-budget reject that may follow — so a slot is never leaked.
+	reservation, admitted := h.enforceOccupancyBudget(c, &req)
+	if !admitted {
+		return
+	}
+	defer reservation.Release()
 
 	m.requestID = generateRequestID()
 	m.tenantID, m.keyID, m.deploymentID = callerIDs(c)
@@ -379,6 +395,9 @@ func (h *Handlers) Passthrough(c *gin.Context) {
 	pending.QuotaModel = m.quotaModel
 	pending.Capability = domain.CapabilityLLM
 	pending.Path = path // forward to the backend's native endpoint at this path
+	if reservation != nil {
+		pending.Reservation = reservation // processor grows it as undeclared output streams
+	}
 
 	if !h.enqueueRequest(c, pending, m.requestID, req.Model) {
 		return
@@ -484,6 +503,55 @@ func (h *Handlers) enforceRequestCaps(c *gin.Context, req *domain.ChatRequest) b
 	return true
 }
 
+// enforceOccupancyBudget applies the KV-occupancy admit budget: the request is
+// admitted only while the model's weighted in-flight token sum plus this
+// request's footprint stays within admit_fraction × admit_budget_tokens, and the
+// in-flight request count stays within max_inflight. The footprint is the input
+// estimate plus the declared max_tokens (reserved up front); an undeclared
+// request reserves only its input and grows as output streams. Over budget, it
+// parks briefly for capacity to free, then returns 429 concurrency_limit_exceeded
+// with Retry-After.
+//
+// It returns the reservation (which the caller MUST release exactly once on every
+// exit path) and whether the request was admitted. A nil reservation with ok=true
+// means the gate is inert for this model — nothing to release, nothing rejected.
+func (h *Handlers) enforceOccupancyBudget(c *gin.Context, req *domain.ChatRequest) (*admission.Reservation, bool) {
+	if h.admission == nil || h.executor == nil {
+		return nil, true
+	}
+	pol := h.executor.EffectivePolicy(req.Model)
+	if pol == nil || (pol.AdmitBudgetTokens <= 0 && pol.MaxInflight <= 0) {
+		return nil, true // no budget and no backstop declared — gate inert
+	}
+	declared := req.MaxCompletionTokens
+	if declared == 0 {
+		declared = req.MaxTokens
+	}
+	// Declared output is reserved up front; an undeclared request reserves only
+	// its input and grows live (grows=true), matching how the processor meters it.
+	footprint := estimatePromptTokens(req) + declared
+	res := h.admission.Admit(c.Request.Context(), req.Model, footprint, declared == 0, pol.AdmitBudgetTokens, pol.MaxInflight)
+	if res == nil {
+		c.Header("Retry-After", "1")
+		writeRouterError(c, http.StatusTooManyRequests, domain.ErrCodeConcurrencyLimit,
+			"server at capacity for this model, please retry", domain.SourceRouter)
+		return nil, false
+	}
+	return res, true
+}
+
+// estimatePromptTokens returns the input-token estimate used by both admission
+// gates: the text estimate, floored at a per-message overhead so a multimodal or
+// tool-only message (no estimable text) is still counted rather than measured as
+// zero.
+func estimatePromptTokens(req *domain.ChatRequest) int {
+	promptTokens := domain.EstimateTokens(domain.GetMessageSlice(req.Messages))
+	if floor := len(req.Messages) * perMessageTokenOverhead; promptTokens < floor {
+		promptTokens = floor
+	}
+	return promptTokens
+}
+
 // effectiveAllowedModels returns the set of models the calling API key may use.
 // The set is derived in this precedence order:
 //
@@ -574,15 +642,10 @@ func (h *Handlers) reserveInputBudget(c *gin.Context, req *domain.ChatRequest, m
 	if h.limiter == nil || m.tpd <= 0 {
 		return true
 	}
-	promptTokens := domain.EstimateTokens(domain.GetMessageSlice(req.Messages))
-	// EstimateTokens only sees text content. A multimodal or tool-only message
-	// (e.g. an image with no text) yields an empty slice and estimates to 0, which
-	// would skip this whole check — including the worst-case max_tokens gate — and
-	// let the request bypass the budget. Floor at a per-message overhead so any
-	// non-empty conversation is always charged and always passes through the gate.
-	if floor := len(req.Messages) * perMessageTokenOverhead; promptTokens < floor {
-		promptTokens = floor
-	}
+	// EstimateTokens only sees text content; estimatePromptTokens floors a
+	// multimodal or tool-only message at a per-message overhead so it is charged
+	// (and passes through this gate) rather than bypassing it with a 0 estimate.
+	promptTokens := estimatePromptTokens(req)
 	if promptTokens == 0 {
 		return true // genuinely empty body — nothing to budget
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,6 +79,19 @@ type Config struct {
 	// 0 disables the wait queue (any ErrNoCapacity immediately escalates to the fallback chain).
 	QueueDepth int
 
+	// AdmitFraction scales a model's KV token capacity into the occupancy admit
+	// budget: a request is admitted only while the weighted in-flight token sum
+	// stays within AdmitFraction × admit_budget_tokens. Below 1.0 it leaves head-
+	// room for token-estimate error; the default is deliberately conservative
+	// until the estimator improves. Range (0,1]; values outside are clamped to 1.
+	// Env: HIVENET_ROUTER_ADMIT_FRACTION
+	AdmitFraction float64
+
+	// AdmitParkTimeout bounds how long an over-budget request waits for occupancy
+	// to free before it is rejected with 429. 0 rejects immediately.
+	// Env: HIVENET_ROUTER_ADMIT_PARK_TIMEOUT (a Go duration, e.g. "250ms").
+	AdmitParkTimeout time.Duration
+
 	// Auth configuration file path.
 	// Path to auth.yaml; if empty both /v1/* and /admin/* default to mode: none.
 	// Env: HIVENET_ROUTER_AUTH_CONFIG
@@ -138,6 +151,8 @@ func DefaultConfig() *Config {
 		MaxTriesPerStep:        3,
 		QueueDepth:             30,
 		MaxRequestBytes:        10 << 20, // 10 MB
+		AdmitFraction:          0.85,     // conservative until the token estimator improves
+		AdmitParkTimeout:       250 * time.Millisecond,
 	}
 }
 
@@ -190,6 +205,16 @@ func LoadFromEnv() *Config {
 	if v := os.Getenv("HIVENET_ROUTER_QUEUE_DEPTH"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
 			cfg.QueueDepth = n
+		}
+	}
+	if v := os.Getenv("HIVENET_ROUTER_ADMIT_FRACTION"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 && f <= 1 {
+			cfg.AdmitFraction = f
+		}
+	}
+	if v := os.Getenv("HIVENET_ROUTER_ADMIT_PARK_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d >= 0 {
+			cfg.AdmitParkTimeout = d
 		}
 	}
 	if v := os.Getenv("HIVENET_ROUTER_SESSION_TTL"); v != "" {

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -25,6 +25,7 @@ const (
 	ErrCodeRateLimitExceeded     ErrorCode = "rate_limit_exceeded"
 	ErrCodeTokenLimitExceeded    ErrorCode = "token_limit_exceeded"
 	ErrCodeInputTooLong          ErrorCode = "input_too_long"
+	ErrCodeConcurrencyLimit      ErrorCode = "concurrency_limit_exceeded"
 )
 
 // ErrorSource identifies which layer produced the error.
@@ -87,7 +88,7 @@ func HTTPStatusFor(code ErrorCode) int {
 		return http.StatusBadGateway
 	case ErrCodeRequestTimeout:
 		return http.StatusGatewayTimeout
-	case ErrCodeRateLimitExceeded, ErrCodeTokenLimitExceeded:
+	case ErrCodeRateLimitExceeded, ErrCodeTokenLimitExceeded, ErrCodeConcurrencyLimit:
 		return http.StatusTooManyRequests
 	default:
 		return http.StatusInternalServerError

--- a/internal/domain/request.go
+++ b/internal/domain/request.go
@@ -71,6 +71,23 @@ type PendingRequest struct {
 	// are guaranteed visible. Zero for non-streaming responses (audit uses resp.Usage).
 	StreamedPromptTokens     atomic.Int64
 	StreamedCompletionTokens atomic.Int64
+
+	// Reservation is the occupancy-budget reservation this request holds, or nil
+	// when the budget gate is inert for its model. The processor grows it as
+	// undeclared output streams; the handler releases it exactly once when the
+	// request finishes. Set by the handler before enqueue.
+	Reservation Reservation
+}
+
+// Reservation is the occupancy-budget slot a request holds for its lifetime.
+// The concrete implementation lives in internal/admission; this interface keeps
+// domain free of that dependency. All methods are safe on a nil receiver.
+type Reservation interface {
+	// Grow adds streamed output tokens for an undeclared request (a no-op for a
+	// declared one, so it may be called unconditionally per output chunk).
+	Grow(tokens int)
+	// Release returns the reservation to the budget; idempotent.
+	Release()
 }
 
 // NewPendingRequest creates a new pending request

--- a/internal/router/processor.go
+++ b/internal/router/processor.go
@@ -633,6 +633,13 @@ func (p *RequestProcessor) forwardToAgent(parentCtx context.Context, agent *doma
 		deferCancel = false
 		pr, pw := io.Pipe()
 		meter := NewSSETokenMeter()
+		// Grow the occupancy reservation as undeclared output streams so the
+		// budget reflects live footprint (a no-op for a declared request, which
+		// reserved its max_tokens up front). Runs before pw.Close(), so all
+		// growth lands before the handler releases the reservation.
+		if pending.Reservation != nil {
+			meter.SetContentObserver(NewGrowthObserver(pending.Reservation))
+		}
 		go func() {
 			defer cancel()
 			defer pw.Close()

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"hivenet_router/internal/admission"
 	"hivenet_router/internal/api"
 	"hivenet_router/internal/auth"
 	"hivenet_router/internal/config"
@@ -565,6 +566,7 @@ func (r *Router) startHTTPServer() {
 		resetMetrics,
 		r.agents.CountHealthyByModel,
 		r, // RegistrationFeed — Router implements SubscribeRegistration
+		admission.NewController(r.cfg.AdmitFraction, r.cfg.AdmitParkTimeout),
 	)
 	server := api.NewServer(handlers, r.cfg.HTTPPort, r.apiAuth, r.adminAuth, r.rateLimiter, r.metrics, r.agents.CountHealthyByModel, r.cfg.MaxRequestBytes)
 	if err := server.Start(); err != nil {

--- a/internal/router/stream_token_meter.go
+++ b/internal/router/stream_token_meter.go
@@ -35,11 +35,40 @@ type SSETokenMeter struct {
 	haveUsage       bool
 	usagePrompt     int
 	usageCompletion int
+
+	// onContent, when set, is called with each streamed delta's content as it is
+	// parsed. It lets the occupancy budget grow an undeclared request's footprint
+	// live, before the stream's total is known. Never called after the stream ends.
+	onContent func(delta string)
 }
 
 // NewSSETokenMeter returns an empty meter ready to be wired into an io.TeeReader.
 func NewSSETokenMeter() *SSETokenMeter {
 	return &SSETokenMeter{}
+}
+
+// NewGrowthObserver returns an SSE content observer that grows res as output
+// streams. It charges the increase in floor(cumulativeBytes/4) rather than
+// summing floor(len(delta)/4) per chunk: the per-chunk form drops up to ~1 token
+// on every delta, so a stream split into many small pieces would badly
+// under-count its footprint. res must be non-nil.
+func NewGrowthObserver(res domain.Reservation) func(delta string) {
+	var bytesSoFar, tokensSoFar int
+	return func(delta string) {
+		bytesSoFar += len(delta)
+		tokens := bytesSoFar / 4
+		if tokens > tokensSoFar {
+			res.Grow(tokens - tokensSoFar)
+			tokensSoFar = tokens
+		}
+	}
+}
+
+// SetContentObserver registers a callback invoked with each streamed delta's
+// content as it is parsed. Pass nil to clear. Set it before the meter starts
+// receiving bytes.
+func (m *SSETokenMeter) SetContentObserver(fn func(delta string)) {
+	m.onContent = fn
 }
 
 // Write implements io.Writer. It never returns an error so that the TeeReader
@@ -98,6 +127,9 @@ func (m *SSETokenMeter) parseLine(line []byte) {
 	for _, ch := range c.Choices {
 		if ch.Delta.Content != "" {
 			m.content.WriteString(ch.Delta.Content)
+			if m.onContent != nil {
+				m.onContent(ch.Delta.Content)
+			}
 		}
 	}
 }

--- a/test/admission/controller_test.go
+++ b/test/admission/controller_test.go
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+// Package admission_test exercises the KV-occupancy admit budget through its
+// exported surface: the weighted in-flight counter, the admit fraction, the
+// max-inflight backstop, the park-then-reject behaviour, and reservation
+// release/grow — all the accounting the request path depends on.
+package admission_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"hivenet_router/internal/admission"
+)
+
+const model = "gemma-4-31b"
+
+// TestThreeConcurrent250K_TwoRejected is the worked example from the spec: with a
+// ~409K budget, one 250K request fits and two more are rejected, and the weighted
+// sum never exceeds the budget.
+func TestThreeConcurrent250K_TwoRejected(t *testing.T) {
+	c := admission.NewController(1.0, 0) // no fraction scaling, no parking
+	ctx := context.Background()
+
+	r1 := c.Admit(ctx, model, 250_000, false, 409_000, 0)
+	if r1 == nil {
+		t.Fatal("first 250K request must be admitted against a 409K budget")
+	}
+	if r2 := c.Admit(ctx, model, 250_000, false, 409_000, 0); r2 != nil {
+		t.Error("second 250K request must be rejected (500K > 409K)")
+	}
+	if r3 := c.Admit(ctx, model, 250_000, false, 409_000, 0); r3 != nil {
+		t.Error("third 250K request must be rejected")
+	}
+
+	sumW, count := c.Occupancy(model)
+	if sumW != 250_000 || count != 1 {
+		t.Fatalf("occupancy must reflect only the admitted request; got sumW=%d count=%d", sumW, count)
+	}
+	if sumW > 409_000 {
+		t.Fatalf("weighted sum %d exceeded the budget 409000", sumW)
+	}
+
+	// Releasing the admitted request frees the budget for a new one.
+	r1.Release()
+	if sumW, count := c.Occupancy(model); sumW != 0 || count != 0 {
+		t.Fatalf("release must restore occupancy to zero; got sumW=%d count=%d", sumW, count)
+	}
+	if r4 := c.Admit(ctx, model, 250_000, false, 409_000, 0); r4 == nil {
+		t.Error("a request must be admitted once the budget is freed")
+	}
+}
+
+// TestAdmitFractionScalesBudget verifies the admit fraction shrinks the effective
+// budget: at 0.85 a request that would fit the raw budget is rejected.
+func TestAdmitFractionScalesBudget(t *testing.T) {
+	full := admission.NewController(1.0, 0)
+	if r := full.Admit(context.Background(), model, 900, false, 1000, 0); r == nil {
+		t.Fatal("900 must fit a raw 1000 budget at fraction 1.0")
+	}
+	scaled := admission.NewController(0.85, 0)
+	if r := scaled.Admit(context.Background(), model, 900, false, 1000, 0); r != nil {
+		t.Error("900 must be rejected at fraction 0.85 (effective budget 850)")
+	}
+	if r := scaled.Admit(context.Background(), model, 850, false, 1000, 0); r == nil {
+		t.Error("850 must be admitted at the effective budget of 850")
+	}
+}
+
+// TestMaxInflightBackstop verifies the plain in-flight count cap rejects the
+// (N+1)-th request even when the token budget still has room.
+func TestMaxInflightBackstop(t *testing.T) {
+	c := admission.NewController(1.0, 0)
+	ctx := context.Background()
+	// Budget is effectively unlimited (0); only max_inflight=2 gates.
+	if c.Admit(ctx, model, 1, false, 0, 2) == nil {
+		t.Fatal("first tiny request must be admitted")
+	}
+	if c.Admit(ctx, model, 1, false, 0, 2) == nil {
+		t.Fatal("second tiny request must be admitted")
+	}
+	if c.Admit(ctx, model, 1, false, 0, 2) != nil {
+		t.Error("third request must hit the max_inflight backstop even with token budget to spare")
+	}
+}
+
+// TestBudgetAndBackstopInertWhenZero verifies a model that declares neither a
+// budget nor a backstop always admits — the gate is a no-op.
+func TestBudgetAndBackstopInertWhenZero(t *testing.T) {
+	c := admission.NewController(0.85, 0)
+	for i := 0; i < 100; i++ {
+		if c.Admit(context.Background(), model, 1_000_000, false, 0, 0) == nil {
+			t.Fatalf("admission must be inert with no budget/backstop, rejected at i=%d", i)
+		}
+	}
+}
+
+// TestParkAdmitsAfterRelease verifies an over-budget request parks and is admitted
+// once an in-flight request releases, rather than being rejected outright.
+func TestParkAdmitsAfterRelease(t *testing.T) {
+	c := admission.NewController(1.0, 2*time.Second)
+	ctx := context.Background()
+	r1 := c.Admit(ctx, model, 1000, false, 1000, 0) // fills the budget
+	if r1 == nil {
+		t.Fatal("first request must fill the budget")
+	}
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		r1.Release()
+	}()
+
+	start := time.Now()
+	r2 := c.Admit(ctx, model, 1000, false, 1000, 0)
+	elapsed := time.Since(start)
+	if r2 == nil {
+		t.Fatal("parked request must be admitted after the slot frees")
+	}
+	if elapsed >= 2*time.Second {
+		t.Errorf("request should have admitted on release (~20ms), not waited the full park window; took %v", elapsed)
+	}
+}
+
+// TestHopelessRequestRejectedFast verifies a request whose footprint alone
+// exceeds the budget is rejected immediately, not parked for the full window —
+// no release can ever make it fit.
+func TestHopelessRequestRejectedFast(t *testing.T) {
+	c := admission.NewController(1.0, 2*time.Second)
+	start := time.Now()
+	r := c.Admit(context.Background(), model, 2000, false, 1000, 0) // 2000 > budget 1000
+	if r != nil {
+		t.Fatal("a request larger than the budget can never fit and must be rejected")
+	}
+	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+		t.Errorf("a hopeless request must not park for the full window; took %v", elapsed)
+	}
+}
+
+// TestSmallBudgetFlooredNotDisabled verifies a positive budget the admit fraction
+// would truncate to zero is floored at 1 rather than silently becoming unlimited:
+// a footprint above the floor is rejected, at the floor is admitted.
+func TestSmallBudgetFlooredNotDisabled(t *testing.T) {
+	c := admission.NewController(0.85, 0) // 0.85 × 1 = 0.85 → would truncate to 0
+	if r := c.Admit(context.Background(), model, 2, false, 1, 0); r != nil {
+		t.Error("footprint 2 must be rejected against a budget floored at 1 (not admitted as unlimited)")
+	}
+	if r := c.Admit(context.Background(), model, 1, false, 1, 0); r == nil {
+		t.Error("footprint 1 must be admitted at the floored budget of 1")
+	}
+}
+
+// TestParkTimeoutRejects verifies a request that never gets room is rejected when
+// the park window expires.
+func TestParkTimeoutRejects(t *testing.T) {
+	c := admission.NewController(1.0, 40*time.Millisecond)
+	ctx := context.Background()
+	if c.Admit(ctx, model, 1000, false, 1000, 0) == nil {
+		t.Fatal("first request must fill the budget")
+	}
+	start := time.Now()
+	r := c.Admit(ctx, model, 1000, false, 1000, 0)
+	if r != nil {
+		t.Fatal("a request that never gets room must be rejected")
+	}
+	if time.Since(start) < 40*time.Millisecond {
+		t.Error("rejection must wait out the park window before giving up")
+	}
+}
+
+// TestParkCancelledByContext verifies a parked request gives up when its context
+// is cancelled, without waiting for the full park window.
+func TestParkCancelledByContext(t *testing.T) {
+	c := admission.NewController(1.0, 2*time.Second)
+	if c.Admit(context.Background(), model, 1000, false, 1000, 0) == nil {
+		t.Fatal("first request must fill the budget")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { time.Sleep(20 * time.Millisecond); cancel() }()
+	start := time.Now()
+	if r := c.Admit(ctx, model, 1000, false, 1000, 0); r != nil {
+		t.Fatal("a request whose context is cancelled must not be admitted")
+	}
+	if time.Since(start) >= 2*time.Second {
+		t.Error("context cancellation must cut the park short")
+	}
+}
+
+// TestGrowIncreasesOccupancy verifies an undeclared reservation grows the
+// weighted sum, a declared one ignores growth, and the release returns exactly
+// what was charged (input + all growth) with no leak.
+func TestGrowIncreasesOccupancy(t *testing.T) {
+	c := admission.NewController(1.0, 0)
+	ctx := context.Background()
+
+	// Undeclared: reserve input only, then grow.
+	und := c.Admit(ctx, model, 100, true, 1_000_000, 0)
+	und.Grow(30)
+	und.Grow(20)
+	if sumW, _ := c.Occupancy(model); sumW != 150 {
+		t.Errorf("undeclared occupancy must include growth (100+50); got %d", sumW)
+	}
+	if und.Weight() != 150 {
+		t.Errorf("reservation weight must track growth; got %d", und.Weight())
+	}
+
+	// Declared: growth is a no-op.
+	dec := c.Admit(ctx, model, 200, false, 1_000_000, 0)
+	dec.Grow(999)
+	if sumW, _ := c.Occupancy(model); sumW != 150+200 {
+		t.Errorf("declared reservation must not grow; got %d, want %d", sumW, 350)
+	}
+
+	und.Release()
+	dec.Release()
+	if sumW, count := c.Occupancy(model); sumW != 0 || count != 0 {
+		t.Fatalf("release must return all footprint incl. growth; got sumW=%d count=%d", sumW, count)
+	}
+}
+
+// TestReleaseIdempotent verifies releasing twice frees the footprint exactly
+// once — a double release must not over-subtract and corrupt the budget.
+func TestReleaseIdempotent(t *testing.T) {
+	c := admission.NewController(1.0, 0)
+	ctx := context.Background()
+	a := c.Admit(ctx, model, 400, false, 1000, 0)
+	b := c.Admit(ctx, model, 400, false, 1000, 0)
+
+	a.Release()
+	a.Release() // second release must be a no-op
+	if sumW, count := c.Occupancy(model); sumW != 400 || count != 1 {
+		t.Fatalf("double release must free once; got sumW=%d count=%d, want 400/1", sumW, count)
+	}
+	b.Release()
+	if sumW, count := c.Occupancy(model); sumW != 0 || count != 0 {
+		t.Fatalf("final occupancy must be zero; got sumW=%d count=%d", sumW, count)
+	}
+}
+
+// TestGrowAfterReleaseNoOp verifies a streaming growth that races in after the
+// request has been released cannot leak budget.
+func TestGrowAfterReleaseNoOp(t *testing.T) {
+	c := admission.NewController(1.0, 0)
+	r := c.Admit(context.Background(), model, 100, true, 1_000_000, 0)
+	r.Release()
+	r.Grow(50) // late callback after release
+	if sumW, count := c.Occupancy(model); sumW != 0 || count != 0 {
+		t.Fatalf("grow after release must be a no-op; got sumW=%d count=%d", sumW, count)
+	}
+}
+
+// TestConcurrentAdmitReleaseNoLeak stress-tests the counter: many goroutines
+// admit and release, and the final occupancy must return exactly to zero.
+func TestConcurrentAdmitReleaseNoLeak(t *testing.T) {
+	c := admission.NewController(1.0, 100*time.Millisecond)
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	for i := 0; i < 200; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if r := c.Admit(ctx, model, 1000, false, 50_000, 0); r != nil {
+				r.Release()
+			}
+		}()
+	}
+	wg.Wait()
+	if sumW, count := c.Occupancy(model); sumW != 0 || count != 0 {
+		t.Fatalf("after all admit/release pairs, occupancy must be zero; got sumW=%d count=%d", sumW, count)
+	}
+}

--- a/test/api/b1_request_caps_test.go
+++ b/test/api/b1_request_caps_test.go
@@ -30,6 +30,7 @@ func newCapHandlers(q chan *domain.PendingRequest, global *policy.Policy) *api.H
 		nil, nil, q, 2*time.Second,
 		exec, nil, nil, nil,
 		nil, nil, nil, nil, nil, nil, nil, nil,
+		nil,
 	)
 }
 
@@ -313,7 +314,7 @@ func TestB1_PerModelPolicyCap(t *testing.T) {
 		t.Fatalf("SetNamedPolicy: %v", err)
 	}
 	q := make(chan *domain.PendingRequest, 1)
-	h := api.NewHandlers(nil, nil, q, 2*time.Second, exec, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	h := api.NewHandlers(nil, nil, q, 2*time.Second, exec, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	// Over-cap request for the capped model → 400.
 	over := fmt.Appendf(nil, `{"model":"capped","messages":[{"role":"user","content":%q}]}`, strings.Repeat("a", 28))

--- a/test/api/b2_occupancy_test.go
+++ b/test/api/b2_occupancy_test.go
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+// Package api_test contains black-box tests for the occupancy admit budget wired
+// into the passthrough handler: an over-budget request is a 429
+// concurrency_limit_exceeded with Retry-After before queueing, and an admitted
+// request's reservation is released on every exit path (success, error, timeout),
+// so the weighted in-flight sum always returns to zero.
+package api_test
+
+import (
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"hivenet_router/internal/admission"
+	"hivenet_router/internal/api"
+	"hivenet_router/internal/domain"
+	"hivenet_router/internal/policy"
+)
+
+// errReader yields one SSE chunk, then fails — simulating a stream that breaks
+// mid-flight after some output was already delivered.
+type errReader struct{ sent bool }
+
+func (e *errReader) Read(p []byte) (int, error) {
+	if !e.sent {
+		e.sent = true
+		return copy(p, []byte("data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\n")), nil
+	}
+	return 0, io.ErrUnexpectedEOF
+}
+func (e *errReader) Close() error { return nil }
+
+const b2Model = "gemma"
+
+// newB2Handlers builds a Handlers whose executor serves global for every model,
+// with a real admission controller so the occupancy budget is live.
+func newB2Handlers(q chan *domain.PendingRequest, ctrl *admission.Controller, global *policy.Policy, timeout time.Duration) *api.Handlers {
+	exec := policy.NewExecutor(nil, nil, global, 0, 0)
+	return api.NewHandlers(
+		nil, nil, q, timeout,
+		exec, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil, nil,
+		ctrl,
+	)
+}
+
+func b2Body(maxTokens int) []byte {
+	if maxTokens > 0 {
+		return []byte(`{"model":"gemma","messages":[{"role":"user","content":"hi"}],"max_tokens":` + strconv.Itoa(maxTokens) + `}`)
+	}
+	return []byte(`{"model":"gemma","messages":[{"role":"user","content":"hi"}]}`)
+}
+
+// TestB2_OverBudget_429WithRetryAfter verifies a request whose footprint exceeds
+// the budget is rejected up front with 429 concurrency_limit_exceeded and a
+// Retry-After header, and is not queued.
+func TestB2_OverBudget_429WithRetryAfter(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	ctrl := admission.NewController(1.0, 0) // no parking → immediate reject
+	h := newB2Handlers(q, ctrl, &policy.Policy{AdmitBudgetTokens: 50}, time.Second)
+	// footprint = input(4) + declared max_tokens(100) = 104 > 50.
+	c, w := newCtx("/v1/chat/completions", b2Body(100))
+
+	h.Passthrough(c)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 over budget, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), string(domain.ErrCodeConcurrencyLimit)) {
+		t.Errorf("expected %q in body, got %s", domain.ErrCodeConcurrencyLimit, w.Body.String())
+	}
+	if w.Header().Get("Retry-After") == "" {
+		t.Error("a 429 must carry a Retry-After header")
+	}
+	if len(q) != 0 {
+		t.Errorf("a rejected request must not be queued, depth=%d", len(q))
+	}
+	if sumW, count := ctrl.Occupancy(b2Model); sumW != 0 || count != 0 {
+		t.Errorf("a rejected request must hold no reservation; got sumW=%d count=%d", sumW, count)
+	}
+}
+
+// TestB2_ReleasedOnSuccess verifies the reservation is held while the request is
+// in flight and released when it completes successfully.
+func TestB2_ReleasedOnSuccess(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	ctrl := admission.NewController(1.0, 0)
+	h := newB2Handlers(q, ctrl, &policy.Policy{AdmitBudgetTokens: 1_000_000}, time.Second)
+	c, w := newCtx("/v1/chat/completions", b2Body(100))
+
+	done := make(chan struct{})
+	go func() { h.Passthrough(c); close(done) }()
+	select {
+	case pending := <-q:
+		if sumW, count := ctrl.Occupancy(b2Model); sumW == 0 || count != 1 {
+			t.Errorf("reservation must be held in flight; got sumW=%d count=%d", sumW, count)
+		}
+		pending.Response <- &domain.ChatResponse{RawBytes: []byte(`{"ok":true}`)}
+	case <-time.After(time.Second):
+		t.Fatal("request was not enqueued")
+	}
+	<-done
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	if sumW, count := ctrl.Occupancy(b2Model); sumW != 0 || count != 0 {
+		t.Fatalf("reservation must be released after success; got sumW=%d count=%d", sumW, count)
+	}
+}
+
+// TestB2_ReleasedOnError verifies the reservation is released when the request
+// ends in a backend error (the same exit path a failed provider failover takes).
+func TestB2_ReleasedOnError(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	ctrl := admission.NewController(1.0, 0)
+	h := newB2Handlers(q, ctrl, &policy.Policy{AdmitBudgetTokens: 1_000_000}, time.Second)
+	c, _ := newCtx("/v1/chat/completions", b2Body(100))
+
+	done := make(chan struct{})
+	go func() { h.Passthrough(c); close(done) }()
+	select {
+	case pending := <-q:
+		pending.Error <- domain.NewRouterError(domain.ErrCodeBackendError, "boom", domain.SourceBackend)
+	case <-time.After(time.Second):
+		t.Fatal("request was not enqueued")
+	}
+	<-done
+	if sumW, count := ctrl.Occupancy(b2Model); sumW != 0 || count != 0 {
+		t.Fatalf("reservation must be released after an error; got sumW=%d count=%d", sumW, count)
+	}
+}
+
+// TestB2_ReleasedOnStreamingMidStreamError verifies the reservation is released
+// even when a streaming response breaks part-way through — the single deferred
+// release covers the streaming exit path just like the clean ones.
+func TestB2_ReleasedOnStreamingMidStreamError(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	ctrl := admission.NewController(1.0, 0)
+	h := newB2Handlers(q, ctrl, &policy.Policy{AdmitBudgetTokens: 1_000_000}, time.Second)
+	c, _ := newCtx("/v1/chat/completions", b2Body(0)) // undeclared → reservation grows as it streams
+
+	done := make(chan struct{})
+	go func() { h.Passthrough(c); close(done) }()
+	select {
+	case pending := <-q:
+		pending.Response <- &domain.ChatResponse{Body: &errReader{}}
+	case <-time.After(time.Second):
+		t.Fatal("request was not enqueued")
+	}
+	<-done
+	if sumW, count := ctrl.Occupancy(b2Model); sumW != 0 || count != 0 {
+		t.Fatalf("reservation must be released even when the stream errors mid-flight; got sumW=%d count=%d", sumW, count)
+	}
+}
+
+// TestB2_ReleasedOnTimeout verifies the reservation is released when the request
+// times out waiting for a response.
+func TestB2_ReleasedOnTimeout(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	ctrl := admission.NewController(1.0, 0)
+	h := newB2Handlers(q, ctrl, &policy.Policy{AdmitBudgetTokens: 1_000_000}, 80*time.Millisecond)
+	c, w := newCtx("/v1/chat/completions", b2Body(100))
+
+	h.Passthrough(c) // no responder drains q → awaitResponse times out
+
+	if w.Code != http.StatusGatewayTimeout {
+		t.Errorf("expected 504 on timeout, got %d", w.Code)
+	}
+	if sumW, count := ctrl.Occupancy(b2Model); sumW != 0 || count != 0 {
+		t.Fatalf("reservation must be released after a timeout; got sumW=%d count=%d", sumW, count)
+	}
+}
+
+// TestB2_DeclaredFootprintReservedUpFront verifies a declared max_tokens is
+// reserved in full at admission (input + max_tokens), not metered live.
+func TestB2_DeclaredFootprintReservedUpFront(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	ctrl := admission.NewController(1.0, 0)
+	h := newB2Handlers(q, ctrl, &policy.Policy{AdmitBudgetTokens: 1_000_000}, time.Second)
+	c, _ := newCtx("/v1/chat/completions", b2Body(100)) // input 4 + declared 100
+
+	done := make(chan struct{})
+	go func() { h.Passthrough(c); close(done) }()
+	select {
+	case pending := <-q:
+		if sumW, _ := ctrl.Occupancy(b2Model); sumW != 104 {
+			t.Errorf("declared footprint must be input+max_tokens=104; got %d", sumW)
+		}
+		pending.Response <- &domain.ChatResponse{RawBytes: []byte(`{"ok":true}`)}
+	case <-time.After(time.Second):
+		t.Fatal("request was not enqueued")
+	}
+	<-done
+}
+
+// TestB2_UndeclaredFootprintInputOnly verifies an undeclared request reserves only
+// its input at admission (output is grown live as it streams).
+func TestB2_UndeclaredFootprintInputOnly(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	ctrl := admission.NewController(1.0, 0)
+	h := newB2Handlers(q, ctrl, &policy.Policy{AdmitBudgetTokens: 1_000_000}, time.Second)
+	c, _ := newCtx("/v1/chat/completions", b2Body(0)) // no max_tokens → input 4 only
+
+	done := make(chan struct{})
+	go func() { h.Passthrough(c); close(done) }()
+	select {
+	case pending := <-q:
+		if sumW, _ := ctrl.Occupancy(b2Model); sumW != 4 {
+			t.Errorf("undeclared footprint must be input only (4); got %d", sumW)
+		}
+		pending.Response <- &domain.ChatResponse{RawBytes: []byte(`{"ok":true}`)}
+	case <-time.After(time.Second):
+		t.Fatal("request was not enqueued")
+	}
+	<-done
+}
+
+// TestB2_InertWhenNoBudget verifies a policy that declares neither a budget nor a
+// backstop attaches no reservation and holds no occupancy.
+func TestB2_InertWhenNoBudget(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	ctrl := admission.NewController(1.0, 0)
+	h := newB2Handlers(q, ctrl, &policy.Policy{}, time.Second) // no admit_budget_tokens, no max_inflight
+	c, _ := newCtx("/v1/chat/completions", b2Body(100))
+
+	done := make(chan struct{})
+	go func() { h.Passthrough(c); close(done) }()
+	select {
+	case pending := <-q:
+		if pending.Reservation != nil {
+			t.Error("an inert budget must attach no reservation")
+		}
+		if sumW, count := ctrl.Occupancy(b2Model); sumW != 0 || count != 0 {
+			t.Errorf("an inert budget must hold no occupancy; got sumW=%d count=%d", sumW, count)
+		}
+		pending.Response <- &domain.ChatResponse{RawBytes: []byte(`{"ok":true}`)}
+	case <-time.After(time.Second):
+		t.Fatal("request was not enqueued")
+	}
+	<-done
+}
+
+// TestB2_MaxInflightBackstop verifies the in-flight count cap rejects a second
+// concurrent request with 429 even when the token budget has room.
+func TestB2_MaxInflightBackstop(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 2)
+	ctrl := admission.NewController(1.0, 0)
+	// No token budget; max_inflight=1.
+	h := newB2Handlers(q, ctrl, &policy.Policy{MaxInflight: 1}, time.Second)
+
+	// First request occupies the single in-flight slot; hold it in the queue.
+	c1, _ := newCtx("/v1/chat/completions", b2Body(0))
+	done1 := make(chan struct{})
+	go func() { h.Passthrough(c1); close(done1) }()
+	var pending1 *domain.PendingRequest
+	select {
+	case pending1 = <-q:
+	case <-time.After(time.Second):
+		t.Fatal("first request was not enqueued")
+	}
+
+	// Second request must be rejected by the backstop while the first is in flight.
+	c2, w2 := newCtx("/v1/chat/completions", b2Body(0))
+	h.Passthrough(c2)
+	if w2.Code != http.StatusTooManyRequests {
+		t.Fatalf("second concurrent request must hit the max_inflight backstop (429), got %d", w2.Code)
+	}
+
+	pending1.Response <- &domain.ChatResponse{RawBytes: []byte(`{"ok":true}`)}
+	<-done1
+	if sumW, count := ctrl.Occupancy(b2Model); sumW != 0 || count != 0 {
+		t.Fatalf("occupancy must be zero once the first request completes; got sumW=%d count=%d", sumW, count)
+	}
+}

--- a/test/api/middleware_test.go
+++ b/test/api/middleware_test.go
@@ -154,6 +154,7 @@ func newPolicyHandlers() *api.Handlers {
 		stor, nil, nil, 2*time.Second,
 		exec, nil, nil, nil,
 		nil, nil, nil, nil, nil, nil, nil, nil,
+		nil,
 	)
 }
 

--- a/test/api/passthrough_test.go
+++ b/test/api/passthrough_test.go
@@ -59,6 +59,7 @@ func newTestHandlers(q chan *domain.PendingRequest, lim auth.RateLimiter) *api.H
 		nil, nil, q, 2*time.Second,
 		nil, nil, nil, lim,
 		nil, nil, nil, nil, nil, nil, nil, nil,
+		nil,
 	)
 }
 

--- a/test/api/registration_stream_test.go
+++ b/test/api/registration_stream_test.go
@@ -47,6 +47,7 @@ func TestRegistrationStream_EmitsSSEFrame(t *testing.T) {
 		nil, nil, nil, time.Second,
 		nil, nil, nil, nil,
 		nil, nil, nil, nil, nil, nil, nil, feed,
+		nil,
 	)
 
 	router := gin.New()
@@ -122,6 +123,7 @@ func TestRegistrationStream_NotImplementedWhenNoFeed(t *testing.T) {
 		nil, nil, nil, time.Second,
 		nil, nil, nil, nil,
 		nil, nil, nil, nil, nil, nil, nil, nil, // registrationFeed = nil
+		nil, // admission controller = nil
 	)
 
 	router := gin.New()

--- a/test/router/stream_token_meter_test.go
+++ b/test/router/stream_token_meter_test.go
@@ -72,6 +72,60 @@ func TestMeter_PrefersExactUsage(t *testing.T) {
 	}
 }
 
+// TestMeter_ContentObserverFiresPerChunk verifies the growth hook: the content
+// observer is invoked with each delta as it is parsed, so the occupancy budget
+// can grow an undeclared request live rather than only at end-of-stream.
+func TestMeter_ContentObserverFiresPerChunk(t *testing.T) {
+	m := router.NewSSETokenMeter()
+	var deltas []string
+	m.SetContentObserver(func(d string) { deltas = append(deltas, d) })
+
+	chunks := []string{
+		`data: {"choices":[{"delta":{"content":"Hello"}}]}` + "\n\n",
+		`data: {"choices":[{"delta":{"content":" there"}}]}` + "\n\n",
+		`data: {"choices":[{"delta":{}}]}` + "\n\n", // no content → no callback
+		"data: [DONE]\n\n",
+	}
+	for _, c := range chunks {
+		if _, err := m.Write([]byte(c)); err != nil {
+			t.Fatalf("Write returned error: %v", err)
+		}
+	}
+
+	want := []string{"Hello", " there"}
+	if len(deltas) != len(want) {
+		t.Fatalf("observer must fire once per content delta; got %d calls %v, want %v", len(deltas), deltas, want)
+	}
+	for i := range want {
+		if deltas[i] != want[i] {
+			t.Errorf("delta %d = %q, want %q", i, deltas[i], want[i])
+		}
+	}
+}
+
+// countingReservation records the total tokens grown, for the growth-observer test.
+type countingReservation struct{ grown int }
+
+func (c *countingReservation) Grow(tokens int) { c.grown += tokens }
+func (c *countingReservation) Release()        {}
+
+// TestGrowthObserver_ChargesFloorOfCumulativeBytes verifies growth charges
+// floor(totalBytes/4) across many small deltas, not the sum of per-chunk floors
+// (which would round each tiny delta down to zero and badly under-count).
+func TestGrowthObserver_ChargesFloorOfCumulativeBytes(t *testing.T) {
+	res := &countingReservation{}
+	obs := router.NewGrowthObserver(res)
+
+	// 100 deltas of 3 bytes each = 300 bytes. Per-chunk floor(3/4)=0 would total 0;
+	// cumulative floor(300/4)=75.
+	for i := 0; i < 100; i++ {
+		obs("abc")
+	}
+	if res.grown != 75 {
+		t.Errorf("cumulative growth must be floor(300/4)=75, got %d", res.grown)
+	}
+}
+
 // TestMeter_HandlesSplitWrites verifies that an SSE event split across multiple
 // Write calls (as happens with TCP/stream chunking) is still parsed once the
 // terminating newline arrives.


### PR DESCRIPTION
## KV-occupancy admit budget — the core gate

Admits a request only while the model's **weighted in-flight token sum** plus the request's own footprint stays within the occupancy budget. A burst of large requests degrades to a clean **429** instead of overcommitting the engine's KV cache and inflating every co-tenant's latency. A plain request counter can't see this — three keys sending one huge request each do the same damage as one key sending three — so the budget is token-weighted.

### The rule
```
footprint wᵢ = input + out
  out = declared max_tokens            (reserved up front)
      = live output-so-far             (undeclared: grows as it streams)
budget B     = admit_fraction × admit_budget_tokens
admit new j  ⇔  (Σ wᵢ over in-flight) + wⱼ ≤ B
```
Plus a plain in-flight **count** backstop (`max_inflight`) that caps concurrency independently of tokens. Over budget, a request **parks briefly** for capacity to free, then 429 `concurrency_limit_exceeded` + `Retry-After` — it does not collapse straight to a reject.

### Release correctness (the main risk)
The reservation is released **exactly once on every exit path** via a *single deferred release in the handler* — success, backend error, timeout, client disconnect, mid-stream stream failure, and provider failover all return through the same `defer`. This is sound because the streaming goroutine finishes its accounting *before* the handler's `io.Copy` returns (verified against the processor lifecycle), so growth always lands before release. Release is idempotent and `Grow` after release is a no-op, so a late streaming callback can't leak. A leaked reservation would permanently shrink the budget — hence the mid-stream-error, timeout, and error-path release tests are explicit.

### Where it lives
- **`internal/admission`** (new): pure per-model token counters + reservations. No engine coupling — it counts tokens the router already estimates.
- **`internal/api/handlers.go`**: `enforceOccupancyBudget` runs after B1 and *before* the daily-budget charge (so a B2 reject never leaks daily tokens); attaches the reservation to the pending request; one `defer Release()`.
- **`internal/router/processor.go` + `stream_token_meter.go`**: a per-chunk content observer grows an undeclared request's footprint live.
- **`internal/config`**: `AdmitFraction` (default **0.85**) and `AdmitParkTimeout` (250ms), both env-overridable.

### Deliberate scope decisions (please sanity-check)
1. **admit_fraction defaults to 0.85, not 0.90.** The estimator under-counts coding inputs; 0.90 is a later change once the estimator improves. Config-driven, so the flip is one line.
2. **Budget is per-model in the router, not scaled by healthy replica count.** For a multi-replica pool this *under-admits* (treats N replicas as one replica's budget) — the conservative, safe direction. Replica-scaling is a clean follow-up; I kept it out to keep the gate deterministic and match the single-budget worked example.
3. **Parking is keyed on budget-release, not the routing `WaitQueue`.** That queue signals on *agent capacity*, a different event from *budget freeing*; coupling them would be wrong. Same "each subsystem owns its concern" principle as the RL-1 reload guards.
4. **No output clamp anywhere** — declared `max_tokens` is reserved for accounting only, never shrunk; undeclared output is metered live, never capped.

### Tests
- **`test/admission/`** (12 tests): the worked example (3×250K vs 409K → 1 admits, 2 rejected, Σw never exceeds B), fraction scaling, max-inflight backstop, park-admits-after-release / park-timeout / context-cancel, grow (undeclared only) + release restores Σw, idempotent release, grow-after-release no-op, and a concurrent admit/release stress test asserting zero leak.
- **`test/api/`** (9 tests): 429 + `concurrency_limit_exceeded` + `Retry-After` + not-queued; release on success / error / timeout / **mid-stream streaming error**; declared footprint reserved up front vs undeclared input-only; inert-when-no-budget; HTTP max-inflight backstop.
- **`test/router/`**: the streaming content-observer fires once per delta.

Full suite passes under `-race`; lint 0 issues.