### PR TITLE
Restore complete Hivenet Router documentation navigation

### DIFF
--- a/docs/deploy/agents/llama-cpp.mdx
+++ b/docs/deploy/agents/llama-cpp.mdx
@@ -4,23 +4,23 @@ description: "Connect a llama.cpp server to Mycoroute, set a stable model name, 
 sidebarTitle: "llama.cpp"
 ---
 
-Connect a llama.cpp server to Mycoroute by running an agent beside the backend.
+Connect a llama.cpp server to Hivenet Router by running an agent beside the backend.
 
 The agent discovers the model served by llama.cpp, registers it with the router, forwards OpenAI-compatible chat-completion requests, and reports engine and hardware metrics.
 
 <Warning>
-  A llama.cpp server runs one model per process, and each Mycoroute agent registers one model. Run a separate server and agent pair for each model you want to expose.
+  A llama.cpp server runs one model per process, and each Hivenet Router agent registers one model. Run a separate server and agent pair for each model you want to expose.
 </Warning>
 
 ## Before you start
 
 You need:
 
-- a running Mycoroute router
+- a running Hivenet Router router
 - a GGUF model file
 - llama.cpp built locally or available as a Docker image
 - network access between the agent host and router
-- the Mycoroute agent binary or Docker image
+- the Hivenet Router agent binary or Docker image
 - the same JWT secret used by the router
 - an NVIDIA GPU if you want CUDA acceleration and GPU metrics
 
@@ -39,9 +39,9 @@ Replace these values with addresses and model names from your deployment.
 
 ## Start llama.cpp
 
-Use the `-a` option to give the model a stable alias. The alias becomes the model name registered with Mycoroute and used by API clients.
+Use the `-a` option to give the model a stable alias. The alias becomes the model name registered with Hivenet Router and used by API clients.
 
-Start llama.cpp with `--metrics` if you want Mycoroute to collect cache, queue, latency, and throughput metrics.
+Start llama.cpp with `--metrics` if you want Hivenet Router to collect cache, queue, latency, and throughput metrics.
 
 <Tabs>
   <Tab title="Docker">
@@ -135,7 +135,7 @@ curl http://localhost:8888/v1/models \
 
 The alias passed with `-a` determines the model name returned by llama.cpp.
 
-| llama.cpp launch options | Model registered with Mycoroute |
+| llama.cpp launch options | Model registered with Hivenet Router |
 | --- | --- |
 | `-m model.gguf -a "my-model"` | `my-model` |
 | `-m llama-3.1-8b.Q4_K_M.gguf` without `-a` | `llama-3.1-8b.Q4_K_M` |
@@ -143,14 +143,14 @@ The alias passed with `-a` determines the model name returned by llama.cpp.
 Using an explicit alias makes client configuration and routing policies less dependent on the model filename.
 
 <Note>
-  Changing the alias changes the model name seen by Mycoroute. Clients and routing policies must use the new value.
+  Changing the alias changes the model name seen by Hivenet Router. Clients and routing policies must use the new value.
 </Note>
 
-## Prepare the Mycoroute agent
+## Prepare the Hivenet Router agent
 
 <Tabs>
   <Tab title="Docker">
-    From the Mycoroute repository, build the agent image if you have not already done so:
+    From the Hivenet Router repository, build the agent image if you have not already done so:
 
     ```bash
     docker build \
@@ -179,10 +179,10 @@ Using an explicit alias makes client configuration and routing policies less dep
     ```
   </Tab>
   <Tab title="Bare metal">
-    Build the agent from the Mycoroute repository:
+    Build the agent from the Hivenet Router repository:
 
     ```bash
-    go build -o bin/mycoroute-agent ./cmd/agent/
+    go build -o bin/hivenet-agent ./cmd/agent/
     ```
 
     Place the shared JWT secret somewhere the agent can read, for example:
@@ -206,7 +206,7 @@ Using an explicit alias makes client configuration and routing policies less dep
   <Tab title="Docker">
     ```bash
     docker run -d \
-      --name mycoroute-agent \
+      --name hivenet-agent \
       --restart unless-stopped \
       --network host \
       --gpus all \
@@ -234,7 +234,7 @@ Using an explicit alias makes client configuration and routing policies less dep
   </Tab>
   <Tab title="Bare metal">
     ```bash
-    ./bin/mycoroute-agent \
+    ./bin/hivenet-agent \
       --engine llamacpp \
       --backend-url http://localhost:8888 \
       --router-grpc 192.168.1.100:50051 \
@@ -258,7 +258,7 @@ The agent waits until llama.cpp is healthy and exposes a model before registerin
 | `--backend-url` | Base URL of the local llama.cpp server |
 | `--router-grpc` | Router endpoint used for agent authentication |
 | `--jwt-secret-file` | Shared secret used to authenticate the agent |
-| `--capacity` | Maximum concurrent requests Mycoroute may assign |
+| `--capacity` | Maximum concurrent requests Hivenet Router may assign |
 | `--region` | Region metadata available to routing policies |
 | `--organization` | Organization or infrastructure-provider metadata |
 | `--machine` | Stable machine identifier |
@@ -292,7 +292,7 @@ The value must match the model alias returned by llama.cpp.
 
 ## Set agent capacity
 
-`--capacity` limits how many concurrent requests Mycoroute may assign to the agent.
+`--capacity` limits how many concurrent requests Hivenet Router may assign to the agent.
 
 It does not change llama.cpp’s own parallelism, slot count, context allocation, or batch configuration.
 
@@ -305,10 +305,10 @@ Conservative starting values from the original deployment guidance are:
 
 Treat these as starting points rather than universal limits. Test with your model, quantization, context size, and hardware.
 
-When the agent reaches its declared capacity, Mycoroute considers another matching agent or a configured fallback step.
+When the agent reaches its declared capacity, Hivenet Router considers another matching agent or a configured fallback step.
 
 <Note>
-  For streaming responses, Mycoroute releases the agent capacity slot when response headers arrive, while backend generation can continue. Treat `--capacity` as a routing-admission setting rather than a hard limit on ongoing streams, and verify llama.cpp concurrency under sustained streaming load.
+  For streaming responses, Hivenet Router releases the agent capacity slot when response headers arrive, while backend generation can continue. Treat `--capacity` as a routing-admission setting rather than a hard limit on ongoing streams, and verify llama.cpp concurrency under sustained streaming load.
 </Note>
 
 ## Verify the connection
@@ -358,7 +358,7 @@ The agent scrapes llama.cpp’s `/metrics` endpoint every 500 milliseconds by de
 
 Start llama.cpp with `--metrics` to make this data available. Metrics are sent to the router and re-exported through its Prometheus endpoint. The agent does not expose a separate Prometheus port.
 
-| Signal | llama.cpp source | Mycoroute field |
+| Signal | llama.cpp source | Hivenet Router field |
 | --- | --- | --- |
 | KV cache utilization | `llamacpp:kv_cache_usage_ratio` | `kv_cache_utilization` |
 | Running requests | `llamacpp:requests_processing` | `running_requests` |
@@ -368,27 +368,27 @@ Start llama.cpp with `--metrics` to make this data available. Metrics are sent t
 | Generation throughput | `llamacpp:predicted_tokens_seconds` | Predicted tokens per second |
 | Prompt throughput | `llamacpp:prompt_tokens_seconds` | Prompt tokens per second |
 
-llama.cpp does not use the preemption mechanism measured for vLLM, so Mycoroute does not populate a preemption metric for this engine.
+llama.cpp does not use the preemption mechanism measured for vLLM, so Hivenet Router does not populate a preemption metric for this engine.
 
 View all engine metrics through the router:
 
 ```bash
 curl http://192.168.1.100:2112/metrics \
-  | grep mycoroute_agent_engine
+  | grep hivenet_router_agent_engine
 ```
 
 Useful exported metrics include:
 
 ```text
-mycoroute_agent_engine_kv_cache_utilization
-mycoroute_agent_engine_running_requests
-mycoroute_agent_engine_waiting_requests
-mycoroute_agent_engine_avg_ttft_seconds
-mycoroute_agent_engine_p90_ttft_seconds
-mycoroute_agent_engine_avg_itl_seconds
-mycoroute_agent_engine_p90_itl_seconds
-mycoroute_agent_engine_predicted_tps
-mycoroute_agent_engine_prompt_tps
+hivenet_router_agent_engine_kv_cache_utilization
+hivenet_router_agent_engine_running_requests
+hivenet_router_agent_engine_waiting_requests
+hivenet_router_agent_engine_avg_ttft_seconds
+hivenet_router_agent_engine_p90_ttft_seconds
+hivenet_router_agent_engine_avg_itl_seconds
+hivenet_router_agent_engine_p90_itl_seconds
+hivenet_router_agent_engine_predicted_tps
+hivenet_router_agent_engine_prompt_tps
 ```
 
 View current values through the routing table:
@@ -434,7 +434,7 @@ exclude_if:
     gt: 2
 ```
 
-When a metric is unavailable, Mycoroute skips that gate for the agent rather than excluding it.
+When a metric is unavailable, Hivenet Router skips that gate for the agent rather than excluding it.
 
 See [Policy YAML reference](/routing/policy-yaml-reference) for the full schema.
 
@@ -531,7 +531,7 @@ curl http://localhost:8888/metrics \
   | head
 ```
 
-Without `--metrics`, the endpoint returns HTTP `404` and Mycoroute cannot collect engine-specific metrics.
+Without `--metrics`, the endpoint returns HTTP `404` and Hivenet Router cannot collect engine-specific metrics.
 
 A metrics scrape failure does not stop the agent from forwarding requests.
 
@@ -550,13 +550,13 @@ Use `-a` to set a stable alias:
 -a "llama-3.1-8b"
 ```
 
-Clients must send the same name to Mycoroute.
+Clients must send the same name to Hivenet Router.
 
 ### Responses are slow
 
 Possible adjustments include:
 
-- reduce `--capacity` on the Mycoroute agent
+- reduce `--capacity` on the Hivenet Router agent
 - reduce llama.cpp’s context size
 - use a smaller model or quantization
 - increase GPU offloading
@@ -571,13 +571,13 @@ Check the agent logs:
 <Tabs>
   <Tab title="Docker">
     ```bash
-    docker logs mycoroute-agent
+    docker logs hivenet-agent
     ```
   </Tab>
   <Tab title="systemd">
     ```bash
     sudo journalctl \
-      -u mycoroute-agent \
+      -u hivenet-agent \
       -n 100 \
       --no-pager
     ```
@@ -605,7 +605,7 @@ Make sure `--identity-path` points to persistent storage.
 For Docker:
 
 ```bash
-docker inspect mycoroute-agent \
+docker inspect hivenet-agent \
   | jq '.[0].Mounts'
 ```
 
@@ -638,7 +638,7 @@ nvidia-smi
 For Docker, confirm the agent received GPU access:
 
 ```bash
-docker inspect mycoroute-agent \
+docker inspect hivenet-agent \
   | jq '.[0].HostConfig.DeviceRequests'
 ```
 
@@ -652,7 +652,7 @@ The agent continues to operate without NVML. It reports CPU and memory metrics b
   </Card>
 
   <Card title="Routing concepts" href="/routing/routing-concepts">
-    Learn how Mycoroute filters and ranks matching agents.
+    Learn how Hivenet Router filters and ranks matching agents.
   </Card>
 
   <Card title="Engine metrics" href="/observability/engine-metrics">

--- a/docs/deploy/agents/sglang.mdx
+++ b/docs/deploy/agents/sglang.mdx
@@ -4,23 +4,23 @@ description: "Connect an SGLang backend to Mycoroute and expose cache, queue, an
 sidebarTitle: "SGLang"
 ---
 
-Connect an SGLang inference server to Mycoroute by running an agent beside the backend.
+Connect an SGLang inference server to Hivenet Router by running an agent beside the backend.
 
 The agent discovers the model exposed by SGLang, registers it with the router, forwards OpenAI-compatible chat-completion requests, and reports engine and hardware metrics.
 
 <Warning>
-  Each Mycoroute agent registers one model. If an SGLang server exposes several models, run a separate agent for each model and use `--model` to select the model that agent represents.
+  Each Hivenet Router agent registers one model. If an SGLang server exposes several models, run a separate agent for each model and use `--model` to select the model that agent represents.
 </Warning>
 
 ## Before you start
 
 You need:
 
-- a running Mycoroute router
+- a running Hivenet Router router
 - an NVIDIA GPU with CUDA support
 - SGLang installed or available as a Docker image
 - network access between the agent host and router
-- the Mycoroute agent binary or Docker image
+- the Hivenet Router agent binary or Docker image
 - the same JWT secret used by the router
 - access to the model you want to serve
 
@@ -90,7 +90,7 @@ Replace these values with addresses and model names from your deployment.
 </Tabs>
 
 <Warning>
-  Start SGLang with `--enable-metrics`. Without it, Mycoroute can still forward requests, but SGLang’s cache, queue, and time-to-first-token metrics will not be available.
+  Start SGLang with `--enable-metrics`. Without it, Hivenet Router can still forward requests, but SGLang’s cache, queue, and time-to-first-token metrics will not be available.
 </Warning>
 
 For a multi-GPU deployment, set the tensor-parallel size:
@@ -119,13 +119,13 @@ curl http://localhost:3000/v1/models \
   | jq '.data[].id'
 ```
 
