### PR TITLE
Add front-door KV-pressure shed

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -229,6 +229,11 @@ type Handlers struct {
 	// is queued. Nil disables the gate (e.g. tests, or when no policy declares a
 	// budget). Reservations it hands out are released on every request exit path.
 	admission *admission.Controller
+
+	// enginePressure returns the aggregate live engine KV-cache utilization and
+	// waiting-request count for a model (each nil when no healthy agent reports
+	// it), driving the front-door shed gate. Nil disables the gate (e.g. tests).
+	enginePressure func(model string) (kvUtil, waiting *float64)
 }
 
 // NewHandlers initializes a Handlers instance with all required dependencies.
@@ -253,6 +258,7 @@ func NewHandlers(
 	healthyAgentCount func(model string) int,
 	registrationFeed RegistrationFeed,
 	admissionController *admission.Controller,
+	enginePressure func(model string) (kvUtil, waiting *float64),
 ) *Handlers {
 	return &Handlers{
 		storage:              storage,
@@ -272,6 +278,7 @@ func NewHandlers(
 		healthyAgentCount:    healthyAgentCount,
 		registrationFeed:     registrationFeed,
 		admission:            admissionController,
+		enginePressure:       enginePressure,
 	}
 }
 
@@ -359,6 +366,9 @@ func (h *Handlers) Passthrough(c *gin.Context) {
 		return
 	}
 	if !h.enforceRequestCaps(c, &req) {
+		return
+	}
+	if !h.enforceShedPressure(c, req.Model) {
 		return
 	}
 	// Occupancy admit budget. The reservation is released on every exit path
@@ -538,6 +548,39 @@ func (h *Handlers) enforceOccupancyBudget(c *gin.Context, req *domain.ChatReques
 		return nil, false
 	}
 	return res, true
+}
+
+// enforceShedPressure is the front-door KV-pressure shed: when the live engine
+// pressure for the model breaches the policy's shed_if thresholds, new requests
+// are rejected with 429 + Retry-After at the door rather than queued into an
+// already-saturated pool. It reads the aggregate engine signal (mean KV-cache
+// utilization and waiting requests across healthy replicas) and evaluates it
+// with the same threshold logic and nil-passes contract routing uses for its
+// per-agent exclude_if gates — a missing signal (non-vLLM engine, no snapshot
+// yet) passes, so the gate fails open. This is additive: the per-agent exclude_if
+// routing gates are unchanged; this adds the clean front-door reject on top.
+//
+// Returns false (after writing 429) when the pool is shedding.
+func (h *Handlers) enforceShedPressure(c *gin.Context, model string) bool {
+	if h.enginePressure == nil || h.executor == nil {
+		return true
+	}
+	pol := h.executor.EffectivePolicy(model)
+	if pol == nil || len(pol.ShedIf) == 0 {
+		return true // no shed thresholds declared — gate inert
+	}
+	kvUtil, waiting := h.enginePressure(model)
+	if kvUtil == nil && waiting == nil {
+		return true // no live engine signal — fail open
+	}
+	snap := policy.AgentSnapshot{KVCacheUtilization: kvUtil, WaitingRequests: waiting}
+	if policy.PassesGates(snap, pol.ShedIf) {
+		return true
+	}
+	c.Header("Retry-After", "1")
+	writeRouterError(c, http.StatusTooManyRequests, domain.ErrCodeConcurrencyLimit,
+		"model is under high load, please retry", domain.SourceRouter)
+	return false
 }
 
 // estimatePromptTokens returns the input-token estimate used by both admission

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -567,6 +567,7 @@ func (r *Router) startHTTPServer() {
 		r.agents.CountHealthyByModel,
 		r, // RegistrationFeed — Router implements SubscribeRegistration
 		admission.NewController(r.cfg.AdmitFraction, r.cfg.AdmitParkTimeout),
+		r.EnginePressureForModel,
 	)
 	server := api.NewServer(handlers, r.cfg.HTTPPort, r.apiAuth, r.adminAuth, r.rateLimiter, r.metrics, r.agents.CountHealthyByModel, r.cfg.MaxRequestBytes)
 	if err := server.Start(); err != nil {
@@ -922,6 +923,58 @@ func (r *Router) reloadPolicyModelDir() {
 func (r *Router) SubscribeRegistration() (<-chan domain.RegistrationEvent, func()) {
 	sub := r.registrationNotifier.Subscribe()
 	return sub.Events, func() { r.registrationNotifier.Unsubscribe(sub) }
+}
+
+// EnginePressureForModel returns the aggregate live engine pressure across the
+// healthy agents serving model: the mean KV-cache utilization and the mean
+// waiting-request count, each averaged over the agents that report it. A metric
+// is nil when no healthy agent reports it (e.g. non-vLLM engines), so the
+// front-door shed gate skips that dimension rather than treating a missing
+// signal as zero pressure. The mean (not max) is used deliberately: a single hot
+// replica is handled by routing's per-agent exclude_if, so shedding new
+// admissions is warranted only when the pool as a whole is under pressure.
+func (r *Router) EnginePressureForModel(model string) (kvUtil, waiting *float64) {
+	var metrics []*domain.BackendMetrics
+	for _, agent := range r.agents.ListByModel(model) {
+		if !agent.IsHealthy() {
+			continue
+		}
+		if ep, err := r.storage.GetEnginePunctual(agent.ID); err == nil && ep != nil {
+			metrics = append(metrics, ep)
+		}
+	}
+	return MeanEnginePressure(metrics)
+}
+
+// MeanEnginePressure averages the KV-cache utilization and waiting-request count
+// over the given per-agent engine snapshots, ignoring nil metrics. A dimension
+// that no snapshot reports is returned as nil (not zero), so the shed gate skips
+// it rather than reading a missing signal as no pressure.
+func MeanEnginePressure(metrics []*domain.BackendMetrics) (kvUtil, waiting *float64) {
+	var kvSum, waitSum float64
+	var kvN, waitN int
+	for _, ep := range metrics {
+		if ep == nil {
+			continue
+		}
+		if ep.KVCacheUtilization != nil {
+			kvSum += *ep.KVCacheUtilization
+			kvN++
+		}
+		if ep.WaitingRequests != nil {
+			waitSum += *ep.WaitingRequests
+			waitN++
+		}
+	}
+	if kvN > 0 {
+		v := kvSum / float64(kvN)
+		kvUtil = &v
+	}
+	if waitN > 0 {
+		v := waitSum / float64(waitN)
+		waiting = &v
+	}
+	return kvUtil, waiting
 }
 
 // GetRoutingTable implements api.RoutingTableProvider.

--- a/policies/_default.yaml
+++ b/policies/_default.yaml
@@ -8,8 +8,10 @@ routing_policy:
     tags: ["production"]
 
   # ── Layer 2: dynamic safety gates ─────────────────────────────────────────
+  # Per-agent routing gates: an agent breaching any of these is dropped from the
+  # candidate pool for this request (503 no_capacity only if none remain).
   exclude_if:
-    kv_cache_utilization: { gt: 0.85 }
+    kv_cache_utilization: { gt: 0.90 }
     waiting_requests:     { gt: 20 }
     capacity_utilization: { gt: 0.90 }
     success_rate:         { lt: 0.95 }
@@ -19,6 +21,22 @@ routing_policy:
   # ── Layer 3: ranking ───────────────────────────────────────────────────────
   strategy: "least-loaded"
   max_tries: 3
+
+
+# ── Front-door shed thresholds ────────────────────────────────────────────────
+# When the aggregate live engine pressure across the healthy replicas serving a
+# model breaches one of these, new requests are rejected with 429 + Retry-After
+# at the door — before queueing — instead of piling into an already-saturated
+# pool. This is additive to the per-agent exclude_if gates above.
+#
+# Operator note: 0.90 is deliberately more permissive than the industry de-facto
+# ~0.80 shed threshold. The headroom leans on the accuracy of the occupancy
+# budget's token estimate — under-counting at 0.90 is what would let preemption
+# start — so this threshold should move down if the token estimator proves
+# optimistic in production (tracked with the estimator-accuracy work).
+shed_if:
+  kv_cache_utilization: { gt: 0.90 }
+  waiting_requests:     { gt: 20 }
 
 
 fallback_chain:

--- a/test/api/b1_request_caps_test.go
+++ b/test/api/b1_request_caps_test.go
@@ -30,7 +30,7 @@ func newCapHandlers(q chan *domain.PendingRequest, global *policy.Policy) *api.H
 		nil, nil, q, 2*time.Second,
 		exec, nil, nil, nil,
 		nil, nil, nil, nil, nil, nil, nil, nil,
-		nil,
+		nil, nil,
 	)
 }
 
