### PR TITLE
Restore documentation configuration before PR #11

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -188,11 +188,5 @@
     }
   },
   "description": "Open-source routing for self-hosted and distributed AI inference.",
-  "redirects": [
-    {
-      "source": "/__rollback-marker",
-      "destination": "/",
-      "permanent": true
-    }
-  ]
+  "redirects": []
 }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -187,5 +187,12 @@
       "github": "https://github.com/HivenetOSS/hivenet_router"
     }
   },
-  "description": "Open-source routing for self-hosted and distributed AI inference."
+  "description": "Open-source routing for self-hosted and distributed AI inference.",
+  "redirects": [
+    {
+      "source": "/__rollback-marker",
+      "destination": "/",
+      "permanent": true
+    }
+  ]
 }


### PR DESCRIPTION
## What changed

Restores the documentation tree and Mintlify configuration to commit `cb2187c4bb2c7423bcedcc97cada76a792cfe6c1`, the state immediately before PR #11 was merged.

## Why

PR #11 was merged before review. The merged version is preserved on `docs-compatibility-review` so the old Mycoroute documentation can be compared against the current Hivenet Router repository, including Igor's naming and compatibility-identifier changes.

## Review and deployment

This PR is intentionally left unmerged. Merging it will roll the public Mintlify site back to the pre-PR #11 configuration. No Git history is rewritten.

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://app.mintlify.com/hivenet/mycoroute/editor/restore-pre-review-config?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/review-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/review-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/review-mintlify-editor-light.svg" alt="Review in Mintlify"></picture></a>

<!-- /mintlify-comment -->