-The model ID returned here is the value clients must use when sending requests through Mycoroute.
+The model ID returned here is the value clients must use when sending requests through Hivenet Router.
 
-## Prepare the Mycoroute agent
+## Prepare the Hivenet Router agent
 
 <Tabs>
   <Tab title="Docker">
-    From the Mycoroute repository, build the agent image if you have not already done so:
+    From the Hivenet Router repository, build the agent image if you have not already done so:
 
     ```bash
     docker build \
@@ -154,10 +154,10 @@ The model ID returned here is the value clients must use when sending requests t
     ```
   </Tab>
   <Tab title="Bare metal">
-    Build the agent from the Mycoroute repository:
+    Build the agent from the Hivenet Router repository:
 
     ```bash
-    go build -o bin/mycoroute-agent ./cmd/agent/
+    go build -o bin/hivenet-agent ./cmd/agent/
     ```
 
     Place the shared JWT secret somewhere the agent process can read, for example:
@@ -181,7 +181,7 @@ The model ID returned here is the value clients must use when sending requests t
   <Tab title="Docker">
     ```bash
     docker run -d \
-      --name mycoroute-agent \
+      --name hivenet-agent \
       --restart unless-stopped \
       --network host \
       --gpus all \
@@ -205,7 +205,7 @@ The model ID returned here is the value clients must use when sending requests t
   </Tab>
   <Tab title="Bare metal">
     ```bash
-    ./bin/mycoroute-agent \
+    ./bin/hivenet-agent \
       --engine sglang \
       --backend-url http://localhost:3000 \
       --router-grpc 192.168.1.100:50051 \
@@ -229,7 +229,7 @@ The agent waits for SGLang to become healthy and expose a model before registeri
 | `--backend-url` | Base URL of the local SGLang server |
 | `--router-grpc` | Router endpoint used for agent authentication |
 | `--jwt-secret-file` | Shared secret used to authenticate the agent |
-| `--capacity` | Maximum concurrent requests Mycoroute may assign |
+| `--capacity` | Maximum concurrent requests Hivenet Router may assign |
 | `--region` | Region metadata available to routing policies |
 | `--organization` | Organization or infrastructure-provider metadata |
 | `--machine` | Stable machine identifier |
@@ -270,12 +270,12 @@ Use `--model` to pin the agent to a particular model:
 The explicit value overrides automatic discovery.
 
 <Note>
-  The model registered by the agent must match the model name clients send to Mycoroute.
+  The model registered by the agent must match the model name clients send to Hivenet Router.
 </Note>
 
 ## Set agent capacity
 
-`--capacity` controls how many concurrent requests Mycoroute may assign to the agent.
+`--capacity` controls how many concurrent requests Hivenet Router may assign to the agent.
 
 It does not change SGLang’s own scheduler or memory configuration.
 
@@ -294,12 +294,12 @@ For example:
 --capacity 20
 ```
 
-When the agent reaches its declared capacity, Mycoroute stops assigning new requests to it and considers other matching agents or configured fallback steps.
+When the agent reaches its declared capacity, Hivenet Router stops assigning new requests to it and considers other matching agents or configured fallback steps.
 
 Test the backend under representative load before increasing capacity.
 
 <Note>
-  For streaming responses, Mycoroute releases the agent capacity slot when response headers arrive, while backend generation can continue. Treat `--capacity` as a routing-admission setting rather than a hard limit on ongoing streams, and verify SGLang concurrency under sustained streaming load.
+  For streaming responses, Hivenet Router releases the agent capacity slot when response headers arrive, while backend generation can continue. Treat `--capacity` as a routing-admission setting rather than a hard limit on ongoing streams, and verify SGLang concurrency under sustained streaming load.
 </Note>
 
 ## Verify the connection
@@ -341,7 +341,7 @@ curl -X POST http://192.168.1.100:8080/v1/chat/completions \
   }'
 ```
 
-Applications call Mycoroute’s OpenAI-compatible endpoint. The agent forwards the request to SGLang’s OpenAI-compatible API.
+Applications call Hivenet Router’s OpenAI-compatible endpoint. The agent forwards the request to SGLang’s OpenAI-compatible API.
 
 ## SGLang metrics
 
@@ -349,7 +349,7 @@ The agent scrapes SGLang’s `/metrics` endpoint every 500 milliseconds by defau
 
 It sends the resulting engine data to the router, which exposes it through the router’s Prometheus endpoint. The agent does not expose a separate Prometheus port.
 
-| Signal | SGLang source | Mycoroute field |
+| Signal | SGLang source | Hivenet Router field |
 | --- | --- | --- |
 | Token-cache utilization | `sglang:token_usage` | `kv_cache_utilization` |
 | Running requests | `sglang:num_running_reqs` | `running_requests` |
@@ -357,7 +357,7 @@ It sends the resulting engine data to the router, which exposes it through the r
 | Average time to first token | `sglang:time_to_first_token_seconds` | Average TTFT |
 | P90 time to first token | `sglang:time_to_first_token_seconds` | P90 TTFT |
 
-SGLang does not expose an inter-token-latency histogram through this integration. Mycoroute therefore does not populate average or P90 ITL values for SGLang agents.
+SGLang does not expose an inter-token-latency histogram through this integration. Hivenet Router therefore does not populate average or P90 ITL values for SGLang agents.
 
 SGLang also has no preemption metric equivalent to the one collected from vLLM.
 
@@ -365,17 +365,17 @@ View engine metrics on the router:
 
 ```bash
 curl http://192.168.1.100:2112/metrics \
-  | grep mycoroute_agent_engine
+  | grep hivenet_router_agent_engine
 ```
 
 Useful exported metrics include:
 
 ```text
-mycoroute_agent_engine_kv_cache_utilization
-mycoroute_agent_engine_running_requests
-mycoroute_agent_engine_waiting_requests
-mycoroute_agent_engine_avg_ttft_seconds
-mycoroute_agent_engine_p90_ttft_seconds
+hivenet_router_agent_engine_kv_cache_utilization
+hivenet_router_agent_engine_running_requests
+hivenet_router_agent_engine_waiting_requests
+hivenet_router_agent_engine_avg_ttft_seconds
+hivenet_router_agent_engine_p90_ttft_seconds
 ```
 
 View current values through the routing table:
@@ -419,7 +419,7 @@ exclude_if:
     gt: 2
 ```
 
-When a metric is unavailable for an agent, Mycoroute skips that gate for the agent rather than excluding it.
+When a metric is unavailable for an agent, Hivenet Router skips that gate for the agent rather than excluding it.
 
 See [Policy YAML reference](/routing/policy-yaml-reference) for the full policy schema.
 
@@ -529,13 +529,13 @@ Check the agent logs:
 <Tabs>
   <Tab title="Docker">
     ```bash
-    docker logs mycoroute-agent
+    docker logs hivenet-agent
     ```
   </Tab>
   <Tab title="systemd">
     ```bash
     sudo journalctl \
-      -u mycoroute-agent \
+      -u hivenet-agent \
       -n 100 \
       --no-pager
     ```
@@ -563,7 +563,7 @@ Make sure `--identity-path` points to persistent storage.
 For Docker:
 
 ```bash
-docker inspect mycoroute-agent \
+docker inspect hivenet-agent \
   | jq '.[0].Mounts'
 ```
 
@@ -596,7 +596,7 @@ nvidia-smi
 For Docker, confirm the agent received GPU access:
 
 ```bash
-docker inspect mycoroute-agent \
+docker inspect hivenet-agent \
   | jq '.[0].HostConfig.DeviceRequests'
 ```
 
@@ -610,7 +610,7 @@ The agent continues to operate without NVML. It reports CPU and memory metrics b
   </Card>
 
   <Card title="Routing concepts" href="/routing/routing-concepts">
-    Learn how Mycoroute filters and ranks matching agents.
+    Learn how Hivenet Router filters and ranks matching agents.
   </Card>
 
   <Card title="Engine metrics" href="/observability/engine-metrics">

--- a/docs/deploy/agents/vllm.mdx
+++ b/docs/deploy/agents/vllm.mdx
@@ -4,24 +4,24 @@ description: "Connect a vLLM backend to Mycoroute, configure model discovery and
 sidebarTitle: "vLLM"
 ---
 
-Connect a vLLM inference server to Mycoroute by running an agent beside the backend.
+Connect a vLLM inference server to Hivenet Router by running an agent beside the backend.
 
-The agent discovers the model served by vLLM, registers it with the router, forwards requests, and reports engine and hardware metrics that Mycoroute can use for routing and observability.
+The agent discovers the model served by vLLM, registers it with the router, forwards requests, and reports engine and hardware metrics that Hivenet Router can use for routing and observability.
 
 <Warning>
-  Each Mycoroute agent registers one model. If a backend exposes several models, run a separate agent for each model and use `--model` to select the model that agent represents.
+  Each Hivenet Router agent registers one model. If a backend exposes several models, run a separate agent for each model and use `--model` to select the model that agent represents.
 </Warning>
 
 ## Before you start
 
 You need:
 
-- a running Mycoroute router
+- a running Hivenet Router router
 - an NVIDIA GPU with CUDA support
 - network access between the agent host and the router
 - access to the model you want to serve
 - either Docker or a Python environment supported by vLLM
-- the Mycoroute agent binary or Docker image
+- the Hivenet Router agent binary or Docker image
 - the same JWT secret used by the router
 
 The examples use:
@@ -99,13 +99,13 @@ curl http://localhost:8888/v1/models \
   | jq '.data[].id'
 ```
 
-The model ID returned here is the value clients must use when sending requests through Mycoroute.
+The model ID returned here is the value clients must use when sending requests through Hivenet Router.
 
-## Prepare the Mycoroute agent
+## Prepare the Hivenet Router agent
 
 <Tabs>
   <Tab title="Docker">
-    From the Mycoroute repository, build the agent image if you have not already done so:
+    From the Hivenet Router repository, build the agent image if you have not already done so:
 
     ```bash
     docker build \
@@ -134,10 +134,10 @@ The model ID returned here is the value clients must use when sending requests t
     ```
   </Tab>
   <Tab title="Bare metal">
-    Build the agent from the Mycoroute repository:
+    Build the agent from the Hivenet Router repository:
 
     ```bash
-    go build -o bin/mycoroute-agent ./cmd/agent/
+    go build -o bin/hivenet-agent ./cmd/agent/
     ```
 
     Place the shared JWT secret somewhere the agent process can read, for example:
@@ -161,7 +161,7 @@ The model ID returned here is the value clients must use when sending requests t
   <Tab title="Docker">
     ```bash
     docker run -d \
-      --name mycoroute-agent \
+      --name hivenet-agent \
       --restart unless-stopped \
       --network host \
       --gpus all \
@@ -185,7 +185,7 @@ The model ID returned here is the value clients must use when sending requests t
   </Tab>
   <Tab title="Bare metal">
     ```bash
-    ./bin/mycoroute-agent \
+    ./bin/hivenet-agent \
       --engine vllm \
       --backend-url http://localhost:8888 \
       --router-grpc 192.168.1.100:50051 \
@@ -250,7 +250,7 @@ Use `--model` when you want to pin the agent to a specific model:
 The explicit value overrides automatic discovery.
 
 <Note>
-  The model name registered by the agent must match the model name clients send to Mycoroute.
+  The model name registered by the agent must match the model name clients send to Hivenet Router.
 </Note>
 
 ## Connect multiple models
@@ -260,7 +260,7 @@ Each agent registers as an independent peer and represents one model.
 If one backend exposes multiple models, start one agent process for each model:
 
 ```bash
-./bin/mycoroute-agent \
+./bin/hivenet-agent \
   --engine vllm \
   --model meta-llama/Llama-3.1-8B-Instruct \
   --backend-url http://localhost:8888 \
@@ -271,7 +271,7 @@ If one backend exposes multiple models, start one agent process for each model:
 Start the second agent with a different model and identity:
 
 ```bash
-./bin/mycoroute-agent \
+./bin/hivenet-agent \
   --engine vllm \
   --model meta-llama/Llama-3.1-70B-Instruct \
   --backend-url http://localhost:8888 \
@@ -293,11 +293,11 @@ vllm serve ... \
 ```
 
 ```bash
-mycoroute-agent ... \
+hivenet-agent ... \
   --capacity 256
 ```
 
-You may set the Mycoroute capacity slightly lower to preserve headroom:
+You may set the Hivenet Router capacity slightly lower to preserve headroom:
 
 ```bash
 --capacity 224
@@ -305,10 +305,10 @@ You may set the Mycoroute capacity slightly lower to preserve headroom:
 
 When an agent reaches its declared capacity, the router stops assigning new requests to it and considers other matching agents or configured fallback steps.
 
-Capacity does not change vLLM’s own scheduler limit. It tells Mycoroute how much work the agent is prepared to accept.
+Capacity does not change vLLM’s own scheduler limit. It tells Hivenet Router how much work the agent is prepared to accept.
 
 <Note>