@@ -314,7 +314,7 @@ func TestB1_PerModelPolicyCap(t *testing.T) {
 		t.Fatalf("SetNamedPolicy: %v", err)
 	}
 	q := make(chan *domain.PendingRequest, 1)
-	h := api.NewHandlers(nil, nil, q, 2*time.Second, exec, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	h := api.NewHandlers(nil, nil, q, 2*time.Second, exec, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	// Over-cap request for the capped model → 400.
 	over := fmt.Appendf(nil, `{"model":"capped","messages":[{"role":"user","content":%q}]}`, strings.Repeat("a", 28))

--- a/test/api/b2_occupancy_test.go
+++ b/test/api/b2_occupancy_test.go
@@ -45,7 +45,7 @@ func newB2Handlers(q chan *domain.PendingRequest, ctrl *admission.Controller, gl
 		nil, nil, q, timeout,
 		exec, nil, nil, nil,
 		nil, nil, nil, nil, nil, nil, nil, nil,
-		ctrl,
+		ctrl, nil,
 	)
 }
 

--- a/test/api/b3_shed_test.go
+++ b/test/api/b3_shed_test.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+// Package api_test contains black-box tests for the front-door KV-pressure shed:
+// when the aggregate live engine pressure for a model breaches the policy's
+// shed_if thresholds, new requests are rejected with 429 + Retry-After before
+// queueing, while a missing signal or an unset shed_if leaves the gate open.
+package api_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"hivenet_router/internal/api"
+	"hivenet_router/internal/domain"
+	"hivenet_router/internal/policy"
+)
+
+func f64(v float64) *float64 { return &v }
+
+// shedPolicy is a policy that sheds above 0.90 KV utilization or 20 waiting.
+func shedPolicy() *policy.Policy {
+	return &policy.Policy{ShedIf: map[string]policy.ThresholdRule{
+		"kv_cache_utilization": {GT: f64(0.90)},
+		"waiting_requests":     {GT: f64(20)},
+	}}
+}
+
+// newB3Handlers builds a Handlers with the given shed policy and an engine-
+// pressure provider returning fixed aggregate values.
+func newB3Handlers(q chan *domain.PendingRequest, pol *policy.Policy, pressure func(string) (*float64, *float64)) *api.Handlers {
+	exec := policy.NewExecutor(nil, nil, pol, 0, 0)
+	return api.NewHandlers(
+		nil, nil, q, time.Second,
+		exec, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil, nil,
+		nil, pressure,
+	)
+}
+
+// TestB3_KVUtilAboveThreshold_429 verifies a model whose aggregate KV
+// utilization is above the shed threshold rejects new requests at the door.
+func TestB3_KVUtilAboveThreshold_429(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	h := newB3Handlers(q, shedPolicy(), func(string) (*float64, *float64) {
+		return f64(0.91), f64(0) // KV over threshold, waiting fine
+	})
+	c, w := newCtx("/v1/chat/completions", b2Body(0))
+
+	h.Passthrough(c)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 when KV utilization is over threshold, got %d", w.Code)
+	}
+	if w.Header().Get("Retry-After") == "" {
+		t.Error("a shed 429 must carry a Retry-After header")
+	}
+	if len(q) != 0 {
+		t.Errorf("a shed request must not be queued, depth=%d", len(q))
+	}
+}
+
+// TestB3_WaitingAboveThreshold_429 verifies the waiting-requests dimension sheds
+// independently of KV utilization.
+func TestB3_WaitingAboveThreshold_429(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	h := newB3Handlers(q, shedPolicy(), func(string) (*float64, *float64) {
+		return f64(0.10), f64(21) // KV fine, waiting over threshold
+	})
+	c, w := newCtx("/v1/chat/completions", b2Body(0))
+
+	h.Passthrough(c)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 when waiting requests exceed threshold, got %d", w.Code)
+	}
+}
+
+// TestB3_BelowThreshold_Passes verifies a model under both thresholds admits
+// normally and reaches the queue.
+func TestB3_BelowThreshold_Passes(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	h := newB3Handlers(q, shedPolicy(), func(string) (*float64, *float64) {
+		return f64(0.50), f64(5) // both comfortably below threshold
+	})
+	c, w := newCtx("/v1/chat/completions", b2Body(0))
+
+	done := make(chan struct{})
+	go func() { h.Passthrough(c); close(done) }()
+	select {
+	case pending := <-q:
+		pending.Response <- &domain.ChatResponse{RawBytes: []byte(`{"ok":true}`)}
+	case <-time.After(time.Second):
+		t.Fatal("a request below the shed thresholds must be admitted")
+	}
+	<-done
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 below thresholds, got %d", w.Code)
+	}
+}
+
+// TestB3_NoSignal_Passes verifies the gate fails open when no healthy replica
+// reports engine metrics (e.g. a non-vLLM engine) — a missing signal is not
+// treated as pressure.
+func TestB3_NoSignal_Passes(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	h := newB3Handlers(q, shedPolicy(), func(string) (*float64, *float64) {
+		return nil, nil // no engine snapshot
+	})
+	c, w := newCtx("/v1/chat/completions", b2Body(0))
+
+	done := make(chan struct{})
+	go func() { h.Passthrough(c); close(done) }()
+	select {
+	case pending := <-q:
+		pending.Response <- &domain.ChatResponse{RawBytes: []byte(`{"ok":true}`)}
+	case <-time.After(time.Second):
+		t.Fatal("a request must pass when no engine signal is available (fail open)")
+	}
+	<-done
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 with no engine signal, got %d", w.Code)
+	}
+}
+
+// TestB3_PartialSignal_EvaluatesAvailableDimension verifies that when only one
+// metric is reported, the gate still evaluates that dimension (nil KV, high
+// waiting → shed) rather than skipping the whole check.
+func TestB3_PartialSignal_EvaluatesAvailableDimension(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	h := newB3Handlers(q, shedPolicy(), func(string) (*float64, *float64) {
+		return nil, f64(21) // KV unavailable, waiting over threshold
+	})
+	c, w := newCtx("/v1/chat/completions", b2Body(0))
+
+	h.Passthrough(c)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("a present-but-breaching dimension must still shed; got %d", w.Code)
+	}
+}
+
+// TestB3_ReadsShedIfNotExcludeIf verifies the front-door shed reads the shed_if
+// thresholds, independent of the per-agent exclude_if routing gates. A policy
+// whose exclude_if would fire at 0.10 but whose shed_if fires at 0.90 must admit
+// a request at 0.50 pressure — B3 must not shed on the routing thresholds.
+func TestB3_ReadsShedIfNotExcludeIf(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	pol := &policy.Policy{
+		RoutingPolicy: policy.PolicyStep{ExcludeIf: map[string]policy.ThresholdRule{
+			"kv_cache_utilization": {GT: f64(0.10)}, // per-agent routing gate — not B3's concern
+		}},
+		ShedIf: map[string]policy.ThresholdRule{
+			"kv_cache_utilization": {GT: f64(0.90)}, // front-door shed
+		},
+	}
+	h := newB3Handlers(q, pol, func(string) (*float64, *float64) {
+		return f64(0.50), nil // above exclude_if 0.10, below shed_if 0.90
+	})
+	c, w := newCtx("/v1/chat/completions", b2Body(0))
+
+	done := make(chan struct{})
+	go func() { h.Passthrough(c); close(done) }()
+	select {
+	case pending := <-q:
+		pending.Response <- &domain.ChatResponse{RawBytes: []byte(`{"ok":true}`)}
+	case <-time.After(time.Second):
+		t.Fatal("B3 must read shed_if (0.90), not exclude_if (0.10); the request should pass")
+	}
+	<-done
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 — B3 must not shed on exclude_if thresholds; got %d", w.Code)
+	}
+}
+
+// TestB3_InertWhenNoShedIf verifies a policy without shed_if never sheds, even
+// under extreme reported pressure.
+func TestB3_InertWhenNoShedIf(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	h := newB3Handlers(q, &policy.Policy{}, func(string) (*float64, *float64) {
+		return f64(0.99), f64(100) // pressure through the roof
+	})
+	c, w := newCtx("/v1/chat/completions", b2Body(0))
+
+	done := make(chan struct{})
+	go func() { h.Passthrough(c); close(done) }()
+	select {
+	case pending := <-q:
+		pending.Response <- &domain.ChatResponse{RawBytes: []byte(`{"ok":true}`)}
+	case <-time.After(time.Second):
+		t.Fatal("with no shed_if declared the gate must be inert")
+	}
+	<-done
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 with shed_if unset, got %d", w.Code)
+	}
+}