-  For streaming responses, Mycoroute releases the agent capacity slot when response headers arrive, while backend generation can continue. Treat `--capacity` as a routing-admission setting rather than a hard limit on ongoing streams, and verify vLLM concurrency under sustained streaming load.
+  For streaming responses, Hivenet Router releases the agent capacity slot when response headers arrive, while backend generation can continue. Treat `--capacity` as a routing-admission setting rather than a hard limit on ongoing streams, and verify vLLM concurrency under sustained streaming load.
 </Note>
 
 ## Verify the connection
@@ -364,7 +364,7 @@ The agent scrapes vLLM’s `/metrics` endpoint every 500 milliseconds by default
 
 It sends the resulting engine data to the router, which exposes it through the router’s Prometheus endpoint. The agent does not expose a separate Prometheus port.
 
-| Signal | vLLM source | Mycoroute use |
+| Signal | vLLM source | Hivenet Router use |
 | --- | --- | --- |
 | KV cache utilization | `vllm:kv_cache_usage_perc` | Routing gates and observability |
 | Running requests | `vllm:num_requests_running` | Routing and load visibility |
@@ -380,20 +380,20 @@ View all engine metrics on the router:
 
 ```bash
 curl http://192.168.1.100:2112/metrics \
-  | grep mycoroute_agent_engine
+  | grep hivenet_router_agent_engine
 ```
 
 Useful exported metrics include:
 
 ```text
-mycoroute_agent_engine_kv_cache_utilization
-mycoroute_agent_engine_running_requests
-mycoroute_agent_engine_waiting_requests
-mycoroute_agent_engine_preemptions_total
-mycoroute_agent_engine_avg_ttft_seconds
-mycoroute_agent_engine_p90_ttft_seconds
-mycoroute_agent_engine_avg_itl_seconds
-mycoroute_agent_engine_p90_itl_seconds
+hivenet_router_agent_engine_kv_cache_utilization
+hivenet_router_agent_engine_running_requests
+hivenet_router_agent_engine_waiting_requests
+hivenet_router_agent_engine_preemptions_total
+hivenet_router_agent_engine_avg_ttft_seconds
+hivenet_router_agent_engine_p90_ttft_seconds
+hivenet_router_agent_engine_avg_itl_seconds
+hivenet_router_agent_engine_p90_itl_seconds
 ```
 
 View live values through the routing table:
@@ -429,7 +429,7 @@ exclude_if:
     gt: 0
 ```
 
-When a metric is unavailable for an agent, Mycoroute skips that gate for the agent rather than excluding it.
+When a metric is unavailable for an agent, Hivenet Router skips that gate for the agent rather than excluding it.
 
 See [Policy YAML reference](/routing/policy-yaml-reference) for the full policy schema.
 
@@ -471,12 +471,12 @@ Check the agent logs:
 <Tabs>
   <Tab title="Docker">
     ```bash
-    docker logs mycoroute-agent
+    docker logs hivenet-agent
     ```
   </Tab>
   <Tab title="systemd">
     ```bash
-    sudo journalctl -u mycoroute-agent -n 100 --no-pager
+    sudo journalctl -u hivenet-agent -n 100 --no-pager
     ```
   </Tab>
 </Tabs>
@@ -492,7 +492,7 @@ Check that the router and agent use the same JWT secret.
 
 ### KV cache utilization remains high
 
-Reduce the amount of work Mycoroute assigns to the agent:
+Reduce the amount of work Hivenet Router assigns to the agent:
 
 ```bash
 --capacity 128
@@ -512,7 +512,7 @@ Rising preemptions indicate that vLLM is evicting in-flight KV-cache data under 
 
 Reduce:
 
-- `--capacity` on the Mycoroute agent
+- `--capacity` on the Hivenet Router agent
 - `--max-num-seqs` on vLLM
 - model context or batch pressure, where appropriate for your workload
 
@@ -533,7 +533,7 @@ Make sure `--identity-path` points to persistent storage.
 For Docker, confirm the volume is mounted:
 
 ```bash
-docker inspect mycoroute-agent \
+docker inspect hivenet-agent \
   | jq '.[0].Mounts'
 ```
 
@@ -564,7 +564,7 @@ Metrics are scraped in the background. A scrape failure does not stop the agent 
   </Card>
 
   <Card title="Routing concepts" href="/routing/routing-concepts">
-    Learn how Mycoroute filters and ranks matching agents.
+    Learn how Hivenet Router filters and ranks matching agents.
   </Card>
 
   <Card title="Engine metrics" href="/observability/engine-metrics">

--- a/docs/deploy/bare-metal.mdx
+++ b/docs/deploy/bare-metal.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Bare-metal deployment"
-description: "Run the Mycoroute router and agents as native Linux services managed by systemd."
+description: "Run the Hivenet Router router and agents as native Linux services managed by systemd."
 sidebarTitle: "Bare metal"
 ---
 
-Run the Mycoroute router and agents as native Linux binaries managed by systemd.
+Run the Hivenet Router router and agents as native Linux binaries managed by systemd.
 
 This setup avoids a container runtime and gives you direct control over process supervision, filesystem permissions, logs, resource limits, and upgrades.
 
@@ -18,9 +18,9 @@ The examples use three machines:
 
 | Machine | Role | Example IP | Software |
 | --- | --- | --- | --- |
-| `router-server` | Mycoroute router | `192.168.1.100` | Router binary |
-| `gpu-eu-1` | Inference host | `192.168.1.101` | vLLM and Mycoroute agent |
-| `gpu-eu-2` | Inference host | `192.168.1.102` | vLLM and Mycoroute agent |
+| `router-server` | Hivenet Router router | `192.168.1.100` | Router binary |
+| `gpu-eu-1` | Inference host | `192.168.1.101` | vLLM and Hivenet Router agent |
+| `gpu-eu-2` | Inference host | `192.168.1.102` | vLLM and Hivenet Router agent |
 
 Applications send requests to the router. Each agent connects its local inference backend to the router.
 
@@ -35,7 +35,7 @@ Applications send requests to the router. Each agent connects its local inferenc
 
 Restrict ports `50051` and `9000` to agent hosts.
 
-Agent hosts initiate their connections to the router and do not need to expose an inbound Mycoroute port. Keep the metrics endpoint limited to your monitoring network.
+Agent hosts initiate their connections to the router and do not need to expose an inbound Hivenet Router port. Keep the metrics endpoint limited to your monitoring network.
 
 ## Prerequisites
 
@@ -50,25 +50,25 @@ You need:
 
 Go is required only to build the binaries. It does not need to be installed on the runtime hosts.
 
-This guide uses vLLM as the example backend. Mycoroute also supports Ollama, SGLang, llama.cpp, Infinity, and custom OpenAI-compatible servers.
+This guide uses vLLM as the example backend. Hivenet Router also supports Ollama, SGLang, llama.cpp, Infinity, and custom OpenAI-compatible servers.
 
 ## Build the binaries
 
 On the build machine:
 
 ```bash
-git clone https://github.com/HiveNetCode/mycoroute.git
+git clone https://github.com/HivenetOSS/hivenet_router.git
 cd mycoroute
 
-go build -o bin/mycoroute-router ./cmd/router/
-go build -o bin/mycoroute-agent ./cmd/agent/
+go build -o bin/hivenet-router ./cmd/router/
+go build -o bin/hivenet-agent ./cmd/agent/
 ```
 
 Check that both binaries start:
 
 ```bash
-./bin/mycoroute-router --help
-./bin/mycoroute-agent --help
+./bin/hivenet-router --help
+./bin/hivenet-agent --help
 ```
 
 ## Prepare the runtime hosts
@@ -164,7 +164,7 @@ getent group render >/dev/null \
 Copy the router binary to the router host through a temporary location:
 
 ```bash
-scp bin/mycoroute-router router-server:/tmp/mycoroute-router
+scp bin/hivenet-router router-server:/tmp/hivenet-router
 ```
 
 On `router-server`:
@@ -174,17 +174,17 @@ sudo install \
   -o root \
   -g root \
   -m 0755 \
-  /tmp/mycoroute-router \
-  /opt/mycoroute/mycoroute-router
+  /tmp/hivenet-router \
+  /opt/mycoroute/hivenet-router
 
-rm /tmp/mycoroute-router
+rm /tmp/hivenet-router
 ```
 
 Copy the agent binary to each inference host:
 
 ```bash
-scp bin/mycoroute-agent gpu-eu-1:/tmp/mycoroute-agent
-scp bin/mycoroute-agent gpu-eu-2:/tmp/mycoroute-agent
+scp bin/hivenet-agent gpu-eu-1:/tmp/hivenet-agent
+scp bin/hivenet-agent gpu-eu-2:/tmp/hivenet-agent
 ```
 
 On each inference host:
@@ -194,10 +194,10 @@ sudo install \
   -o root \
   -g root \
   -m 0755 \
-  /tmp/mycoroute-agent \
-  /opt/mycoroute/mycoroute-agent
+  /tmp/hivenet-agent \
+  /opt/mycoroute/hivenet-agent
 
-rm /tmp/mycoroute-agent
+rm /tmp/hivenet-agent
 ```
 
 Keeping the binaries owned by `root` prevents the service account from replacing its own executable.
@@ -221,7 +221,7 @@ scp jwt.secret gpu-eu-1:/tmp/mycoroute-jwt.secret
 scp jwt.secret gpu-eu-2:/tmp/mycoroute-jwt.secret
 ```
 
-On each host, install it with permissions that allow the Mycoroute service to read it:
+On each host, install it with permissions that allow the Hivenet Router service to read it:
 
 ```bash
 sudo install \
@@ -229,7 +229,7 @@ sudo install \
   -g mycoroute \
   -m 0640 \
   /tmp/mycoroute-jwt.secret \
-  /etc/mycoroute/jwt.secret
+  /etc/hivenet-router/jwt.secret
 
 rm /tmp/mycoroute-jwt.secret
 ```
@@ -267,22 +267,22 @@ curl http://localhost:8888/health
 
 A ready vLLM server returns HTTP status `200`.
 
-The Mycoroute agent runs as a long-lived daemon. It can start before the backend is ready and will continue polling until it becomes available. If the backend or router later becomes unavailable, the agent waits and reconnects rather than exiting on the first transient failure.
+The Hivenet Router agent runs as a long-lived daemon. It can start before the backend is ready and will continue polling until it becomes available. If the backend or router later becomes unavailable, the agent waits and reconnects rather than exiting on the first transient failure.
 
 ## Configure the router service
 
 Create:
 
 ```text
-/etc/systemd/system/mycoroute-router.service
+/etc/systemd/system/hivenet-router.service
 ```
 
 with the following content:
 
 ```ini
 [Unit]
-Description=Mycoroute router
-Documentation=https://github.com/HiveNetCode/mycoroute
+Description=Hivenet Router router
+Documentation=https://github.com/HivenetOSS/hivenet_router
 After=network-online.target
 Wants=network-online.target
 
@@ -292,8 +292,8 @@ User=mycoroute
 Group=mycoroute
 WorkingDirectory=/var/lib/mycoroute
 
-ExecStart=/opt/mycoroute/mycoroute-router \
-  --jwt-secret-file /etc/mycoroute/jwt.secret \
+ExecStart=/opt/mycoroute/hivenet-router \
+  --jwt-secret-file /etc/hivenet-router/jwt.secret \
   --http-port :8080 \
   --grpc-port :50051 \
   --p2p-port 9000 \
@@ -301,7 +301,7 @@ ExecStart=/opt/mycoroute/mycoroute-router \
   --metrics-port :2112 \
   --disk-db-path /var/lib/mycoroute/badger
 
-Environment=mycoroute_AUDIT_LOG_PATH=/var/log/mycoroute/audit.jsonl
+Environment=HIVENET_ROUTER_AUDIT_LOG_PATH=/var/log/mycoroute/audit.jsonl
 Environment=mycoroute_ALLOW_INSECURE_ADMIN=true
 
 Restart=on-failure
@@ -310,7 +310,7 @@ TimeoutStopSec=30s
 
 StandardOutput=journal
 StandardError=journal
-SyslogIdentifier=mycoroute-router
+SyslogIdentifier=hivenet-router
 
 UMask=0027
 NoNewPrivileges=true
@@ -338,7 +338,7 @@ The `--p2p-listen-addr 0.0.0.0` setting is required when agents connect from oth
 Create a host-specific environment file on `gpu-eu-1`:
 
 ```text
-/etc/mycoroute/agent.env
+/etc/hivenet-router/agent.env
 ```
 
 with:
@@ -352,22 +352,22 @@ AGENT_CAPACITY=32
 Protect the file:
 
 ```bash
-sudo chown root:mycoroute /etc/mycoroute/agent.env
-sudo chmod 0640 /etc/mycoroute/agent.env
+sudo chown root:mycoroute /etc/hivenet-router/agent.env
+sudo chmod 0640 /etc/hivenet-router/agent.env
 ```
 
 Create:
 
 ```text
-/etc/systemd/system/mycoroute-agent.service
+/etc/systemd/system/hivenet-agent.service
 ```
 
 with:
 
 ```ini
 [Unit]
-Description=Mycoroute agent
-Documentation=https://github.com/HiveNetCode/mycoroute
+Description=Hivenet Router agent
+Documentation=https://github.com/HivenetOSS/hivenet_router
 After=network-online.target
 Wants=network-online.target
 
@@ -377,11 +377,11 @@ User=mycoroute
 Group=mycoroute
 SupplementaryGroups=video
 WorkingDirectory=/var/lib/mycoroute/agent
-EnvironmentFile=/etc/mycoroute/agent.env
+EnvironmentFile=/etc/hivenet-router/agent.env
 
-ExecStart=/opt/mycoroute/mycoroute-agent \
+ExecStart=/opt/mycoroute/hivenet-agent \
   --router-grpc ${ROUTER_IP}:50051 \
-  --jwt-secret-file /etc/mycoroute/jwt.secret \
+  --jwt-secret-file /etc/hivenet-router/jwt.secret \
   --engine vllm \
   --backend-url http://localhost:8888 \
   --capacity ${AGENT_CAPACITY} \
@@ -394,7 +394,7 @@ TimeoutStopSec=30s
 
 StandardOutput=journal
 StandardError=journal
-SyslogIdentifier=mycoroute-agent
+SyslogIdentifier=hivenet-agent
 
 UMask=0027
 NoNewPrivileges=true
@@ -422,7 +422,7 @@ The important multi-machine settings are:
 
 Install the same systemd service file on `gpu-eu-2`.
 
-Create `/etc/mycoroute/agent.env` with host-specific values:
+Create `/etc/hivenet-router/agent.env` with host-specific values:
 
 ```bash
 ROUTER_IP=192.168.1.100
@@ -433,8 +433,8 @@ AGENT_CAPACITY=32
 Protect it:
 
 ```bash
-sudo chown root:mycoroute /etc/mycoroute/agent.env
-sudo chmod 0640 /etc/mycoroute/agent.env
+sudo chown root:mycoroute /etc/hivenet-router/agent.env
+sudo chmod 0640 /etc/hivenet-router/agent.env
 ```
 
 The service file itself does not need to change between hosts.
@@ -445,28 +445,28 @@ On `router-server`:
 
 ```bash
 sudo systemctl daemon-reload
-sudo systemctl enable --now mycoroute-router
+sudo systemctl enable --now hivenet-router
 ```
 
 Check its status:
 
 ```bash
-sudo systemctl status mycoroute-router
-sudo journalctl -fu mycoroute-router
+sudo systemctl status hivenet-router
+sudo journalctl -fu hivenet-router
 ```
 
 On each agent host:
 
 ```bash
 sudo systemctl daemon-reload
-sudo systemctl enable --now mycoroute-agent
+sudo systemctl enable --now hivenet-agent
 ```
 
 Check the agent:
 
 ```bash
-sudo systemctl status mycoroute-agent
-sudo journalctl -fu mycoroute-agent
+sudo systemctl status hivenet-agent
+sudo journalctl -fu hivenet-agent
 ```
 
 ## Verify the deployment
@@ -564,22 +564,22 @@ On the new host:
 1. Create the `mycoroute` account and directories.
 2. Install the agent binary.
 3. Install the shared JWT secret.
-4. Create `/etc/mycoroute/agent.env` with the router address and agent region.
+4. Create `/etc/hivenet-router/agent.env` with the router address and agent region.
 5. Install the agent systemd unit.
 6. Start the inference backend.
-7. Enable and start `mycoroute-agent`.
+7. Enable and start `hivenet-agent`.
 
 The new agent registers automatically once it can reach the router and its backend is ready.
 
-## Upgrade Mycoroute
+## Upgrade Hivenet Router
 
 Build the new binaries on the build machine:
 
 ```bash
 git pull
 
-go build -o bin/mycoroute-router ./cmd/router/
-go build -o bin/mycoroute-agent ./cmd/agent/
+go build -o bin/hivenet-router ./cmd/router/
+go build -o bin/hivenet-agent ./cmd/agent/
 ```
 
 ### Upgrade agents
@@ -589,29 +589,29 @@ When several agents serve the same model, upgrade them one at a time to preserve
 Copy the new agent binary:
 
 ```bash
-scp bin/mycoroute-agent gpu-eu-1:/tmp/mycoroute-agent.new
+scp bin/hivenet-agent gpu-eu-1:/tmp/hivenet-agent.new
 ```
 
 On the agent host:
 
 ```bash
-sudo systemctl stop mycoroute-agent
+sudo systemctl stop hivenet-agent
 
 sudo cp \
-  /opt/mycoroute/mycoroute-agent \
-  /opt/mycoroute/mycoroute-agent.bak
+  /opt/mycoroute/hivenet-agent \
+  /opt/mycoroute/hivenet-agent.bak
 
 sudo install \
   -o root \
   -g root \
   -m 0755 \
-  /tmp/mycoroute-agent.new \
-  /opt/mycoroute/mycoroute-agent
+  /tmp/hivenet-agent.new \
+  /opt/mycoroute/hivenet-agent
 
-rm /tmp/mycoroute-agent.new
+rm /tmp/hivenet-agent.new
 
-sudo systemctl start mycoroute-agent
-sudo systemctl status mycoroute-agent
+sudo systemctl start hivenet-agent
+sudo systemctl status hivenet-agent
 ```
 
 Confirm that the agent registers again before upgrading the next host.
@@ -621,29 +621,29 @@ Confirm that the agent registers again before upgrading the next host.
 Copy the new binary:
 
 ```bash
-scp bin/mycoroute-router router-server:/tmp/mycoroute-router.new
+scp bin/hivenet-router router-server:/tmp/hivenet-router.new
 ```
 
 On the router host:
 
 ```bash
-sudo systemctl stop mycoroute-router
+sudo systemctl stop hivenet-router
 
 sudo cp \
-  /opt/mycoroute/mycoroute-router \
-  /opt/mycoroute/mycoroute-router.bak
+  /opt/mycoroute/hivenet-router \
+  /opt/mycoroute/hivenet-router.bak
 
 sudo install \
   -o root \
   -g root \
   -m 0755 \
-  /tmp/mycoroute-router.new \
-  /opt/mycoroute/mycoroute-router
+  /tmp/hivenet-router.new \
+  /opt/mycoroute/hivenet-router
 
-rm /tmp/mycoroute-router.new
+rm /tmp/hivenet-router.new
 
-sudo systemctl start mycoroute-router
-sudo systemctl status mycoroute-router
+sudo systemctl start hivenet-router
+sudo systemctl status hivenet-router
 ```
 
 Check the health endpoint before returning traffic:
@@ -657,16 +657,16 @@ curl http://localhost:8080/health
 To restore the previous router binary:
 
 ```bash
-sudo systemctl stop mycoroute-router
+sudo systemctl stop hivenet-router
 
 sudo mv \
-  /opt/mycoroute/mycoroute-router.bak \
-  /opt/mycoroute/mycoroute-router
+  /opt/mycoroute/hivenet-router.bak \
+  /opt/mycoroute/hivenet-router
 
-sudo systemctl start mycoroute-router
+sudo systemctl start hivenet-router
 ```
 
-Use the equivalent commands with `mycoroute-agent` on an agent host.
+Use the equivalent commands with `hivenet-agent` on an agent host.
 
 ## Run an agent behind NAT
 
@@ -688,15 +688,15 @@ When the router itself is behind NAT or another translated network, configure th
 Inspect its status and recent logs:
 
 ```bash
-sudo systemctl status mycoroute-router
-sudo journalctl -u mycoroute-router -n 100 --no-pager
+sudo systemctl status hivenet-router
+sudo journalctl -u hivenet-router -n 100 --no-pager
 ```
 
 For an agent:
 
 ```bash
-sudo systemctl status mycoroute-agent
-sudo journalctl -u mycoroute-agent -n 100 --no-pager
+sudo systemctl status hivenet-agent
+sudo journalctl -u hivenet-agent -n 100 --no-pager
 ```
 
 ### The router cannot read the JWT secret
@@ -704,7 +704,7 @@ sudo journalctl -u mycoroute-agent -n 100 --no-pager
 Check the file ownership and mode:
 
 ```bash
-sudo ls -l /etc/mycoroute/jwt.secret
+sudo ls -l /etc/hivenet-router/jwt.secret
 ```
 
 Expected ownership and permissions:
@@ -716,7 +716,7 @@ Expected ownership and permissions:
 Test access as the service account:
 
 ```bash
-sudo -u mycoroute cat /etc/mycoroute/jwt.secret >/dev/null
+sudo -u mycoroute cat /etc/hivenet-router/jwt.secret >/dev/null
 ```
 
 ### An agent does not register
@@ -773,7 +773,7 @@ If necessary:
 
 ```bash
 sudo usermod -aG video mycoroute
-sudo systemctl restart mycoroute-agent
+sudo systemctl restart hivenet-agent
 ```
 
 If NVML remains unavailable, the agent continues to report CPU and memory metrics but omits GPU metrics.

--- a/docs/deploy/docker-compose.mdx
+++ b/docs/deploy/docker-compose.mdx
@@ -123,7 +123,7 @@ environment:
     On the router host:
 
     ```bash
-    git clone https://github.com/HiveNetCode/mycoroute.git
+    git clone https://github.com/HivenetOSS/hivenet_router.git
     cd mycoroute
     ```
 
@@ -228,7 +228,7 @@ Repeat these steps on every machine that runs an inference backend.
     Clone the repository:
 
     ```bash
-    git clone https://github.com/HiveNetCode/mycoroute.git
+    git clone https://github.com/HivenetOSS/hivenet_router.git
     cd mycoroute
     ```
 

--- a/docs/deploy/docker-quickstart.mdx
+++ b/docs/deploy/docker-quickstart.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Docker quickstart"
 sidebarTitle: "Docker quickstart"
-description: "Deploy a Mycoroute router and two vLLM agents across Linux hosts with Docker, then verify routing and metrics."
+description: "Deploy a Hivenet Router router and two vLLM agents across Linux hosts with Docker, then verify routing and metrics."
 ---
 
-Deploy one Mycoroute router and two vLLM agents across three Linux machines.
+Deploy one Hivenet Router router and two vLLM agents across three Linux machines.
 
-The router receives application requests through one client-facing API. Each agent connects a vLLM backend to the router. Both agents serve the same model, allowing Mycoroute to distribute requests between them.
+The router receives application requests through one client-facing API. Each agent connects a vLLM backend to the router. Both agents serve the same model, allowing Hivenet Router to distribute requests between them.
 
 <Note>
   The hostnames and private IP addresses in this guide are examples. Replace them with addresses from your own network.
@@ -16,7 +16,7 @@ The router receives application requests through one client-facing API. Each age
 
 | Machine | Role | Example IP | GPU |
 | --- | --- | --- | --- |
-| `router-server` | Mycoroute router | `192.168.1.100` | None |
+| `router-server` | Hivenet Router router | `192.168.1.100` | None |
 | `gpu-eu-1` | Agent and vLLM | `192.168.1.101` | NVIDIA GPU |
 | `gpu-eu-2` | Agent and vLLM | `192.168.1.102` | NVIDIA GPU |
 
@@ -33,7 +33,7 @@ Agents authenticate with the router over gRPC, receive the router’s libp2p con
 | Agents → Router | `9000` | libp2p registration and communication |
 | Monitoring → Router | `2112` | Prometheus metrics |
 
-Agent hosts initiate their connections to the router and do not need to expose an inbound Mycoroute port.
+Agent hosts initiate their connections to the router and do not need to expose an inbound Hivenet Router port.
 
 Keep the Prometheus endpoint restricted to your monitoring network.
 
@@ -56,7 +56,7 @@ This guide uses Docker host networking and is intended for Linux hosts.
     On `router-server`, clone the repository:
 
     ```bash
-    git clone https://github.com/HiveNetCode/mycoroute.git
+    git clone https://github.com/HivenetOSS/hivenet_router.git
     cd mycoroute
     ```
 
@@ -85,7 +85,7 @@ This guide uses Docker host networking and is intended for Linux hosts.
     Clone the repository:
 
     ```bash
-    git clone https://github.com/HiveNetCode/mycoroute.git
+    git clone https://github.com/HivenetOSS/hivenet_router.git
     cd mycoroute
     ```
 