--- a/test/api/middleware_test.go
+++ b/test/api/middleware_test.go
@@ -154,7 +154,7 @@ func newPolicyHandlers() *api.Handlers {
 		stor, nil, nil, 2*time.Second,
 		exec, nil, nil, nil,
 		nil, nil, nil, nil, nil, nil, nil, nil,
-		nil,
+		nil, nil,
 	)
 }
 

--- a/test/api/passthrough_test.go
+++ b/test/api/passthrough_test.go
@@ -59,7 +59,7 @@ func newTestHandlers(q chan *domain.PendingRequest, lim auth.RateLimiter) *api.H
 		nil, nil, q, 2*time.Second,
 		nil, nil, nil, lim,
 		nil, nil, nil, nil, nil, nil, nil, nil,
-		nil,
+		nil, nil,
 	)
 }
 

--- a/test/api/registration_stream_test.go
+++ b/test/api/registration_stream_test.go
@@ -47,7 +47,7 @@ func TestRegistrationStream_EmitsSSEFrame(t *testing.T) {
 		nil, nil, nil, time.Second,
 		nil, nil, nil, nil,
 		nil, nil, nil, nil, nil, nil, nil, feed,
-		nil,
+		nil, nil,
 	)
 
 	router := gin.New()
@@ -124,6 +124,7 @@ func TestRegistrationStream_NotImplementedWhenNoFeed(t *testing.T) {
 		nil, nil, nil, nil,
 		nil, nil, nil, nil, nil, nil, nil, nil, // registrationFeed = nil
 		nil, // admission controller = nil
+		nil, // engine-pressure provider = nil
 	)
 
 	router := gin.New()