@@ -155,10 +155,10 @@ This guide uses Docker host networking and is intended for Linux hosts.
 
     ```bash
     docker run -d \
-      --name mycoroute-router \
+      --name hivenet-router \
       --restart unless-stopped \
       --network host \
-      -e mycoroute_ALLOW_INSECURE_ADMIN=true \
+      -e HIVENET_ROUTER_ALLOW_INSECURE_ADMIN=true \
       -v "$PWD/jwt.secret:/jwt.secret:ro" \
       -v "$PWD/badger:/badger" \
       mycoroute/router:latest \
@@ -174,7 +174,7 @@ This guide uses Docker host networking and is intended for Linux hosts.
     The router uses host networking so its HTTP, gRPC, libp2p, and metrics interfaces bind directly to the machine.
 
     <Warning>
-      `mycoroute_ALLOW_INSECURE_ADMIN=true` permits unauthenticated access to `/admin/*` for this quickstart. Configure administrator API-key authentication before exposing the router to shared or untrusted networks.
+      `HIVENET_ROUTER_ALLOW_INSECURE_ADMIN=true` permits unauthenticated access to `/admin/*` for this quickstart. Configure administrator API-key authentication before exposing the router to shared or untrusted networks.
     </Warning>
 
     Check the public liveness endpoint:
@@ -250,7 +250,7 @@ This guide uses Docker host networking and is intended for Linux hosts.
 
     ```bash
     docker run -d \
-      --name mycoroute-agent \
+      --name hivenet-agent \
       --restart unless-stopped \
       --network host \
       --gpus all \
@@ -271,7 +271,7 @@ This guide uses Docker host networking and is intended for Linux hosts.
     Check the agent logs:
 
     ```bash
-    docker logs mycoroute-agent
+    docker logs hivenet-agent
     ```
 
     The agent waits for the backend to become healthy, discovers the model through `GET /v1/models`, authenticates with the router, and registers.
@@ -309,7 +309,7 @@ This guide uses Docker host networking and is intended for Linux hosts.
 
     ```bash
     docker run -d \
-      --name mycoroute-agent \
+      --name hivenet-agent \
       --restart unless-stopped \
       --network host \
       --gpus all \
@@ -450,7 +450,7 @@ Because the agent container uses host networking, it reaches vLLM at `localhost:
 Check the agent logs:
 
 ```bash
-docker logs mycoroute-agent
+docker logs hivenet-agent
 ```
 
 Test the agent’s connection to the router:
@@ -508,7 +508,7 @@ docker run --rm \
 Confirm that the agent container received a GPU device request:
 
 ```bash
-docker inspect mycoroute-agent \
+docker inspect hivenet-agent \
   | grep -A5 DeviceRequests
 ```
 
@@ -536,15 +536,15 @@ sudo ufw allow from <monitoring-ip> to any port 2112 proto tcp
 On each agent host:
 
 ```bash
-docker stop mycoroute-agent vllm
-docker rm mycoroute-agent vllm
+docker stop hivenet-agent vllm
+docker rm hivenet-agent vllm
 ```
 
 On the router:
 
 ```bash
-docker stop mycoroute-router
-docker rm mycoroute-router
+docker stop hivenet-router
+docker rm hivenet-router
 ```
 
 The BadgerDB data in the mounted `badger` directory and agent identity files in `/opt/mycoroute` remain after the containers are removed.
@@ -561,6 +561,6 @@ The BadgerDB data in the mounted `badger` directory and agent identity files in 
   </Card>
 
   <Card title="Routing concepts" href="/routing/routing-concepts">
-    Control how Mycoroute filters, ranks, and falls back across agents.
+    Control how Hivenet Router filters, ranks, and falls back across agents.
   </Card>
 </CardGroup>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -11,33 +11,21 @@
   "navigation": {
     "pages": [
       "index",
-      "quickstart",
       {
         "group": "Getting started",
         "pages": [
           "getting-started/introduction",
+          "quickstart",
           "getting-started/architecture-overview",
-          "getting-started/why-mycoroute",
           "getting-started/mycoroute-hivenet-inference-api-compute"
         ]
       },
       {
-        "group": "Deploy",
+        "group": "Deploy Hivenet Router",
         "pages": [
           "deploy/docker-quickstart",
-          "deploy/bare-metal",
-          {
-            "group": "Agent deployment",
-            "pages": [
-              "deploy/agents/vllm",
-              "deploy/agents/ollama",
-              "deploy/agents/sglang",
-              "deploy/agents/llama-cpp",
-              "deploy/agents/infinity",
-              "deploy/agents/custom-engine"
-            ]
-          },
           "deploy/docker-compose",
+          "deploy/bare-metal",
           {
             "group": "Agents",
             "pages": [
@@ -48,24 +36,17 @@
               "deploy/agents/infinity",
               "deploy/agents/custom-engine"
             ]
-          },
-          "deploy/docker-compose",
-          "deploy/bare-metal"
+          }
         ]
       },
       {
         "group": "Use the API",
         "pages": [
-          "api/chat-completions",
-          "api/embeddings",
-          "api/reranking",
-          "api/models-list",
-          "api/admin-endpoints",
-          "api/chat-completions",
-          "api/embeddings",
-          "api/reranking",
-          "api/models",
-          "api/admin-endpoints"
+          "use-the-api/chat-completions",
+          "use-the-api/embeddings",
+          "use-the-api/reranking",
+          "use-the-api/models",
+          "use-the-api/admin-endpoints"
         ]
       },
       {
@@ -73,15 +54,10 @@
         "pages": [
           "routing/routing-concepts",
           "routing/policy-yaml-reference",
+          "routing/fallback-chains",
+          "routing/provider-fallback",
           "routing/policy-gates",
-          "routing/fallback-chains",
-          "routing/provider-fallback",
-          "routing/hardware-aware-routing",
-          "routing/routing-concepts",
-          "routing/policy-yaml-reference",
-          "routing/fallback-chains",
-          "routing/provider-fallback",
-          "routing/policy-gates"
+          "routing/admission-control"
         ]
       },
       {
@@ -91,22 +67,12 @@
           "security/api-keys",
           "security/auth-yaml-reference",
           "security/model-restrictions",
-          "security/key-rotation",
-          "security/authentication-overview",
-          "security/auth-yaml-reference",
-          "security/api-keys",
-          "security/model-restrictions",
           "security/key-rotation"
         ]
       },
       {
         "group": "Observability",
         "pages": [
-          "observability/prometheus-metrics",
-          "observability/grafana-dashboards",
-          "observability/audit-logging",
-          "observability/hardware-metrics",
-          "observability/engine-metrics",
           "observability/observability-overview",
           "observability/prometheus-metrics",
           "observability/grafana-dashboards",
@@ -120,12 +86,12 @@
       {
         "group": "Integrations",
         "pages": [
-          "integrations/overview",
+          "integrations/integrations-overview",
           "integrations/claude-code",
-          "integrations/opencode",
+          "integrations/open-code",
           "integrations/pi",
-          "integrations/open-webui",
-          "integrations/using-from-code"
+          "integrations/open-web-ui",
+          "integrations/use-from-code"
         ]
       },
       {
@@ -134,17 +100,68 @@
           "reference/detailed-architecture",
           "reference/configuration-reference",
           "reference/error-codes",
-          "reference/performance-characteristics",
-          "reference/rfc-6298-latency-tracking"
+          "reference/performance-characteristics"
         ]
       },
       {
         "group": "Project",
         "pages": [
+          "project/project-overview",
           "project/contributing",
           "project/code-of-conduct",
-          "project/security-policy",
           "project/license"
+        ]
+      },
+      {
+        "group": "Migration leftovers",
+        "hidden": true,
+        "pages": [
+          "getting-started/why-mycoroute",
+          "api/chat-completions",
+          "api/embeddings",
+          "api/reranking",
+          "api/models-list",
+          "api/admin-endpoints",
+          "api/chat-completions",
+          "api/embeddings",
+          "api/reranking",
+          "api/models",
+          "api/admin-endpoints",
+          "routing/hardware-aware-routing",
+          "routing/routing-concepts",
+          "routing/policy-yaml-reference",
+          "routing/fallback-chains",
+          "routing/provider-fallback",
+          "routing/policy-gates",
+          "security/authentication-overview",
+          "security/auth-yaml-reference",
+          "security/api-keys",
+          "security/model-restrictions",
+          "security/key-rotation",
+          "observability/prometheus-metrics",
+          "observability/grafana-dashboards",
+          "observability/audit-logging",
+          "observability/hardware-metrics",
+          "observability/engine-metrics",
+          "integrations/overview",
+          "integrations/opencode",
+          "integrations/open-webui",
+          "integrations/using-from-code",
+          "reference/rfc-6298-latency-tracking",
+          "project/security-policy",
+          {
+            "group": "Agent deployment",
+            "pages": [
+              "deploy/agents/vllm",
+              "deploy/agents/ollama",
+              "deploy/agents/sglang",
+              "deploy/agents/llama-cpp",
+              "deploy/agents/infinity",
+              "deploy/agents/custom-engine"
+            ]
+          },
+          "deploy/docker-compose",
+          "deploy/bare-metal"
         ]
       }
     ]
@@ -187,5 +204,32 @@
       "github": "https://github.com/HivenetOSS/hivenet_router"
     }
   },
-  "description": "Open-source routing for self-hosted and distributed AI inference."
+  "description": "Open-source routing for self-hosted and distributed AI inference.",
+  "redirects": [
+    {
+      "source": "/api/:slug*",
+      "destination": "/use-the-api/:slug*",
+      "permanent": true
+    },
+    {
+      "source": "/integrations/overview",
+      "destination": "/integrations/integrations-overview",
+      "permanent": true
+    },
+    {
+      "source": "/integrations/opencode",
+      "destination": "/integrations/open-code",
+      "permanent": true
+    },
+    {
+      "source": "/integrations/open-webui",
+      "destination": "/integrations/open-web-ui",
+      "permanent": true
+    },
+    {
+      "source": "/integrations/using-from-code",
+      "destination": "/integrations/use-from-code",
+      "permanent": true
+    }
+  ]
 }

--- a/docs/getting-started/architecture-overview.mdx
+++ b/docs/getting-started/architecture-overview.mdx
@@ -4,7 +4,7 @@ description: "Understand how the router, agents, control plane, data plane, stor
 sidebarTitle: "Architecture overview"
 ---
 
-Mycoroute uses a hub-and-spoke architecture.
+Hivenet Router uses a hub-and-spoke architecture.
 
 A central router exposes the API used by applications and coordinates a fleet of agents. Each agent connects one inference backend to the router and reports the information needed to make routing decisions.
 
@@ -14,7 +14,7 @@ Applications only need to know the router endpoint. They do not need to know whi
 
 ## Main components
 
-Mycoroute has two runtime components: the router and one or more agents.
+Hivenet Router has two runtime components: the router and one or more agents.
 
 ### Router
 
@@ -81,7 +81,7 @@ A deployment can mix different backend types. Applications continue to use the r
 
 ## Request lifecycle
 
-A typical inference request moves through Mycoroute like this:
+A typical inference request moves through Hivenet Router like this:
 
 1. A client sends a request to the router.
 2. The router authenticates the client if API authentication is enabled.
@@ -93,9 +93,9 @@ A typical inference request moves through Mycoroute like this:
 8. The request is forwarded to the agent over the encrypted libp2p data plane.
 9. The agent sends the request to its local inference backend.
 10. The response returns through the agent and router to the client.
-11. Mycoroute records the outcome and updates routing and latency metrics.
+11. Hivenet Router records the outcome and updates routing and latency metrics.
 
-If the initial routing step cannot serve the request, Mycoroute can continue through a configured fallback chain. An optional provider fallback can send the request to OpenAI or Anthropic after local options are exhausted.
+If the initial routing step cannot serve the request, Hivenet Router can continue through a configured fallback chain. An optional provider fallback can send the request to OpenAI or Anthropic after local options are exhausted.
 
 ## Routing pipeline
 
@@ -109,11 +109,11 @@ Routing policies use three stages.
 
 `least-loaded` is currently the only implemented ranking strategy. It ranks agents by the proportion of their declared capacity that is in use.
 
-If you do not configure a policy file, Mycoroute uses its built-in least-loaded policy without static filters or dynamic gates.
+If you do not configure a policy file, Hivenet Router uses its built-in least-loaded policy without static filters or dynamic gates.
 
 ## Control and data paths
 
-Mycoroute separates authentication from inference traffic.
+Hivenet Router separates authentication from inference traffic.
 
 ### Agent authentication
 
@@ -156,11 +156,11 @@ Agents collect backend and system state at different intervals. The router uses 
 
 Routing signals carry recent engine and hardware data without updating the agent’s heartbeat timestamp. Heartbeats act as the health keepalive and include fallback metric information.
 
-This separation lets Mycoroute receive fresh routing data without treating every metrics update as proof that the agent is healthy.
+This separation lets Hivenet Router receive fresh routing data without treating every metrics update as proof that the agent is healthy.
 
 ## Storage
 
-Mycoroute uses two BadgerDB stores.
+Hivenet Router uses two BadgerDB stores.
 
 | Store | Location | Purpose | Default lifetime |
 | --- | --- | --- | --- |
@@ -177,7 +177,7 @@ The disk database preserves information such as smoothed round-trip time and lif
 
 ## Authentication and access control
 
-Mycoroute handles agent and client authentication separately.
+Hivenet Router handles agent and client authentication separately.
 
 ### Agents
 
@@ -215,7 +215,7 @@ Common deployments include:
 - router and agents running in Docker
 - a mix of local infrastructure and hosted compute instances
 
-Mycoroute does not require Kubernetes. The current repository does not include a supported Helm deployment.
+Hivenet Router does not require Kubernetes. The current repository does not include a supported Helm deployment.
 
 ## What to read next
 
@@ -224,7 +224,7 @@ Mycoroute does not require Kubernetes. The current repository does not include a
     Deploy a router and several agents, then send your first routed request.
   </Card>
 
-  <Card title="Mycoroute and Hivenet services" href="/getting-started/mycoroute-hivenet-inference-api-compute">
-    Understand how Mycoroute differs from Hivenet Inference API and Compute with Hivenet.
+  <Card title="Hivenet Router and Hivenet services" href="/getting-started/mycoroute-hivenet-inference-api-compute">
+    Understand how Hivenet Router differs from Hivenet Inference API and Compute with Hivenet.
   </Card>
 </CardGroup>

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -1,22 +1,22 @@
 ---
-title: "Introduction to Mycoroute"
-description: "Learn what Mycoroute does, when to use it, and how it fits around your inference engines."
+title: "Introduction to Hivenet Router"
+description: "Learn what Hivenet Router does, when to use it, and how it fits around your inference engines."
 sidebarTitle: "Introduction"
 ---
 
-Mycoroute is an open-source router for self-hosted AI inference, maintained by Hivenet.
+Hivenet Router is an open-source router for self-hosted AI inference, maintained by Hivenet.
 
 It puts one client-facing API surface in front of multiple inference servers. A central router tracks the health, load, latency, models, and capabilities of connected agents, then forwards each request according to your routing policies.
 
-Mycoroute handles the layer around your inference engines. It does not run models itself.
+Hivenet Router handles the layer around your inference engines. It does not run models itself.
 
 <Warning>
-  Mycoroute is currently in alpha. Interfaces, configuration, and deployment workflows may change as the project develops.
+  Hivenet Router is currently in alpha. Interfaces, configuration, and deployment workflows may change as the project develops.
 </Warning>
 
-## When to use Mycoroute
+## When to use Hivenet Router
 
-Mycoroute is designed for setups where inference runs across more than one backend, machine, model, or location.
+Hivenet Router is designed for setups where inference runs across more than one backend, machine, model, or location.
 
 Use it when you need to:
 
@@ -30,9 +30,9 @@ Use it when you need to:
 
 For a single inference server with no routing, fallback, or shared access requirements, calling the inference engine directly may be simpler.
 
-## How Mycoroute works
+## How Hivenet Router works
 
-Mycoroute has two main components.
+Hivenet Router has two main components.
 
 ### Router
 
@@ -50,7 +50,7 @@ You can run agents beside inference servers on the same machine, across a privat
 
 ## Supported backends
 
-Mycoroute supports:
+Hivenet Router supports:
 
 - vLLM
 - Ollama
@@ -65,7 +65,7 @@ Backend capabilities differ. For example, Infinity supports embedding and rerank
 
 Applications send requests to the router through OpenAI-compatible and Anthropic-compatible endpoints.
 
-Mycoroute currently supports:
+Hivenet Router currently supports:
 
 | Workload | Endpoint |
 | --- | --- |
@@ -76,7 +76,7 @@ Mycoroute currently supports:
 | Reranking | `POST /v1/rerank` |
 | Model discovery | `GET /v1/models` |
 
-This lets existing clients and SDKs connect to Mycoroute without needing to know which agent or inference engine handles each request.
+This lets existing clients and SDKs connect to Hivenet Router without needing to know which agent or inference engine handles each request.
 
 ## Routing and fallback
 
@@ -93,7 +93,7 @@ Policies can consider:
 - KV cache usage
 - GPU utilization, temperature, and memory pressure
 
-Fallback chains provide ordered alternatives when the preferred backend is unavailable or cannot accept more work. Mycoroute can also be configured to use OpenAI or Anthropic as a final provider fallback.
+Fallback chains provide ordered alternatives when the preferred backend is unavailable or cannot accept more work. Hivenet Router can also be configured to use OpenAI or Anthropic as a final provider fallback.
 
 ## Authentication and observability
 
@@ -101,21 +101,21 @@ Agents authenticate with the router using a shared JWT secret.
 
 Client API-key authentication is optional and can be used for tenant access, quotas, and model restrictions.
 
-Mycoroute exports Prometheus metrics and includes Grafana dashboards for routing, agents, hardware, engine behavior, tenant activity, and audit logs.
+Hivenet Router exports Prometheus metrics and includes Grafana dashboards for routing, agents, hardware, engine behavior, tenant activity, and audit logs.
 
 ## Start exploring
 
 <CardGroup cols={2}>
   <Card title="Quickstart" href="/quickstart">
-    Build Mycoroute, start a router and agent, and send your first request.
+    Build Hivenet Router, start a router and agent, and send your first request.
   </Card>
 
   <Card title="Architecture overview" href="/getting-started/architecture-overview">
     Understand the control plane, data plane, storage, authentication, and request flow.
   </Card>
 
-  <Card title="Mycoroute and Hivenet services" href="/getting-started/mycoroute-hivenet-inference-api-compute">
-    See how Mycoroute differs from Hivenet Inference API and Compute with Hivenet.
+  <Card title="Hivenet Router and Hivenet services" href="/getting-started/mycoroute-hivenet-inference-api-compute">
+    See how Hivenet Router differs from Hivenet Inference API and Compute with Hivenet.
   </Card>
 
   <Card title="GitHub repository" href="https://github.com/HiveNetCode/mycoroute">

--- a/docs/getting-started/mycoroute-hivenet-inference-api-compute.mdx
+++ b/docs/getting-started/mycoroute-hivenet-inference-api-compute.mdx
@@ -1,28 +1,28 @@
 ---
-title: "Mycoroute, Hivenet Inference API, and Compute with Hivenet"
-description: "Understand how Mycoroute differs from Hivenet Inference API and Compute with Hivenet, and choose the right option for your workload."
-sidebarTitle: "Mycoroute and Hivenet services"
+title: "Hivenet Router, Hivenet Inference API, and Compute with Hivenet"
+description: "Understand how Hivenet Router differs from Hivenet Inference API and Compute with Hivenet, and choose the right option for your workload."
+sidebarTitle: "Hivenet Router and Hivenet services"
 ---
 
-Mycoroute, Hivenet Inference API, and Compute with Hivenet all support AI inference workloads, but they solve different problems.
+Hivenet Router, Hivenet Inference API, and Compute with Hivenet all support AI inference workloads, but they solve different problems.
 
 The main difference is who operates each layer.
 
-- With **Mycoroute**, you operate the routing layer and connect your own inference infrastructure.
+- With **Hivenet Router**, you operate the routing layer and connect your own inference infrastructure.
 - With **Hivenet Inference API**, Hivenet operates the inference service behind a managed API.
 - With **Compute with Hivenet**, you rent infrastructure and decide what software to run on it.
 
 <Note>
-  These docs cover Mycoroute. Information about Hivenet Inference API and Compute with Hivenet is included here only to explain where Mycoroute fits.
+  These docs cover Hivenet Router. Information about Hivenet Inference API and Compute with Hivenet is included here only to explain where Hivenet Router fits.
 </Note>
 
-## Mycoroute
+## Hivenet Router
 
-Mycoroute is open-source software for routing requests across self-hosted inference backends.
+Hivenet Router is open-source software for routing requests across self-hosted inference backends.
 
 You deploy the router and agents yourself. You choose the inference engines, models, machines, regions, routing policies, authentication rules, fallback behavior, and monitoring setup.
 
-Mycoroute provides:
+Hivenet Router provides:
 
 - one OpenAI-compatible endpoint for several inference backends
 - routing based on model, engine, region, tags, capacity, and live metrics
@@ -31,9 +31,9 @@ Mycoroute provides:
 - API-key authentication, quotas, and model restrictions
 - Prometheus metrics, Grafana dashboards, and audit logs
 
-Mycoroute does not provide GPUs or host models by itself. It coordinates inference servers that you already operate.
+Hivenet Router does not provide GPUs or host models by itself. It coordinates inference servers that you already operate.
 
-Use Mycoroute when you want to:
+Use Hivenet Router when you want to:
 
 - run inference across several machines or locations
 - combine different inference engines behind one endpoint
@@ -45,7 +45,7 @@ Use Mycoroute when you want to:
 
 Hivenet Inference API is a managed inference service.
 
-You connect your application to an API endpoint operated by Hivenet. Hivenet runs and maintains the service infrastructure behind that endpoint, so you do not need to deploy a Mycoroute router, agents, or inference engines yourself.
+You connect your application to an API endpoint operated by Hivenet. Hivenet runs and maintains the service infrastructure behind that endpoint, so you do not need to deploy a Hivenet Router router, agents, or inference engines yourself.
 
 Use Hivenet Inference API when you want to:
 
@@ -54,63 +54,63 @@ Use Hivenet Inference API when you want to:
 - avoid maintaining routers, agents, and model servers
 - use a commercial service with managed operations
 
-The models, regions, service limits, and commercial terms available through Hivenet Inference API are separate from Mycoroute and may change independently.
+The models, regions, service limits, and commercial terms available through Hivenet Inference API are separate from Hivenet Router and may change independently.
 
 ## Compute with Hivenet
 
 Compute with Hivenet provides GPU and CPU infrastructure for workloads you operate yourself.
 
-You create an instance, choose the runtime environment, and deploy the software you need. That could include an inference engine, a Mycoroute agent, a Mycoroute router, a notebook, or another application.
+You create an instance, choose the runtime environment, and deploy the software you need. That could include an inference engine, a Hivenet Router agent, a Hivenet Router router, a notebook, or another application.
 
 Use Compute with Hivenet when you want to:
 
 - rent GPU or CPU infrastructure
 - control the operating system and runtime environment
 - run your own inference engine
-- deploy Mycoroute on infrastructure you manage
+- deploy Hivenet Router on infrastructure you manage
 - run workloads that are not covered by a managed inference API
 
 Compute with Hivenet provides the machines. You remain responsible for the software running on them.
 
 ## Compare the three options
 
-|  | Mycoroute | Hivenet Inference API | Compute with Hivenet |
+|  | Hivenet Router | Hivenet Inference API | Compute with Hivenet |
 | --- | --- | --- | --- |
 | What it provides | Inference routing software | Managed inference endpoint | GPU and CPU infrastructure |
 | Who operates it | You | Hivenet | You |
 | Open source | Yes | No | Not applicable |
 | Infrastructure included | No | Yes | Yes |
 | You manage inference engines | Yes | No | Yes |
-| You manage routing | Yes | No | Yes, if you deploy Mycoroute or another router |
+| You manage routing | Yes | No | Yes, if you deploy Hivenet Router or another router |
 | Primary interface | OpenAI-compatible API from your router | Managed API endpoint | Virtual machine or compute instance |
 | Best suited to | Self-hosted and distributed inference | Managed model access | Custom infrastructure and workloads |
 
-## Using Mycoroute with Compute with Hivenet
+## Using Hivenet Router with Compute with Hivenet
 
-You can run Mycoroute on Compute with Hivenet in the same way you would run it on other infrastructure.
+You can run Hivenet Router on Compute with Hivenet in the same way you would run it on other infrastructure.
 
 A typical setup could include:
 
-1. One Compute instance running the Mycoroute router.
+1. One Compute instance running the Hivenet Router router.
 2. Several GPU instances running inference engines.
-3. One Mycoroute agent beside each inference engine.
+3. One Hivenet Router agent beside each inference engine.
 4. Applications sending requests to the router’s OpenAI-compatible endpoint.
 
-Mycoroute can also route across a mixed environment. For example, some agents could run on your own machines while others run on Compute with Hivenet or another provider.
+Hivenet Router can also route across a mixed environment. For example, some agents could run on your own machines while others run on Compute with Hivenet or another provider.
 
-Mycoroute does not require Hivenet infrastructure. It can run wherever its router, agents, and inference backends can communicate.
+Hivenet Router does not require Hivenet infrastructure. It can run wherever its router, agents, and inference backends can communicate.
 
 ## Choosing the right option
 
-Choose **Mycoroute** when you want to operate your own inference setup and need routing across several backends.
+Choose **Hivenet Router** when you want to operate your own inference setup and need routing across several backends.
 
 Choose **Hivenet Inference API** when you want a managed endpoint and do not want to operate the underlying inference service.
 
 Choose **Compute with Hivenet** when you need infrastructure for software and workloads that you control.
 
-You can also combine them where appropriate. For example, you might run Mycoroute on your own infrastructure, use Compute with Hivenet for additional GPU capacity, and configure an external provider as a final fallback.
+You can also combine them where appropriate. For example, you might run Hivenet Router on your own infrastructure, use Compute with Hivenet for additional GPU capacity, and configure an external provider as a final fallback.
 
-## Continue with Mycoroute
+## Continue with Hivenet Router
 
 <CardGroup cols={2}>
   <Card title="Quickstart" href="/quickstart">

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Mycoroute"
+title: "Hivenet Router"
 sidebarTitle: "Home"
 description: "Open-source routing for self-hosted and distributed AI inference."
 ---
@@ -24,7 +24,7 @@ description: "Open-source routing for self-hosted and distributed AI inference."
       Get started
     </a>
 
-    <a href="https://github.com/HiveNetCode/mycoroute" className="inline-flex items-center justify-center rounded-lg border border-gray-300 dark:border-zinc-700 px-5 py-3 text-sm font-medium text-gray-900 dark:text-zinc-100 hover:bg-gray-50 dark:hover:bg-zinc-900 transition-colors">
+    <a href="https://github.com/HivenetOSS/hivenet_router" className="inline-flex items-center justify-center rounded-lg border border-gray-300 dark:border-zinc-700 px-5 py-3 text-sm font-medium text-gray-900 dark:text-zinc-100 hover:bg-gray-50 dark:hover:bg-zinc-900 transition-colors">
       View on GitHub
     </a>
   </div>
@@ -44,7 +44,7 @@ description: "Open-source routing for self-hosted and distributed AI inference."
 
   <Columns cols={2}>
     <Card title="Introduction" icon="book-open" color="#FF9A33" href="/getting-started/introduction">
-      Learn what Mycoroute does, when it is useful, and what it does not
+      Learn what Hivenet Router does, when it is useful, and what it does not
       provide.
     </Card>
 
@@ -58,26 +58,26 @@ description: "Open-source routing for self-hosted and distributed AI inference."
       and request flow.
     </Card>
 
-    <Card title="Mycoroute and Hivenet services" icon="arrows-split-up-and-left" color="#FF9A33" href="/getting-started/mycoroute-hivenet-inference-api-compute">
-      See how Mycoroute differs from Hivenet Inference API and Compute
+    <Card title="Hivenet Router and Hivenet services" icon="arrows-split-up-and-left" color="#FF9A33" href="/getting-started/mycoroute-hivenet-inference-api-compute">
+      See how Hivenet Router differs from Hivenet Inference API and Compute
       with Hivenet.
     </Card>
   </Columns>
 </div>
 
-Mycoroute is an open-source router for self-hosted AI inference, maintained by Hivenet.
+Hivenet Router is an open-source router for self-hosted AI inference, maintained by Hivenet.
 
 It puts one client-facing API in front of multiple inference servers. A central router tracks the health, load, latency, models, and capabilities of connected agents, then forwards each request according to your routing policies.
 
 <Warning>
-  Mycoroute is currently in alpha. Interfaces, configuration, and deployment workflows may change as the project develops.
+  Hivenet Router is currently in alpha. Interfaces, configuration, and deployment workflows may change as the project develops.
 </Warning>
 
 ## Start here
 
 <CardGroup cols={2}>
   <Card title="Introduction" href="/getting-started/introduction">
-    Understand what Mycoroute does and when to use it.
+    Understand what Hivenet Router does and when to use it.
   </Card>
 
   <Card title="Quickstart" href="/quickstart">
@@ -113,7 +113,7 @@ It puts one client-facing API in front of multiple inference servers. A central 
   </Card>
 
   <Card title="Integrations" icon="plug" href="/integrations/overview">
-    Connect Mycoroute to Claude Code, OpenCode, Open WebUI, and more.
+    Connect Hivenet Router to Claude Code, OpenCode, Open WebUI, and more.
   </Card>
 
   <Card title="Reference" icon="book" href="/reference/detailed-architecture">

--- a/docs/integrations/pi.mdx
+++ b/docs/integrations/pi.mdx
@@ -310,7 +310,7 @@ in this variable.
 <Note>
   `MYCOROUTE_API_KEY` is a client-side environment variable chosen for this guide.
 
-  It does not need to follow the case-sensitive lower-case `mycoroute_*` convention used by the Hivenet Router router process.
+  It does not need to follow the case-sensitive `HIVENET_ROUTER_*` convention used by the Hivenet Router process.
 </Note>
 
 ## Read the key from a command

--- a/docs/observability/prometheus-metrics.mdx
+++ b/docs/observability/prometheus-metrics.mdx
@@ -112,7 +112,7 @@ Check that Hivenet Router metrics exist:
 ```bash
 curl -s \
   http://localhost:2112/metrics \
-  | grep '^mycoroute_'
+  | grep '^hivenet_router_'
 ```
 
 ## How metrics reach the router

--- a/docs/project/contributing.mdx
+++ b/docs/project/contributing.mdx
@@ -6,24 +6,24 @@ sidebarTitle: "Contributing"
 
 Contributions to Hivenet Router are welcome, including bug reports, feature proposals, documentation improvements, tests, and code changes.
 
-The repository’s root [`CONTRIBUTING.md`](https://github.com/HiveNetCode/mycoroute/blob/main/CONTRIBUTING.md) file is the canonical contribution guide. This page summarizes the workflow and provides additional context for common changes.
+The repository’s root [`CONTRIBUTING.md`](https://github.com/HivenetOSS/hivenet_router/blob/main/CONTRIBUTING.md) file is the canonical contribution guide. This page summarizes the workflow and provides additional context for common changes.
 
 By participating in the project, you agree to follow the [Code of conduct](/project/code-of-conduct).
 
 <CardGroup cols={2}>
-  <Card title="Report a bug" href="https://github.com/HiveNetCode/mycoroute/issues">
+  <Card title="Report a bug" href="https://github.com/HivenetOSS/hivenet_router/issues">
     Share a reproducible problem with the affected version, configuration, and relevant logs.
   </Card>
 
-  <Card title="Propose a feature" href="https://github.com/HiveNetCode/mycoroute/issues">
+  <Card title="Propose a feature" href="https://github.com/HivenetOSS/hivenet_router/issues">
     Describe the use case and expected behavior before investing in a substantial implementation.
   </Card>
 
-  <Card title="Improve the documentation" href="https://github.com/HiveNetCode/mycoroute/tree/main/docs">
+  <Card title="Improve the documentation" href="https://github.com/HivenetOSS/hivenet_router/tree/main/docs">
     Correct stale commands, clarify behavior, improve examples, or add missing troubleshooting guidance.
   </Card>
 
-  <Card title="Open a pull request" href="https://github.com/HiveNetCode/mycoroute/pulls">
+  <Card title="Open a pull request" href="https://github.com/HivenetOSS/hivenet_router/pulls">
     Submit a focused change with tests, verification details, and a clear explanation of the problem it solves.
   </Card>
 </CardGroup>
@@ -50,7 +50,7 @@ Clone the repository:
 
 ```bash
 git clone \
-  https://github.com/HiveNetCode/mycoroute.git
+  https://github.com/HivenetOSS/hivenet_router.git
 
 cd mycoroute
 ```
@@ -555,7 +555,7 @@ Before submitting:
 ## Next steps
 
 <CardGroup cols={3}>
-  <Card title="Canonical contribution guide" href="https://github.com/HiveNetCode/mycoroute/blob/main/CONTRIBUTING.md">
+  <Card title="Canonical contribution guide" href="https://github.com/HivenetOSS/hivenet_router/blob/main/CONTRIBUTING.md">
     Read the authoritative repository version of the contribution instructions.
   </Card>
 
@@ -567,11 +567,11 @@ Before submitting:
     Review the Apache License 2.0 terms applying to contributions.
   </Card>
 
-  <Card title="GitHub issues" href="https://github.com/HiveNetCode/mycoroute/issues">
+  <Card title="GitHub issues" href="https://github.com/HivenetOSS/hivenet_router/issues">
     Report bugs and discuss feature proposals.
   </Card>
 
-  <Card title="Pull requests" href="https://github.com/HiveNetCode/mycoroute/pulls">
+  <Card title="Pull requests" href="https://github.com/HivenetOSS/hivenet_router/pulls">
     Review current work or submit a focused change.
   </Card>
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -75,7 +75,7 @@ Run these commands on:
 On the build machine:
 
 ```bash
-git clone https://github.com/HiveNetCode/mycoroute.git
+git clone https://github.com/HivenetOSS/hivenet_router.git
 cd mycoroute
 
 go build -o bin/hivenet-router ./cmd/router/

--- a/docs/reference/configuration-reference.mdx
+++ b/docs/reference/configuration-reference.mdx
@@ -4,31 +4,31 @@ title: "Configuration Reference"
 
 Complete reference for all Router and Agent CLI flags and environment variables.
 
-> **Note on env var casing:** All environment variables use the prefix `mycoroute_` (lowercase 'h', uppercase 'LLM') — this is case-sensitive on Linux.
+> **Note on env var casing:** All environment variables use the prefix `HIVENET_ROUTER_` (lowercase 'h', uppercase 'LLM') — this is case-sensitive on Linux.
 
 ## Router Flags
 
 | Flag | Environment Variable | Default | Description |
-|------|---------------------|---------|-------------|
-| `--http-port` | `mycoroute_HTTP_PORT` | `:8080` | HTTP API port |
-| `--grpc-port` | `mycoroute_GRPC_PORT` | `:50051` | gRPC auth port |
-| `--p2p-port` | `mycoroute_P2P_PORT` | `9000` | libp2p port (no colon prefix) |
+| --- | --- | --- | --- |
+| `--http-port` | `HIVENET_ROUTER_HTTP_PORT` | `:8080` | HTTP API port |
+| `--grpc-port` | `HIVENET_ROUTER_GRPC_PORT` | `:50051` | gRPC auth port |
+| `--p2p-port` | `HIVENET_ROUTER_P2P_PORT` | `9000` | libp2p port (no colon prefix) |
 | `--p2p-listen-addr` | — | `127.0.0.1` | libp2p bind address (`0.0.0.0` for remote agents) |
-| `--p2p-announce-addr` | — | `` | Advertised P2P address (required behind NAT/Docker) |
-| `--p2p-max-conns-per-ip` | `mycoroute_P2P_MAX_CONNS_PER_IP` | `32` | Max concurrent libp2p connections from one source IP (see note below) |
-| `--metrics-port` | `mycoroute_METRICS_PORT` | `:2112` | Prometheus metrics port |
-| `--jwt-secret-file` | `mycoroute_JWT_SECRET` | — | **Required.** JWT HMAC-SHA256 secret |
-| `--auth-config-file` | `mycoroute_AUTH_CONFIG` | `` | Path to `auth.yaml` |
-| `mycoroute_AUTH_MODE` | — | `none` | Auth mode: `none`, `api-key`, `dynamic` |
-| `--policy-file` | `mycoroute_POLICY_FILE` | `` | Routing policy YAML |
-| `--policy-model-dir` | `mycoroute_POLICY_MODEL_DIR` | `` | Per-model policies directory |
-| `--max-tries-per-step` | `mycoroute_MAX_TRIES_PER_STEP` | `3` | Default max slot attempts per policy step |
-| `--queue-size` | `mycoroute_QUEUE_SIZE` | `100` | Internal request channel size |
-| `--queue-depth` | `mycoroute_QUEUE_DEPTH` | `30` | Capacity wait queue depth per model (0 = disabled) |
-| `--request-timeout` | `mycoroute_REQUEST_TIMEOUT` | `60s` | End-to-end request timeout |
-| `mycoroute_MAX_REQUEST_BYTES` | — | `10485760` | Max `/v1/*` request body size in bytes (10 MB; 0 disables) |
-| `--session-ttl` | `mycoroute_SESSION_TTL` | `1h` | Agent session token TTL (minimum 5m) |
-| `--disk-db-path` | `mycoroute_DISK_DB_PATH` | `./badger_disk` | Persistent BadgerDB path |
+| `--p2p-announce-addr` | — | \`\` | Advertised P2P address (required behind NAT/Docker) |
+| `--p2p-max-conns-per-ip` | `HIVENET_ROUTER_P2P_MAX_CONNS_PER_IP` | `32` | Max concurrent libp2p connections from one source IP (see note below) |
+| `--metrics-port` | `HIVENET_ROUTER_METRICS_PORT` | `:2112` | Prometheus metrics port |
+| `--jwt-secret-file` | `HIVENET_ROUTER_JWT_SECRET` | — | **Required.** JWT HMAC-SHA256 secret |
+| `--auth-config-file` | `HIVENET_ROUTER_AUTH_CONFIG` | \`\` | Path to `auth.yaml` |
+| `HIVENET_ROUTER_AUTH_MODE` | — | `none` | Auth mode: `none`, `api-key`, `dynamic` |
+| `--policy-file` | `HIVENET_ROUTER_POLICY_FILE` | \`\` | Routing policy YAML |
+| `--policy-model-dir` | `HIVENET_ROUTER_POLICY_MODEL_DIR` | \`\` | Per-model policies directory |
+| `--max-tries-per-step` | `HIVENET_ROUTER_MAX_TRIES_PER_STEP` | `3` | Default max slot attempts per policy step |
+| `--queue-size` | `HIVENET_ROUTER_QUEUE_SIZE` | `100` | Internal request channel size |
+| `--queue-depth` | `HIVENET_ROUTER_QUEUE_DEPTH` | `30` | Capacity wait queue depth per model (0 = disabled) |
+| `--request-timeout` | `HIVENET_ROUTER_REQUEST_TIMEOUT` | `60s` | End-to-end request timeout |
+| `HIVENET_ROUTER_MAX_REQUEST_BYTES` | — | `10485760` | Max `/v1/*` request body size in bytes (10 MB; 0 disables) |
+| `--session-ttl` | `HIVENET_ROUTER_SESSION_TTL` | `1h` | Agent session token TTL (minimum 5m) |
+| `--disk-db-path` | `HIVENET_ROUTER_DISK_DB_PATH` | `./badger_disk` | Persistent BadgerDB path |
 | `--disk-db-ttl` | — | `30` | diskDB entry TTL in days (0 = no expiry) |
 | `--reset-disk-db` | — | `false` | Wipe diskDB on startup (testing/migrations) |
 | `--universal-flush-interval` | — | `30s` | How often universal history is flushed to diskDB |
@@ -38,44 +38,33 @@ Complete reference for all Router and Agent CLI flags and environment variables.
 | `--max-concurrent` | — | `50` | Max concurrent in-flight request forwards |
 | `--heartbeat-interval` | — | `5s` | Expected heartbeat cadence sent to agents in `RouterConfig` |
 
-> **`--p2p-max-conns-per-ip` and agents behind a shared NAT.** go-libp2p's resource
-> manager caps concurrent connections from a single source IP at **8** by default.
-> When agents reach the router through one shared egress IP — e.g. a Kubernetes
-> SNAT gateway, a Docker bridge, or any NAT — they all count against that single
-> bucket, so the **9th agent's connection is accepted at TCP but reset during the
-> Noise handshake** (the agent logs `failed to negotiate security protocol: EOF`).
-> This flag raises that per-IP ceiling (default `32`). Keep it **≥ 2× the number of
-> agents behind a single egress IP**, not equal to the agent count: a restarting
-> agent briefly holds both its old (not yet timed out, see `--remove-after`) and
-> its new connection, so a fleet-wide rollout transiently needs up to ~2× the
-> slots. Agents that present distinct source IPs each get their own bucket and are
-> unaffected.
+> **`--p2p-max-conns-per-ip` and agents behind a shared NAT.** go-libp2p's resource manager caps concurrent connections from a single source IP at **8** by default. When agents reach the router through one shared egress IP — e.g. a Kubernetes SNAT gateway, a Docker bridge, or any NAT — they all count against that single bucket, so the **9th agent's connection is accepted at TCP but reset during the Noise handshake** (the agent logs `failed to negotiate security protocol: EOF`). This flag raises that per-IP ceiling (default `32`). Keep it **≥ 2× the number of agents behind a single egress IP**, not equal to the agent count: a restarting agent briefly holds both its old (not yet timed out, see `--remove-after`) and its new connection, so a fleet-wide rollout transiently needs up to ~2× the slots. Agents that present distinct source IPs each get their own bucket and are unaffected.
 
 ### Provider API Keys (Environment Only)
 
 | Environment Variable | Description |
-|---------------------|-------------|
-| `mycoroute_OPENAI_API_KEY` | OpenAI API key for `fallback_provider: { engine: openai }` |
-| `mycoroute_ANTHROPIC_API_KEY` | Anthropic API key for `fallback_provider: { engine: anthropic }` |
-| `mycoroute_ADMIN_API_KEYS` | Comma-separated admin keys (used when `admin.mode: api-key` in auth.yaml) |
-| `mycoroute_ALLOW_INSECURE_ADMIN` | Set to `true` to start with unauthenticated `/admin/*` (admin `mode: none`). Otherwise the router refuses to start without admin auth. Dev/test only. |
-| `mycoroute_QUOTA_BACKEND` | Quota storage backend: `memory` (default) or `badger` |
-| `mycoroute_AUDIT_LOG_PATH` | Audit log file path (default `/var/log/mycoroute/audit.jsonl`); falls back to stdout if unwritable |
+| --- | --- |
+| `HIVENET_ROUTER_OPENAI_API_KEY` | OpenAI API key for `fallback_provider: { engine: openai }` |
+| `HIVENET_ROUTER_ANTHROPIC_API_KEY` | Anthropic API key for `fallback_provider: { engine: anthropic }` |
+| `HIVENET_ROUTER_ADMIN_API_KEYS` | Comma-separated admin keys (used when `admin.mode: api-key` in auth.yaml) |
+| `HIVENET_ROUTER_ALLOW_INSECURE_ADMIN` | Set to `true` to start with unauthenticated `/admin/*` (admin `mode: none`). Otherwise the router refuses to start without admin auth. Dev/test only. |
+| `HIVENET_ROUTER_QUOTA_BACKEND` | Quota storage backend: `memory` (default) or `badger` |
+| `HIVENET_ROUTER_AUDIT_LOG_PATH` | Audit log file path (default `/var/log/mycoroute/audit.jsonl`); falls back to stdout if unwritable |
 
 ### Logging
 
 | Environment Variable | Default | Description |
-|---------------------|---------|-------------|
+| --- | --- | --- |
 | `GOLOG_LOG_LEVEL` | `info` | Log level for all subsystems. Accepts a global level (`debug`, `info`, `warn`, `error`) or per-subsystem overrides: `subsystem=level,subsystem2=level2`. Available subsystems: `router`, `policy`, `metrics`, `api`, `grpc`, `p2p`, `agent`, `hardware`, `storage`, `auth`. |
 
 ## Agent Flags
 
 | Flag | Environment Variable | Default | Description |
-|------|---------------------|---------|-------------|
+| --- | --- | --- | --- |
 | `--engine` | — | `vllm` | Backend engine: `vllm`, `ollama`, `sglang`, `llamacpp`, `infinity`, `custom` |
 | `--backend-url` | — | `http://localhost:8888` | Backend inference server URL |
-| `--model` | — | `` | Model name override (required for `--engine custom`) |
-| `--health-url` | — | `` | Health check URL (required for `--engine custom`) |
+| `--model` | — | \`\` | Model name override (required for `--engine custom`) |
+| `--health-url` | — | \`\` | Health check URL (required for `--engine custom`) |
 | `--capacity` | — | `10` | Max concurrent requests |
 | `--region` | — | `UE-France` | Region label |
 | `--organization` | — | `Unknown` | Organization/cloud provider label |
@@ -83,12 +72,12 @@ Complete reference for all Router and Agent CLI flags and environment variables.
 | `--tags` | — | `production` | Comma-separated tags |
 | `--router-grpc` | — | `localhost:50051` | Router gRPC address |
 | `--router-p2p` | — | `/ip4/127.0.0.1/tcp/9000` | Router libp2p address |
-| `--jwt-secret-file` | `mycoroute_JWT_SECRET` | — | **Required.** JWT secret |
+| `--jwt-secret-file` | `HIVENET_ROUTER_JWT_SECRET` | — | **Required.** JWT secret |
 | `--capability` | — | `llm` | Inference capability: `llm`, `embedding`, `reranker` |
-| `--gpu-model` | `mycoroute_GPU_MODEL` | `` | GPU hardware label for routing (e.g. `RTX4090`) |
+| `--gpu-model` | `HIVENET_ROUTER_GPU_MODEL` | \`\` | GPU hardware label for routing (e.g. `RTX4090`) |
 | `--hide-llm` | — | `false` | Exclude from `/v1/models` listing |
-| `--llm-pretty-name` | — | `` | Human-readable model display name |
-| `--llm-info` | — | `` | Short model description |
+| `--llm-pretty-name` | — | \`\` | Human-readable model display name |
+| `--llm-info` | — | \`\` | Short model description |
 | `--identity-path` | — | `./agent_identity.key` | Persistent libp2p identity file |
 | `--p2p-listen-port` | — | `0` | Agent libp2p listen port (0 = random; agents accept no inbound dials, so a fixed port is rarely needed). In case of multiple agents on the same host, make sure each agent is using a different port when using fixed ports |
 | `--hardware-sample-interval` | — | `2s` | GPU/CPU/memory sampling interval |
@@ -96,7 +85,7 @@ Complete reference for all Router and Agent CLI flags and environment variables.
 | `--routing-signal-interval` | — | `500ms` | How often agent pushes metrics to router |
 | `--http-timeout` | — | `120s` | HTTP timeout for backend requests |
 | `--stream-write-timeout` | — | `60s` | Rolling per-chunk deadline for writing a streaming response to the router; a stalled write fails after this so the stream is released (0 disables) |
-| `--gpu-devices-file` | — | `` | File containing GPU UUIDs to monitor (one per line) |
+| `--gpu-devices-file` | — | \`\` | File containing GPU UUIDs to monitor (one per line) |
 | `--version` | — | `1.0.0` | Agent version string sent in registration metadata |
 
 ## Minimal Startup Examples
@@ -104,7 +93,7 @@ Complete reference for all Router and Agent CLI flags and environment variables.
 ### Router
 
 ```bash
-./bin/mycoroute-router \
+./bin/hivenet-router \
   --jwt-secret-file jwt.secret \
   --auth-config-file auth.yaml \
   --policy-file policy.yaml
@@ -113,7 +102,7 @@ Complete reference for all Router and Agent CLI flags and environment variables.
 ### Agent (vLLM)
 
 ```bash
-./bin/mycoroute-agent \
+./bin/hivenet-agent \
   --engine vllm \
   --backend-url http://localhost:8888 \
   --jwt-secret-file jwt.secret \
@@ -127,7 +116,7 @@ Complete reference for all Router and Agent CLI flags and environment variables.
 ### Agent (Custom Engine)
 
 ```bash
-./bin/mycoroute-agent \
+./bin/hivenet-agent \
   --engine custom \
   --model my-custom-model \
   --health-url http://localhost:1234/health \

--- a/docs/reference/error-codes.mdx
+++ b/docs/reference/error-codes.mdx
@@ -2,7 +2,7 @@
 title: "Error Codes"
 ---
 
-All Mycoroute errors use a consistent JSON envelope.
+All Hivenet Router errors use a consistent JSON envelope.
 
 ## Response Format
 
@@ -17,7 +17,7 @@ All Mycoroute errors use a consistent JSON envelope.
 ```
 
 | Field | Type | Description |
-|-------|------|-------------|
+| --- | --- | --- |
 | `code` | string | Machine-readable error identifier. Stable across versions. Use this for programmatic handling — never parse `message`. |
 | `message` | string | Human-readable explanation. May contain verbatim text from the backend engine. |
 | `source` | string | `"router"` — error produced before or during agent selection; `"backend"` — error originated in the inference engine. |
@@ -25,7 +25,7 @@ All Mycoroute errors use a consistent JSON envelope.
 ## Error Code Reference
 
 | Code | HTTP | Source | Retryable | Trigger |
-|------|------|--------|-----------|---------|
+| --- | --- | --- | --- | --- |
 | `request_invalid` | 400 | router | No | Malformed JSON or missing required field (`model`, `messages`) |
 | `context_length_exceeded` | 400 | backend | No | Input tokens exceed the model's maximum context window |
 | `invalid_parameter` | 400 | backend | No | Invalid inference parameter (`temperature`, `top_p`, `max_tokens`, etc.) |
@@ -40,12 +40,12 @@ All Mycoroute errors use a consistent JSON envelope.
 | `backend_unavailable` | 503 | backend | Yes — backoff | Inference engine not yet ready (model still loading) |
 | `queue_full` | 503 | router | Yes — backoff | Router request queue at capacity; backpressure signal |
 | `backend_error` | 502 | backend | Yes — once | Inference engine returned an unexpected server error |
-| `request_timeout` | 504 | router | Yes | End-to-end deadline exceeded (queue wait + forwarding + inference) |
+| `request_timeout` | 504 | router | Yes | End-to-end deadline exceeded (queue wait \+ forwarding \+ inference) |
 
 ## Retry Guidelines
 
 | Code | Strategy |
-|------|----------|
+| --- | --- |
 | `request_invalid`, `context_length_exceeded`, `invalid_parameter` | **Do not retry.** Fix the request payload. |
 | `unauthorized`, `model_forbidden` | **Do not retry.** Fix credentials or request a different model. |
 | `model_not_found` | **Do not retry** until an agent for that model is running. Verify name via `GET /v1/models`. |
@@ -60,7 +60,7 @@ All Mycoroute errors use a consistent JSON envelope.
 
 When a backend inference engine returns a non-200 response, the router classifies it:
 
-```
+```text
 Backend HTTP status → error code
 
 400 / 422  + "context"/"length"/"window"/"token" in body  →  context_length_exceeded
@@ -73,6 +73,6 @@ If the backend returns a JSON body with a `type` field (vLLM/OpenAI format), tha
 
 ## See Also
 
-- [Audit Logging](/observability/audit-logging) - Per-request error_code in audit trail
+- [Audit Logging](/observability/audit-logging) - Per-request error\_code in audit trail
 - [API Keys](/security/api-keys) - Rate limit and quota configuration
 - [Routing Concepts](/routing/routing-concepts) - How agent selection works


### PR DESCRIPTION
Restores every page from the completed Mintlify docs archive, adds the current admission-control page, rebuilds navigation to 52 pages, preserves verified technical identifiers, updates verified Hivenet Router names and paths, and adds permanent redirects for the former API and integration URLs.

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://app.mintlify.com/hivenet/mycoroute/editor/docs-navigation-final?preview=%2Fdeploy%2Fagents%2Fllama-cpp&source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/review-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/review-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/review-mintlify-editor-light.svg" alt="Review in Mintlify"></picture></a>

<!-- /mintlify-comment -->