--- a/test/router/engine_pressure_test.go
+++ b/test/router/engine_pressure_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+// Package router_test contains black-box tests for the aggregate engine-pressure
+// helper that feeds the front-door KV-pressure shed gate.
+package router_test
+
+import (
+	"math"
+	"testing"
+
+	"hivenet_router/internal/domain"
+	"hivenet_router/internal/router"
+)
+
+func fp(v float64) *float64 { return &v }
+
+func approx(got *float64, want float64) bool {
+	return got != nil && math.Abs(*got-want) < 1e-9
+}
+
+// TestMeanEnginePressure_AveragesReportedMetrics verifies the helper returns the
+// mean over the agents that report each metric, skips nil snapshots, and returns
+// nil for a dimension no agent reports.
+func TestMeanEnginePressure_AveragesReportedMetrics(t *testing.T) {
+	metrics := []*domain.BackendMetrics{
+		{KVCacheUtilization: fp(0.80), WaitingRequests: fp(10)},
+		{KVCacheUtilization: fp(0.90), WaitingRequests: fp(30)},
+		nil,                            // skipped
+		{KVCacheUtilization: fp(0.70)}, // no waiting reported
+	}
+	kv, waiting := router.MeanEnginePressure(metrics)
+	if !approx(kv, 0.80) { // (0.80+0.90+0.70)/3
+		t.Errorf("kv mean = %v, want 0.80", kv)
+	}
+	if !approx(waiting, 20) { // (10+30)/2
+		t.Errorf("waiting mean = %v, want 20", waiting)
+	}
+}
+
+// TestMeanEnginePressure_NilWhenNoneReported verifies a dimension no agent
+// reports is nil (not zero), so the gate skips it instead of reading it as no
+// pressure.
+func TestMeanEnginePressure_NilWhenNoneReported(t *testing.T) {
+	// Waiting reported, KV never reported.
+	kv, waiting := router.MeanEnginePressure([]*domain.BackendMetrics{
+		{WaitingRequests: fp(5)},
+		{WaitingRequests: fp(15)},
+	})
+	if kv != nil {
+		t.Errorf("kv must be nil when no agent reports it, got %v", *kv)
+	}
+	if !approx(waiting, 10) {
+		t.Errorf("waiting mean = %v, want 10", waiting)
+	}
+}
+
+// TestMeanEnginePressure_EmptyIsNil verifies an empty fleet reports no pressure
+// on either dimension.
+func TestMeanEnginePressure_EmptyIsNil(t *testing.T) {
+	kv, waiting := router.MeanEnginePressure(nil)
+	if kv != nil || waiting != nil {
+		t.Errorf("empty input must yield nil/nil, got kv=%v waiting=%v", kv, waiting)
+	}
+}


### PR DESCRIPTION
## Front-door KV-pressure shed

When the **aggregate live engine pressure** for a model breaches the policy's `shed_if` thresholds, new requests are rejected with **429 + `Retry-After`** at the door — before queueing — instead of piling into an already-saturated pool. It's the direct read of *"is the box full right now?"*, catching whatever the occupancy budget mis-estimates.

### How it works
- A new provider aggregates the **mean** KV-cache utilization and waiting-request count across the **healthy** replicas serving the model (`Router.EnginePressureForModel` → `MeanEnginePressure`).
- The handler gate (`enforceShedPressure`, run after B1 caps and before the B2 occupancy reservation) evaluates that aggregate against `pol.ShedIf` using the **same** `policy.PassesGates` / `ThresholdRule` logic and nil-passes contract routing already uses for `exclude_if`.
- Order: allowlist → parse → authorize → **B1 caps → B3 shed → B2 occupancy** → daily budget → enqueue. Shedding before B2 avoids reserving occupancy for a request we're about to drop.

### Design decisions (please sanity-check)
1. **Mean, not max.** A single hot replica is already handled by routing's per-agent `exclude_if`; shedding *new admissions* is warranted only when the pool as a whole is under pressure. Max would over-shed.
2. **Fails open.** No engine signal (non-vLLM engine, no snapshot yet) → the dimension is nil → the gate passes, exactly like the per-agent nil-passes contract. A missing signal is never read as pressure.
3. **Additive, routing untouched.** The per-agent `exclude_if` 503 routing gates are unchanged — this only adds the front-door 429. I did **not** modify the evaluator; B3 reuses `PassesGates` read-only.
4. **Error code.** Reuses `concurrency_limit_exceeded` (429) per the spec's grouping of rate/occupancy/shed; the distinct **metric** reason label is the observability ticket's job, not a new error code here.
5. **Threshold 0.90.** `policies/_default.yaml` bumps `exclude_if` KV 0.85→0.90 and gains a `shed_if` block. An operator note explains 0.90 is deliberately more permissive than the industry ~0.80 default and leans on the occupancy budget's token-estimate accuracy — move it down if the estimator proves optimistic.

### Perf note
`EnginePressureForModel` reads each healthy agent's engine snapshot from the in-memory store per request (same reads routing already does). A cached per-model aggregate updated on signal ingestion is a possible follow-up if this shows on the hot path.

### Tests
- **`test/api/b3_shed_test.go`** (7): KV-over-threshold 429 + Retry-After + not-queued; waiting-over-threshold 429; below-threshold passes; no-signal fails open; partial-signal still evaluates the present dimension; inert when `shed_if` unset; **reads `shed_if` not `exclude_if`** (guards against confusing the two threshold sets).
- **`test/router/engine_pressure_test.go`** (3): mean over reporting agents (skips nil), nil-when-none-reported, empty→nil.
- Per-agent `exclude_if` routing is unchanged (no evaluator edits) and stays covered by the existing `TestPassesGates` / `TestExhaustionLog_ExcludeIfFail`.

Full suite passes under `-race`; gofmt + lint clean.
