### PR TITLE
Add serverless per-key caps and per-model default derivation

### DIFF
--- a/internal/admission/reservation.go
+++ b/internal/admission/reservation.go
@@ -63,3 +63,25 @@ func (r *Reservation) Weight() int64 {
 	defer r.mu.Unlock()
 	return r.weight
 }
+
+// Reservations bundles the reservations a single request holds — the global
+// occupancy budget plus, on a serverless replica, the per-key occupancy share —
+// so the handler releases them together and the processor grows them together.
+// It satisfies domain.Reservation. A nil or empty slice is a valid no-op, so the
+// handler can always attach and defer-release it unconditionally.
+type Reservations []*Reservation
+
+// Grow forwards streamed output growth to every held reservation.
+func (rs Reservations) Grow(tokens int) {
+	for _, r := range rs {
+		r.Grow(tokens)
+	}
+}
+
+// Release returns every held reservation to its budget. Idempotent per
+// reservation, so calling it more than once is safe.
+func (rs Reservations) Release() {
+	for _, r := range rs {
+		r.Release()
+	}
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -401,10 +401,13 @@ func (h *Handlers) Passthrough(c *gin.Context) {
 		h.onRequestReceived(MetricContext{TenantID: m.tenantID, KeyID: m.keyID, DeploymentID: m.deploymentID})
 	}
 
-	if !h.reserveInputBudget(c, &req, m) {
+	// Per-key rate caps before the daily-budget charge: reserveInputBudget
+	// deducts daily tokens, so charging it only after the cheaper per-minute
+	// caps means a rate rejection never spends a tenant's daily budget.
+	if !h.enforcePerKeyRates(c, &req, m) {
 		return
 	}
-	if !h.enforcePerKeyRates(c, &req, m) {
+	if !h.reserveInputBudget(c, &req, m) {
 		return
 	}
 	if !captureRawBody(c, &req, m.requestID) {
@@ -621,13 +624,15 @@ func (h *Handlers) enforcePerKeyRates(c *gin.Context, req *domain.ChatRequest, m
 		return true
 	}
 	limits := quotaLimitsFromContext(c)
+	// Check the non-deducting OTPM gate before charging the ITPM bucket, so an
+	// output-rate rejection never spends input-rate tokens.
+	if limits.OutputTokensPerMinute > 0 && h.minuteLimiter.OutputExhausted(m.keyID, req.Model, limits.OutputTokensPerMinute) {
+		return h.writeRateLimited(c, m, req.Model, "output token rate exceeded, please retry")
+	}
 	if limits.InputTokensPerMinute > 0 {
 		if !h.minuteLimiter.AllowInputTokens(m.keyID, req.Model, limits.InputTokensPerMinute, estimatePromptTokens(req)) {
 			return h.writeRateLimited(c, m, req.Model, "input token rate exceeded, please retry")
 		}
-	}
-	if limits.OutputTokensPerMinute > 0 && h.minuteLimiter.OutputExhausted(m.keyID, req.Model, limits.OutputTokensPerMinute) {
-		return h.writeRateLimited(c, m, req.Model, "output token rate exceeded, please retry")
 	}
 	return true
 }

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -234,6 +234,14 @@ type Handlers struct {
 	// waiting-request count for a model (each nil when no healthy agent reports
 	// it), driving the front-door shed gate. Nil disables the gate (e.g. tests).
 	enginePressure func(model string) (kvUtil, waiting *float64)
+
+	// keyAdmission enforces the serverless per-key occupancy share — a per-key
+	// token-weighted in-flight budget parallel to the global one. Nil disables it.
+	keyAdmission *admission.Controller
+
+	// minuteLimiter enforces the serverless per-key tokens-per-minute caps
+	// (ITPM/OTPM). Nil disables them.
+	minuteLimiter *auth.MinuteRateLimiter
 }
 
 // NewHandlers initializes a Handlers instance with all required dependencies.
@@ -259,6 +267,8 @@ func NewHandlers(
 	registrationFeed RegistrationFeed,
 	admissionController *admission.Controller,
 	enginePressure func(model string) (kvUtil, waiting *float64),
+	keyAdmission *admission.Controller,
+	minuteLimiter *auth.MinuteRateLimiter,
 ) *Handlers {
 	return &Handlers{
 		storage:              storage,
@@ -279,6 +289,8 @@ func NewHandlers(
 		registrationFeed:     registrationFeed,
 		admission:            admissionController,
 		enginePressure:       enginePressure,
+		keyAdmission:         keyAdmission,
+		minuteLimiter:        minuteLimiter,
 	}
 }
 
@@ -392,6 +404,9 @@ func (h *Handlers) Passthrough(c *gin.Context) {
 	if !h.reserveInputBudget(c, &req, m) {
 		return
 	}
+	if !h.enforcePerKeyRates(c, &req, m) {
+		return
+	}
 	if !captureRawBody(c, &req, m.requestID) {
 		return
 	}
@@ -405,7 +420,7 @@ func (h *Handlers) Passthrough(c *gin.Context) {
 	pending.QuotaModel = m.quotaModel
 	pending.Capability = domain.CapabilityLLM
 	pending.Path = path // forward to the backend's native endpoint at this path
-	if reservation != nil {
+	if len(reservation) > 0 {
 		pending.Reservation = reservation // processor grows it as undeclared output streams
 	}
 
@@ -522,16 +537,19 @@ func (h *Handlers) enforceRequestCaps(c *gin.Context, req *domain.ChatRequest) b
 // parks briefly for capacity to free, then returns 429 concurrency_limit_exceeded
 // with Retry-After.
 //
-// It returns the reservation (which the caller MUST release exactly once on every
-// exit path) and whether the request was admitted. A nil reservation with ok=true
-// means the gate is inert for this model — nothing to release, nothing rejected.
-func (h *Handlers) enforceOccupancyBudget(c *gin.Context, req *domain.ChatRequest) (*admission.Reservation, bool) {
-	if h.admission == nil || h.executor == nil {
-		return nil, true
+// It returns the reservations (which the caller MUST release exactly once on
+// every exit path) and whether the request was admitted. An empty slice with
+// ok=true means the gate is inert for this model — nothing to release, nothing
+// rejected. On a serverless replica it holds a second, per-key reservation for
+// the key's occupancy share alongside the global budget.
+func (h *Handlers) enforceOccupancyBudget(c *gin.Context, req *domain.ChatRequest) (admission.Reservations, bool) {
+	var rs admission.Reservations
+	if h.executor == nil {
+		return rs, true
 	}
 	pol := h.executor.EffectivePolicy(req.Model)
-	if pol == nil || (pol.AdmitBudgetTokens <= 0 && pol.MaxInflight <= 0) {
-		return nil, true // no budget and no backstop declared — gate inert
+	if pol == nil {
+		return rs, true
 	}
 	declared := req.MaxCompletionTokens
 	if declared == 0 {
@@ -540,14 +558,104 @@ func (h *Handlers) enforceOccupancyBudget(c *gin.Context, req *domain.ChatReques
 	// Declared output is reserved up front; an undeclared request reserves only
 	// its input and grows live (grows=true), matching how the processor meters it.
 	footprint := estimatePromptTokens(req) + declared
-	res := h.admission.Admit(c.Request.Context(), req.Model, footprint, declared == 0, pol.AdmitBudgetTokens, pol.MaxInflight)
-	if res == nil {
-		c.Header("Retry-After", "1")
-		writeRouterError(c, http.StatusTooManyRequests, domain.ErrCodeConcurrencyLimit,
-			"server at capacity for this model, please retry", domain.SourceRouter)
-		return nil, false
+	grows := declared == 0
+
+	// Global occupancy budget (all replicas).
+	if h.admission != nil && (pol.AdmitBudgetTokens > 0 || pol.MaxInflight > 0) {
+		res := h.admission.Admit(c.Request.Context(), req.Model, footprint, grows, pol.AdmitBudgetTokens, pol.MaxInflight)
+		if res == nil {
+			c.Header("Retry-After", "1")
+			writeRouterError(c, http.StatusTooManyRequests, domain.ErrCodeConcurrencyLimit,
+				"server at capacity for this model, please retry", domain.SourceRouter)
+			return nil, false
+		}
+		rs = append(rs, res)
 	}
-	return res, true
+
+	// Per-key occupancy share (serverless replicas only): the key's in-flight
+	// footprint must stay within max_occupancy_share × admit_budget_tokens. This
+	// is anti-abuse fairness, not box safety (the global budget above is), so the
+	// shares are intentionally oversubscribed and no admit fraction is applied.
+	if pol.IsServerless() && pol.AdmitBudgetTokens > 0 && h.keyAdmission != nil {
+		if share := quotaLimitsFromContext(c).MaxOccupancyShare; share > 0 {
+			_, keyID, _ := callerIDs(c)
+			budget := int(share * float64(pol.AdmitBudgetTokens))
+			res := h.keyAdmission.Admit(c.Request.Context(), keyID+"\x00"+req.Model, footprint, grows, budget, 0)
+			if res == nil {
+				rs.Release() // hand back the global reservation already taken
+				c.Header("Retry-After", "1")
+				writeRouterError(c, http.StatusTooManyRequests, domain.ErrCodeRateLimitExceeded,
+					"per-key occupancy share exceeded, please retry", domain.SourceRouter)
+				return nil, false
+			}
+			rs = append(rs, res)
+		}
+	}
+	return rs, true
+}
+
+// quotaLimitsFromContext returns the calling key's resolved quota limits, or a
+// zero value when none were stashed (no auth). The serverless per-key caps live
+// on the flat fields; a per-model key leaves them zero, so B4 is inert for it.
+func quotaLimitsFromContext(c *gin.Context) auth.QuotaLimits {
+	if raw, ok := c.Get("quota_limits"); ok {
+		if limits, ok := raw.(auth.QuotaLimits); ok {
+			return limits
+		}
+	}
+	return auth.QuotaLimits{}
+}
+
+// enforcePerKeyRates applies the serverless per-key token-per-minute caps: it
+// charges the request's estimated input tokens against the key's ITPM bucket and
+// rejects when the key's OTPM bucket is already drained by recent output. Both
+// deny with 429 rate_limit_exceeded + Retry-After. Inert unless the request
+// lands on a serverless policy and the key declares the cap. Returns false after
+// writing the 429.
+func (h *Handlers) enforcePerKeyRates(c *gin.Context, req *domain.ChatRequest, m reqMeta) bool {
+	if h.minuteLimiter == nil || h.executor == nil {
+		return true
+	}
+	pol := h.executor.EffectivePolicy(req.Model)
+	if pol == nil || !pol.IsServerless() {
+		return true
+	}
+	limits := quotaLimitsFromContext(c)
+	if limits.InputTokensPerMinute > 0 {
+		if !h.minuteLimiter.AllowInputTokens(m.keyID, req.Model, limits.InputTokensPerMinute, estimatePromptTokens(req)) {
+			return h.writeRateLimited(c, m, req.Model, "input token rate exceeded, please retry")
+		}
+	}
+	if limits.OutputTokensPerMinute > 0 && h.minuteLimiter.OutputExhausted(m.keyID, req.Model, limits.OutputTokensPerMinute) {
+		return h.writeRateLimited(c, m, req.Model, "output token rate exceeded, please retry")
+	}
+	return true
+}
+
+// chargeOutputRate meters completion tokens against the key's OTPM bucket after
+// a serverless response, so a burst of output throttles the key's next requests.
+// Best-effort and post-hoc: the response is already delivered. No-op unless the
+// request is serverless and the key declares an OTPM cap.
+func (h *Handlers) chargeOutputRate(c *gin.Context, req *domain.ChatRequest, m reqMeta, completionTokens int) {
+	if h.minuteLimiter == nil || h.executor == nil || completionTokens <= 0 {
+		return
+	}
+	pol := h.executor.EffectivePolicy(req.Model)
+	if pol == nil || !pol.IsServerless() {
+		return
+	}
+	if otpm := quotaLimitsFromContext(c).OutputTokensPerMinute; otpm > 0 {
+		h.minuteLimiter.ChargeOutputTokens(m.keyID, req.Model, otpm, completionTokens)
+	}
+}
+
+// writeRateLimited emits a 429 rate_limit_exceeded with Retry-After for a per-key
+// cap breach, firing the token-limited metric callback. Always returns false.
+func (h *Handlers) writeRateLimited(c *gin.Context, m reqMeta, model, msg string) bool {
+	h.fireTokenLimited(m, model)
+	c.Header("Retry-After", "1")
+	writeRouterError(c, http.StatusTooManyRequests, domain.ErrCodeRateLimitExceeded, msg, domain.SourceRouter)
+	return false
 }
 
 // enforceShedPressure is the front-door KV-pressure shed: when the live engine
@@ -830,6 +938,7 @@ func (h *Handlers) writeSuccessResponse(c *gin.Context, pending *domain.PendingR
 
 	if resp.Body == nil {
 		c.Writer.Write(resp.RawBytes) //nolint:errcheck
+		h.chargeOutputRate(c, req, m, resp.Usage.CompletionTokens)
 		return
 	}
 	// Streaming: flush SSE chunks as they arrive so tokens appear progressively.
@@ -851,6 +960,7 @@ func (h *Handlers) writeSuccessResponse(c *gin.Context, pending *domain.PendingR
 	if ct := pending.StreamedCompletionTokens.Load(); ct > 0 {
 		c.Set(auditKeyOutputTokens, ct)
 	}
+	h.chargeOutputRate(c, req, m, int(pending.StreamedCompletionTokens.Load()))
 }
 
 // writeErrorResponse writes a worker error, carrying real usage/agent into the

--- a/internal/auth/derive.go
+++ b/internal/auth/derive.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+package auth
+
+// ModelLimits holds the per-model numbers the serverless per-key defaults are
+// derived from — the values a benchmark campaign certifies for a model
+// (router_limits.yaml). Deriving from these, rather than copying a frozen block
+// of constants, keeps each model's caps tied to its own measured envelope.
+type ModelLimits struct {
+	AdmitBudgetTokens int // KV-occupancy admit budget B (tokens)
+	MaxModelLen       int // engine max context window (tokens)
+	MaxInputTokens    int // per-request input cap (tokens)
+	ITPMCeiling       int // physical input-tokens/min ceiling for the SKU
+	OTPMCeiling       int // physical output-tokens/min ceiling for the SKU
+	SellableRPM       int // max(per_sku_reference.*.sellable_rpm): never-throttle floor
+}
+
+// KeyDefaults are the serverless per-key B4 caps derived for one model.
+type KeyDefaults struct {
+	OccupancyShare        float64
+	InputTokensPerMinute  int
+	OutputTokensPerMinute int
+	RequestsPerMinute     int
+}
+
+// minOccupancyShare is the baseline per-key share: even a small model gives each
+// key at least this fraction of the admit budget so per-key caps never become a
+// hidden context throttle.
+const minOccupancyShare = 0.40
+
+// DeriveKeyDefaults renders the serverless per-key caps for a model from its
+// certified limits, per the four rules below. The caps are intentionally
+// oversubscribed (they do not sum to the box) — box safety is the occupancy
+// budget and the shed gate, not the sum of per-key shares.
+//
+//   - occupancy share = max(max_model_len / admit_budget, 0.40). Below
+//     max_model_len/admit_budget the share would silently become a context cap,
+//     so that ratio is the floor; 0.40 is the baseline for larger models.
+//   - ITPM = clamp(share × itpm_ceiling, 2 × max_input_tokens, itpm_ceiling).
+//     The floor (2 × max_input_tokens) lets one full-context request through
+//     roughly every 30 s; the ceiling caps it at the physical rate. When the
+//     ceiling is below the floor, the ceiling wins (physics binds).
+//   - OTPM = share × otpm_ceiling. No floor: output is metered as it is
+//     generated, never reserved, so the bucket is just one minute's rate.
+//   - RPM ≈ 2 × max(sellable_rpm): twice the never-throttle-legit floor, a flood
+//     guard for tiny requests (the true tiny-request ceiling is unmeasured).
+func DeriveKeyDefaults(m ModelLimits) KeyDefaults {
+	share := minOccupancyShare
+	if m.AdmitBudgetTokens > 0 {
+		if floor := float64(m.MaxModelLen) / float64(m.AdmitBudgetTokens); floor > share {
+			share = floor
+		}
+	}
+
+	itpm := int(share * float64(m.ITPMCeiling))
+	if floor := 2 * m.MaxInputTokens; itpm < floor {
+		itpm = floor
+	}
+	if m.ITPMCeiling > 0 && itpm > m.ITPMCeiling {
+		itpm = m.ITPMCeiling
+	}
+
+	return KeyDefaults{
+		OccupancyShare:        share,
+		InputTokensPerMinute:  itpm,
+		OutputTokensPerMinute: int(share * float64(m.OTPMCeiling)),
+		RequestsPerMinute:     2 * m.SellableRPM,
+	}
+}

--- a/internal/auth/derive.go
+++ b/internal/auth/derive.go
@@ -52,6 +52,13 @@ func DeriveKeyDefaults(m ModelLimits) KeyDefaults {
 			share = floor
 		}
 	}
+	// A share is a fraction of the admit budget, so it can never exceed 1.0 (the
+	// loader validates (0,1]). It reaches the ceiling only when the KV pool
+	// barely holds one max-context request — a provisioning limit the derivation
+	// cannot lift, but the returned value must stay valid.
+	if share > 1.0 {
+		share = 1.0
+	}
 
 	itpm := int(share * float64(m.ITPMCeiling))
 	if floor := 2 * m.MaxInputTokens; itpm < floor {

--- a/internal/auth/quota.go
+++ b/internal/auth/quota.go
@@ -115,11 +115,11 @@ type InMemoryLimiter struct {
 	// Set once at startup via SetOnTokensUsed before any requests arrive.
 	onTokensUsed func(tenantID string, used int)
 
-	// rpmBurstSeconds sizes the RPM token bucket's burst as that many seconds of
-	// the rate, instead of a full minute. 0 (or >= 60) keeps the legacy
-	// full-minute burst. A short certified window (e.g. 10s) closes the hole
-	// where a key could spend its entire minute's quota in one instant. Set once
-	// at startup via SetRPMBurstWindow before any request is handled.
+	// rpmBurstSeconds sizes the per-tenant RPM token bucket's burst as that many
+	// seconds of the rate, instead of a full minute. 0 (or >= 60) keeps the
+	// legacy full-minute burst. A short certified window (e.g. 10s) closes the
+	// hole where a tenant could spend its entire minute's quota in one instant.
+	// Set once at startup via SetRPMBurstWindow before any request is handled.
 	rpmBurstSeconds int
 }
 

--- a/internal/auth/quota.go
+++ b/internal/auth/quota.go
@@ -79,12 +79,16 @@ func bucketKey(tenantID, model string) string {
 func NewRateLimiter(cfg *config.Config, store DailyQuotaStore) (RateLimiter, error) {
 	switch cfg.QuotaBackend {
 	case "", "memory":
-		return NewInMemoryLimiter(), nil
+		l := NewInMemoryLimiter()
+		l.SetRPMBurstWindow(cfg.RPMBurstSeconds)
+		return l, nil
 	case "badger":
 		if store == nil {
 			return nil, fmt.Errorf("quota backend 'badger' requires a DailyQuotaStore (BadgerStorage must be initialised first)")
 		}
-		return NewBadgerLimiter(store), nil
+		l := NewBadgerLimiter(store)
+		l.SetRPMBurstWindow(cfg.RPMBurstSeconds)
+		return l, nil
 	default:
 		return nil, fmt.Errorf("unknown quota backend %q: valid values are 'memory' (default) or 'badger'", cfg.QuotaBackend)
 	}
@@ -110,6 +114,33 @@ type InMemoryLimiter struct {
 	// tenant ID and the new cumulative used count for today. Nil-safe.
 	// Set once at startup via SetOnTokensUsed before any requests arrive.
 	onTokensUsed func(tenantID string, used int)
+
+	// rpmBurstSeconds sizes the RPM token bucket's burst as that many seconds of
+	// the rate, instead of a full minute. 0 (or >= 60) keeps the legacy
+	// full-minute burst. A short certified window (e.g. 10s) closes the hole
+	// where a key could spend its entire minute's quota in one instant. Set once
+	// at startup via SetRPMBurstWindow before any request is handled.
+	rpmBurstSeconds int
+}
+
+// SetRPMBurstWindow sets the RPM burst window in seconds (see rpmBurstSeconds).
+// Must be called before the limiter handles any requests.
+func (l *InMemoryLimiter) SetRPMBurstWindow(seconds int) {
+	l.rpmBurstSeconds = seconds
+}
+
+// rpmBurst returns the token-bucket burst for a per-minute request rate. With a
+// window of 0 or >= 60 the burst is a full minute's quota (legacy x/time/rate
+// default). A shorter window enforces the certified burst instead —
+// rpm × window / 60, floored at 1.
+func (l *InMemoryLimiter) rpmBurst(rpm int) int {
+	if l.rpmBurstSeconds <= 0 || l.rpmBurstSeconds >= 60 {
+		return rpm
+	}
+	if b := rpm * l.rpmBurstSeconds / 60; b > 1 {
+		return b
+	}
+	return 1
 }
 
 // SetOnTokensUsed registers a callback that fires after every successful token
@@ -224,12 +255,12 @@ func (l *InMemoryLimiter) getOrCreateRPM(bucket string, rpm int) *rate.Limiter {
 		if lim.Limit() != r {
 			lim.SetLimit(r)
 		}
-		if lim.Burst() != rpm {
-			lim.SetBurst(rpm)
+		if burst := l.rpmBurst(rpm); lim.Burst() != burst {
+			lim.SetBurst(burst)
 		}
 		return lim
 	}
-	lim := rate.NewLimiter(r, rpm) // burst = full minute's quota
+	lim := rate.NewLimiter(r, l.rpmBurst(rpm)) // burst = certified window (default: full minute)
 	actual, _ := l.rpmLimiters.LoadOrStore(bucket, lim)
 	return actual.(*rate.Limiter)
 }

--- a/internal/auth/rate_minute.go
+++ b/internal/auth/rate_minute.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+package auth
+
+import (
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// MinuteRateLimiter enforces the serverless per-key tokens-per-minute caps
+// (ITPM/OTPM). It is separate from RateLimiter so the RPM/daily interface (and
+// its fakes) stay stable. Each (tenant, model, direction) pair gets its own
+// x/time/rate token bucket measured in tokens: rate = limit/60 tokens per
+// second, burst = limit (one minute's capacity). Safe for concurrent use.
+type MinuteRateLimiter struct {
+	buckets sync.Map // direction+bucketKey → *rate.Limiter
+}
+
+// NewMinuteRateLimiter creates an empty MinuteRateLimiter.
+func NewMinuteRateLimiter() *MinuteRateLimiter { return &MinuteRateLimiter{} }
+
+func inKey(tenantID, model string) string  { return "i\x00" + bucketKey(tenantID, model) }
+func outKey(tenantID, model string) string { return "o\x00" + bucketKey(tenantID, model) }
+
+// bucket returns the token bucket for key, sized to limit. Like the RPM bucket
+// it applies the current rate/burst on every call so a reloaded limit takes
+// effect without recreating the bucket.
+func (l *MinuteRateLimiter) bucket(key string, limit int) *rate.Limiter {
+	r := rate.Limit(float64(limit) / 60.0)
+	if v, ok := l.buckets.Load(key); ok {
+		lim := v.(*rate.Limiter)
+		if lim.Limit() != r {
+			lim.SetLimit(r)
+		}
+		if lim.Burst() != limit {
+			lim.SetBurst(limit)
+		}
+		return lim
+	}
+	lim := rate.NewLimiter(r, limit)
+	actual, _ := l.buckets.LoadOrStore(key, lim)
+	return actual.(*rate.Limiter)
+}
+
+// AllowInputTokens deducts count input tokens from the (tenant, model) ITPM
+// bucket, returning true when within the per-minute rate and false when it would
+// exceed it. limit <= 0 (or count <= 0) disables the cap. The loader guarantees
+// ITPM capacity >= max_input_tokens, so a single request's input always fits the
+// burst and can be admitted when the bucket is full.
+func (l *MinuteRateLimiter) AllowInputTokens(tenantID, model string, limit, count int) bool {
+	if limit <= 0 || count <= 0 {
+		return true
+	}
+	return l.bucket(inKey(tenantID, model), limit).AllowN(time.Now(), count)
+}
+
+// OutputExhausted reports whether the (tenant, model) OTPM bucket has run dry —
+// the admission-time check that throttles new requests once a key's recent
+// output has blown its per-minute rate. Non-deducting. limit <= 0 disables it
+// (never exhausted). Output is metered post-response (ChargeOutputTokens), so
+// this is how OTPM gates: a key that over-produces is held off on its next call.
+func (l *MinuteRateLimiter) OutputExhausted(tenantID, model string, limit int) bool {
+	if limit <= 0 {
+		return false
+	}
+	return l.bucket(outKey(tenantID, model), limit).TokensAt(time.Now()) < 1
+}
+
+// ChargeOutputTokens deducts count output tokens from the OTPM bucket after a
+// response completes, so a burst of output drains the bucket and throttles the
+// key's subsequent requests via OutputExhausted. The charge is capped at one
+// minute's capacity so a single huge response drains at most the full bucket.
+// limit <= 0 (or count <= 0) is a no-op.
+func (l *MinuteRateLimiter) ChargeOutputTokens(tenantID, model string, limit, count int) {
+	if limit <= 0 || count <= 0 {
+		return
+	}
+	if count > limit {
+		count = limit
+	}
+	l.bucket(outKey(tenantID, model), limit).ReserveN(time.Now(), count)
+}
+
+// Reset clears all buckets so limits reloaded from auth.yaml take effect
+// immediately. Safe to call concurrently with request handling.
+func (l *MinuteRateLimiter) Reset() {
+	l.buckets.Range(func(k, _ any) bool { l.buckets.Delete(k); return true })
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,6 +92,15 @@ type Config struct {
 	// Env: HIVENET_ROUTER_ADMIT_PARK_TIMEOUT (a Go duration, e.g. "250ms").
 	AdmitParkTimeout time.Duration
 
+	// RPMBurstSeconds sizes the per-key RPM token bucket's burst as that many
+	// seconds of the rate, instead of a full minute. 0 (default) keeps the legacy
+	// full-minute burst; a short certified window (e.g. 10) stops a key from
+	// spending its whole minute's quota in one instant — the anti-flood burst
+	// control for serverless keys. Range [0,60); values outside keep the legacy
+	// full-minute burst.
+	// Env: HIVENET_ROUTER_RPM_BURST_SECONDS
+	RPMBurstSeconds int
+
 	// Auth configuration file path.
 	// Path to auth.yaml; if empty both /v1/* and /admin/* default to mode: none.
 	// Env: HIVENET_ROUTER_AUTH_CONFIG
@@ -215,6 +224,11 @@ func LoadFromEnv() *Config {
 	if v := os.Getenv("HIVENET_ROUTER_ADMIT_PARK_TIMEOUT"); v != "" {
 		if d, err := time.ParseDuration(v); err == nil && d >= 0 {
 			cfg.AdmitParkTimeout = d
+		}
+	}
+	if v := os.Getenv("HIVENET_ROUTER_RPM_BURST_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 && n < 60 {
+			cfg.RPMBurstSeconds = n
 		}
 	}
 	if v := os.Getenv("HIVENET_ROUTER_SESSION_TTL"); v != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,12 +92,11 @@ type Config struct {
 	// Env: HIVENET_ROUTER_ADMIT_PARK_TIMEOUT (a Go duration, e.g. "250ms").
 	AdmitParkTimeout time.Duration
 
-	// RPMBurstSeconds sizes the per-key RPM token bucket's burst as that many
+	// RPMBurstSeconds sizes the per-tenant RPM token bucket's burst as that many
 	// seconds of the rate, instead of a full minute. 0 (default) keeps the legacy
-	// full-minute burst; a short certified window (e.g. 10) stops a key from
+	// full-minute burst; a short certified window (e.g. 10) stops a tenant from
 	// spending its whole minute's quota in one instant — the anti-flood burst
-	// control for serverless keys. Range [0,60); values outside keep the legacy
-	// full-minute burst.
+	// control. Range [0,60); values outside keep the legacy full-minute burst.
 	// Env: HIVENET_ROUTER_RPM_BURST_SECONDS
 	RPMBurstSeconds int
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -140,6 +140,11 @@ type Router struct {
 	// rateLimiter enforces per-tenant RPM and daily token limits on /v1/* endpoints.
 	rateLimiter auth.RateLimiter
 
+	// minuteLimiter enforces the serverless per-key tokens-per-minute caps
+	// (ITPM/OTPM). Reset alongside rateLimiter on auth reload so updated caps
+	// take effect immediately.
+	minuteLimiter *auth.MinuteRateLimiter
+
 	// keyRegistry is the mutable in-memory API key registry (dynamic mode).
 	// Nil when running in static-key or no-auth mode — guards against SIGHUP reload.
 	keyRegistry *auth.DynamicKeyProvider
@@ -288,6 +293,7 @@ func New(cfg *config.Config) (*Router, error) {
 		apiAuth:              auth.NewAtomicProvider(apiProv),
 		adminAuth:            auth.NewAtomicProvider(adminProv),
 		rateLimiter:          rateLimiter,
+		minuteLimiter:        auth.NewMinuteRateLimiter(),
 		keyRegistry:          keyRegistry,
 	}
 	// Refresh tenant quota gauges whenever the dynamic key registry changes,
@@ -568,6 +574,10 @@ func (r *Router) startHTTPServer() {
 		r, // RegistrationFeed — Router implements SubscribeRegistration
 		admission.NewController(r.cfg.AdmitFraction, r.cfg.AdmitParkTimeout),
 		r.EnginePressureForModel,
+		// Per-key occupancy share: no admit fraction (it is fairness, not box
+		// safety) and no parking (a per-key breach is denied immediately).
+		admission.NewController(1.0, 0),
+		r.minuteLimiter,
 	)
 	server := api.NewServer(handlers, r.cfg.HTTPPort, r.apiAuth, r.adminAuth, r.rateLimiter, r.metrics, r.agents.CountHealthyByModel, r.cfg.MaxRequestBytes)
 	if err := server.Start(); err != nil {
@@ -730,6 +740,7 @@ func (r *Router) reloadAuthProviders() {
 	r.apiAuth.Swap(apiProv)
 	r.adminAuth.Swap(adminProv)
 	r.rateLimiter.Reset()
+	r.minuteLimiter.Reset()
 	r.publishTenantQuotas()
 	if r.cfg.AuthConfigFile != "" {
 		log.Infof("SIGHUP: auth providers reloaded from %s", r.cfg.AuthConfigFile)

--- a/test/admission/controller_test.go
+++ b/test/admission/controller_test.go
@@ -152,6 +152,26 @@ func TestSmallBudgetFlooredNotDisabled(t *testing.T) {
 	}
 }
 
+// TestPerKeyOversubscriptionIsIndependent models the per-key occupancy share:
+// three keys each capped at 0.40 of a 1000-token budget (400 each) all admit
+// their full share concurrently, because per-key buckets are independent — the
+// shares are intentionally oversubscribed (3 × 400 = 1200 > 1000). Box safety is
+// the separate global budget, not the sum of shares.
+func TestPerKeyOversubscriptionIsIndependent(t *testing.T) {
+	c := admission.NewController(1.0, 0) // per-key controller: no fraction, no park
+	ctx := context.Background()
+	const perKeyBudget = 400 // 0.40 × 1000
+	for _, key := range []string{"keyA\x00m", "keyB\x00m", "keyC\x00m"} {
+		if c.Admit(ctx, key, perKeyBudget, false, perKeyBudget, 0) == nil {
+			t.Errorf("key %q must admit its full 0.40 share independently", key)
+		}
+	}
+	// Each key is at its own cap; a second request on any key is denied.
+	if c.Admit(ctx, "keyA\x00m", 1, false, perKeyBudget, 0) != nil {
+		t.Error("a key already at its share must be denied more")
+	}
+}
+
 // TestParkTimeoutRejects verifies a request that never gets room is rejected when
 // the park window expires.
 func TestParkTimeoutRejects(t *testing.T) {

--- a/test/api/b1_request_caps_test.go
+++ b/test/api/b1_request_caps_test.go
@@ -30,7 +30,7 @@ func newCapHandlers(q chan *domain.PendingRequest, global *policy.Policy) *api.H
 		nil, nil, q, 2*time.Second,
 		exec, nil, nil, nil,
 		nil, nil, nil, nil, nil, nil, nil, nil,
-		nil, nil,
+		nil, nil, nil, nil,
 	)
 }
 
@@ -314,7 +314,7 @@ func TestB1_PerModelPolicyCap(t *testing.T) {
 		t.Fatalf("SetNamedPolicy: %v", err)
 	}
 	q := make(chan *domain.PendingRequest, 1)
-	h := api.NewHandlers(nil, nil, q, 2*time.Second, exec, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	h := api.NewHandlers(nil, nil, q, 2*time.Second, exec, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	// Over-cap request for the capped model → 400.
 	over := fmt.Appendf(nil, `{"model":"capped","messages":[{"role":"user","content":%q}]}`, strings.Repeat("a", 28))

--- a/test/api/b2_occupancy_test.go
+++ b/test/api/b2_occupancy_test.go
@@ -45,7 +45,7 @@ func newB2Handlers(q chan *domain.PendingRequest, ctrl *admission.Controller, gl
 		nil, nil, q, timeout,
 		exec, nil, nil, nil,
 		nil, nil, nil, nil, nil, nil, nil, nil,
-		ctrl, nil,
+		ctrl, nil, nil, nil,
 	)
 }
 

--- a/test/api/b3_shed_test.go
+++ b/test/api/b3_shed_test.go
@@ -35,7 +35,7 @@ func newB3Handlers(q chan *domain.PendingRequest, pol *policy.Policy, pressure f
 		nil, nil, q, time.Second,
 		exec, nil, nil, nil,
 		nil, nil, nil, nil, nil, nil, nil, nil,
-		nil, pressure,
+		nil, pressure, nil, nil,
 	)
 }
 

--- a/test/api/b4_perkey_test.go
+++ b/test/api/b4_perkey_test.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+// Package api_test contains black-box tests for the serverless per-key caps
+// (B4): the per-key occupancy share and the input-token-per-minute rate, plus
+// the guarantee that a reserved-mode replica bypasses all of them.
+package api_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"hivenet_router/internal/admission"
+	"hivenet_router/internal/api"
+	"hivenet_router/internal/auth"
+	"hivenet_router/internal/domain"
+	"hivenet_router/internal/policy"
+
+	"github.com/gin-gonic/gin"
+)
+
+// newB4Handlers builds a Handlers with a global occupancy controller (sized so
+// only the per-key caps bind), a per-key occupancy controller, and a per-minute
+// (ITPM/OTPM) limiter, serving pol for every model.
+func newB4Handlers(q chan *domain.PendingRequest, pol *policy.Policy) *api.Handlers {
+	exec := policy.NewExecutor(nil, nil, pol, 0, 0)
+	return api.NewHandlers(
+		nil, nil, q, time.Second,
+		exec, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil, nil,
+		admission.NewController(1.0, 0), // global budget (fraction 1)
+		nil,                             // engine pressure
+		admission.NewController(1.0, 0), // per-key occupancy share
+		auth.NewMinuteRateLimiter(),     // ITPM/OTPM
+	)
+}
+
+// withKey stamps the caller identity and resolved quota limits a serverless
+// request would carry.
+func withKey(c *gin.Context, limits auth.QuotaLimits) {
+	c.Set("tenant_id", "t1")
+	c.Set("key_id", "k1")
+	c.Set("quota_limits", limits)
+}
+
+func serverless(admitBudget int) *policy.Policy {
+	return &policy.Policy{Mode: policy.ModeServerless, AdmitBudgetTokens: admitBudget}
+}
+
+// TestB4_PerKeyOccupancyShare_DeniesOverShare verifies a key whose in-flight
+// footprint would exceed max_occupancy_share × admit_budget_tokens is denied with
+// 429 rate_limit_exceeded, even though the global budget has room.
+func TestB4_PerKeyOccupancyShare_DeniesOverShare(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	h := newB4Handlers(q, serverless(1000)) // global budget 1000
+	// share 0.40 → per-key budget 400; footprint = input(4) + max_tokens(500) = 504 > 400.
+	c, w := newCtx("/v1/chat/completions", b2Body(500))
+	withKey(c, auth.QuotaLimits{MaxOccupancyShare: 0.40})
+
+	h.Passthrough(c)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 over per-key share, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), string(domain.ErrCodeRateLimitExceeded)) {
+		t.Errorf("expected %q in body, got %s", domain.ErrCodeRateLimitExceeded, w.Body.String())
+	}
+	if len(q) != 0 {
+		t.Errorf("a denied request must not be queued, depth=%d", len(q))
+	}
+}
+
+// TestB4_WithinShare_Passes verifies a request within the per-key share admits.
+func TestB4_WithinShare_Passes(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	h := newB4Handlers(q, serverless(1000))
+	// footprint = 4 + 300 = 304 <= per-key budget 400.
+	c, w := newCtx("/v1/chat/completions", b2Body(300))
+	withKey(c, auth.QuotaLimits{MaxOccupancyShare: 0.40})
+
+	runAndRespond(t, h, c, q)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 within the per-key share, got %d", w.Code)
+	}
+}
+
+// TestB4_ITPMDeniesOverRate verifies the per-key input-token-per-minute cap
+// denies a request whose input exceeds the remaining rate with 429.
+func TestB4_ITPMDeniesOverRate(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	h := newB4Handlers(q, serverless(0)) // no occupancy budget; only ITPM gates
+	// content 40 chars → input estimate 40/4 + 4 = 14 tokens, over the ITPM burst of 10.
+	c, w := newCtx("/v1/chat/completions", textBody(40, 0))
+	withKey(c, auth.QuotaLimits{InputTokensPerMinute: 10})
+
+	h.Passthrough(c)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 over ITPM, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), string(domain.ErrCodeRateLimitExceeded)) {
+		t.Errorf("expected %q in body, got %s", domain.ErrCodeRateLimitExceeded, w.Body.String())
+	}
+}
+
+// TestB4_ReservedModeBypassesAllCaps verifies a reserved-mode replica ignores all
+// four B4 caps: a request that would breach the per-key share AND the ITPM cap is
+// admitted anyway (only the global circuit breaker applies on reserved replicas).
+func TestB4_ReservedModeBypassesAllCaps(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	// Reserved (default mode) with a large global budget so B2 doesn't gate.
+	h := newB4Handlers(q, &policy.Policy{AdmitBudgetTokens: 1_000_000})
+	// These caps WOULD deny under serverless: tiny share and tiny ITPM.
+	c, w := newCtx("/v1/chat/completions", textBody(40, 500)) // input 14, footprint 514
+	withKey(c, auth.QuotaLimits{MaxOccupancyShare: 0.0001, InputTokensPerMinute: 2, OutputTokensPerMinute: 2})
+
+	runAndRespond(t, h, c, q)
+	if w.Code != http.StatusOK {
+		t.Errorf("reserved mode must bypass all B4 caps; expected 200, got %d", w.Code)
+	}
+}
+
+// TestB4_FullContextRequestPassesAllCaps verifies a legitimate request passes all
+// serverless caps when they are sized to admit it (D16: never throttle legit
+// traffic) — the caps admit a normal request rather than clamping it.
+func TestB4_FullContextRequestPassesAllCaps(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	h := newB4Handlers(q, serverless(1_000_000)) // roomy global + per-key budgets
+	c, w := newCtx("/v1/chat/completions", textBody(40, 100))
+	withKey(c, auth.QuotaLimits{
+		MaxOccupancyShare:     0.64,
+		InputTokensPerMinute:  519_540,
+		OutputTokensPerMinute: 47_424,
+	})
+
+	runAndRespond(t, h, c, q)
+	if w.Code != http.StatusOK {
+		t.Errorf("a legit serverless request must pass all B4 caps; expected 200, got %d", w.Code)
+	}
+}
+
+// runAndRespond runs Passthrough in a goroutine, answers the queued request, and
+// waits for completion — the shared drive-to-success helper for admit tests.
+func runAndRespond(t *testing.T, h *api.Handlers, c *gin.Context, q chan *domain.PendingRequest) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() { h.Passthrough(c); close(done) }()
+	select {
+	case pending := <-q:
+		pending.Response <- &domain.ChatResponse{RawBytes: []byte(`{"ok":true}`)}
+	case <-time.After(time.Second):
+		t.Fatal("request was not enqueued")
+	}
+	<-done
+}

--- a/test/api/b4_perkey_test.go
+++ b/test/api/b4_perkey_test.go
@@ -141,6 +141,32 @@ func TestB4_FullContextRequestPassesAllCaps(t *testing.T) {
 	}
 }
 
+// TestB4_ITPMDenialDoesNotChargeDailyBudget verifies the gate order: a request
+// rejected by the per-key input-rate cap must not have spent the tenant's daily
+// token budget (the per-minute caps are enforced before the daily charge).
+func TestB4_ITPMDenialDoesNotChargeDailyBudget(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	exec := policy.NewExecutor(nil, nil, serverless(0), 0, 0)
+	lim := &fakeLimiter{remaining: 1_000_000, inAllowed: true, inRemaining: 1_000_000}
+	h := api.NewHandlers(
+		nil, nil, q, time.Second,
+		exec, nil, nil, lim,
+		nil, nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, auth.NewMinuteRateLimiter(),
+	)
+	c, w := newCtx("/v1/chat/completions", textBody(40, 0)) // input 14 > ITPM burst 10
+	withKey(c, auth.QuotaLimits{TokensPerDay: 1_000_000, InputTokensPerMinute: 10})
+
+	h.Passthrough(c)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 from ITPM, got %d", w.Code)
+	}
+	if lim.inputCalls != 0 {
+		t.Errorf("an ITPM-denied request must not charge the daily budget; AllowInputTokens called %d times", lim.inputCalls)
+	}
+}
+
 // runAndRespond runs Passthrough in a goroutine, answers the queued request, and
 // waits for completion — the shared drive-to-success helper for admit tests.
 func runAndRespond(t *testing.T, h *api.Handlers, c *gin.Context, q chan *domain.PendingRequest) {

--- a/test/api/middleware_test.go
+++ b/test/api/middleware_test.go
@@ -154,7 +154,7 @@ func newPolicyHandlers() *api.Handlers {
 		stor, nil, nil, 2*time.Second,
 		exec, nil, nil, nil,
 		nil, nil, nil, nil, nil, nil, nil, nil,
-		nil, nil,
+		nil, nil, nil, nil,
 	)
 }
 

--- a/test/api/passthrough_test.go
+++ b/test/api/passthrough_test.go
@@ -59,7 +59,7 @@ func newTestHandlers(q chan *domain.PendingRequest, lim auth.RateLimiter) *api.H
 		nil, nil, q, 2*time.Second,
 		nil, nil, nil, lim,
 		nil, nil, nil, nil, nil, nil, nil, nil,
-		nil, nil,
+		nil, nil, nil, nil,
 	)
 }
 

--- a/test/api/registration_stream_test.go
+++ b/test/api/registration_stream_test.go
@@ -47,7 +47,7 @@ func TestRegistrationStream_EmitsSSEFrame(t *testing.T) {
 		nil, nil, nil, time.Second,
 		nil, nil, nil, nil,
 		nil, nil, nil, nil, nil, nil, nil, feed,
-		nil, nil,
+		nil, nil, nil, nil,
 	)
 
 	router := gin.New()
@@ -125,6 +125,8 @@ func TestRegistrationStream_NotImplementedWhenNoFeed(t *testing.T) {
 		nil, nil, nil, nil, nil, nil, nil, nil, // registrationFeed = nil
 		nil, // admission controller = nil
 		nil, // engine-pressure provider = nil
+		nil, // key admission = nil
+		nil, // minute limiter = nil
 	)
 
 	router := gin.New()

--- a/test/auth/derive_test.go
+++ b/test/auth/derive_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+// Package auth_test exercises the serverless per-key default derivation through
+// its exported surface: each of the four cap rules and every branch that can
+// bind (share floor, ITPM floor vs ceiling vs share), plus the published
+// gemma-4-31b reference row.
+package auth_test
+
+import (
+	"math"
+	"testing"
+
+	"hivenet_router/internal/auth"
+)
+
+// --- occupancy share ---------------------------------------------------------
+
+func TestDerive_ShareBaselineFloor(t *testing.T) {
+	// max_model_len / admit_budget = 0.25 < 0.40 → the 0.40 baseline binds.
+	d := auth.DeriveKeyDefaults(auth.ModelLimits{AdmitBudgetTokens: 1_000_000, MaxModelLen: 250_000})
+	if d.OccupancyShare != 0.40 {
+		t.Errorf("share = %v, want 0.40 (baseline floor)", d.OccupancyShare)
+	}
+}
+
+func TestDerive_ShareContextFloorBinds(t *testing.T) {
+	// max_model_len / admit_budget = 0.60 > 0.40 → the context ratio binds.
+	d := auth.DeriveKeyDefaults(auth.ModelLimits{AdmitBudgetTokens: 1_000_000, MaxModelLen: 600_000})
+	if math.Abs(d.OccupancyShare-0.60) > 1e-9 {
+		t.Errorf("share = %v, want 0.60 (context-ratio floor)", d.OccupancyShare)
+	}
+}
+
+// --- ITPM: the three binding branches ---------------------------------------
+
+func TestDerive_ITPMFloorBinds(t *testing.T) {
+	// share × ceiling = 0.40 × 1,000,000 = 400,000, below the floor 2×250,000.
+	d := auth.DeriveKeyDefaults(auth.ModelLimits{
+		AdmitBudgetTokens: 1_000_000, MaxModelLen: 100_000, // share = 0.40
+		MaxInputTokens: 250_000, ITPMCeiling: 1_000_000,
+	})
+	if d.InputTokensPerMinute != 500_000 { // 2 × max_input_tokens
+		t.Errorf("ITPM = %d, want 500000 (floor binds)", d.InputTokensPerMinute)
+	}
+}
+
+func TestDerive_ITPMShareBinds(t *testing.T) {
+	// floor 2×100,000=200,000 < share×ceiling 0.40×800,000=320,000 < ceiling.
+	d := auth.DeriveKeyDefaults(auth.ModelLimits{
+		AdmitBudgetTokens: 1_000_000, MaxModelLen: 100_000, // share = 0.40
+		MaxInputTokens: 100_000, ITPMCeiling: 800_000,
+	})
+	if d.InputTokensPerMinute != 320_000 { // 0.40 × 800,000
+		t.Errorf("ITPM = %d, want 320000 (share binds)", d.InputTokensPerMinute)
+	}
+}
+
+func TestDerive_ITPMCeilingBinds(t *testing.T) {
+	// floor 2×260,000=520,000 exceeds the physical ceiling 500,000 → ceiling wins.
+	d := auth.DeriveKeyDefaults(auth.ModelLimits{
+		AdmitBudgetTokens: 1_000_000, MaxModelLen: 100_000, // share = 0.40
+		MaxInputTokens: 260_000, ITPMCeiling: 500_000,
+	})
+	if d.InputTokensPerMinute != 500_000 { // ceiling caps below the floor
+		t.Errorf("ITPM = %d, want 500000 (ceiling binds)", d.InputTokensPerMinute)
+	}
+}
+
+// --- OTPM and RPM ------------------------------------------------------------
+
+func TestDerive_OTPMIsShareTimesCeiling(t *testing.T) {
+	d := auth.DeriveKeyDefaults(auth.ModelLimits{
+		AdmitBudgetTokens: 1_000_000, MaxModelLen: 100_000, // share = 0.40
+		OTPMCeiling: 120_000,
+	})
+	if d.OutputTokensPerMinute != 48_000 { // 0.40 × 120,000, no floor
+		t.Errorf("OTPM = %d, want 48000", d.OutputTokensPerMinute)
+	}
+}
+
+func TestDerive_RPMIsTwiceSellable(t *testing.T) {
+	d := auth.DeriveKeyDefaults(auth.ModelLimits{SellableRPM: 48})
+	if d.RequestsPerMinute != 96 {
+		t.Errorf("RPM = %d, want 96 (2 × sellable)", d.RequestsPerMinute)
+	}
+}
+
+// --- published reference row -------------------------------------------------
+
+// TestDerive_Gemma431bReferenceRow reproduces the fleet-table row for
+// gemma-4-31b. ITPM (ceiling binds) and RPM are integer-exact; the occupancy
+// share and OTPM depend on the exact certified ceilings (which live in the
+// benchmark's router_limits.yaml, not this repo), so they are checked within a
+// small tolerance of the published values.
+func TestDerive_Gemma431bReferenceRow(t *testing.T) {
+	d := auth.DeriveKeyDefaults(auth.ModelLimits{
+		AdmitBudgetTokens: 408_987,
+		MaxModelLen:       262_144,
+		MaxInputTokens:    262_144,
+		ITPMCeiling:       519_540,
+		OTPMCeiling:       74_000,
+		SellableRPM:       48,
+	})
+	if d.InputTokensPerMinute != 519_540 {
+		t.Errorf("ITPM = %d, want 519540 (physics ceiling)", d.InputTokensPerMinute)
+	}
+	if d.RequestsPerMinute != 96 {
+		t.Errorf("RPM = %d, want 96", d.RequestsPerMinute)
+	}
+	if math.Abs(d.OccupancyShare-0.64) > 0.01 {
+		t.Errorf("share = %v, want ~0.64", d.OccupancyShare)
+	}
+	if math.Abs(float64(d.OutputTokensPerMinute-47_424)) > 500 {
+		t.Errorf("OTPM = %d, want ~47424", d.OutputTokensPerMinute)
+	}
+}

--- a/test/auth/derive_test.go
+++ b/test/auth/derive_test.go
@@ -32,6 +32,16 @@ func TestDerive_ShareContextFloorBinds(t *testing.T) {
 	}
 }
 
+func TestDerive_ShareClampedToOne(t *testing.T) {
+	// max_model_len > admit_budget (a KV pool that barely holds one max-context
+	// request) would give share_floor > 1.0 — the derived share must clamp to 1.0
+	// so it stays a valid (0,1] config value.
+	d := auth.DeriveKeyDefaults(auth.ModelLimits{AdmitBudgetTokens: 100_000, MaxModelLen: 150_000})
+	if d.OccupancyShare != 1.0 {
+		t.Errorf("share = %v, want 1.0 (clamped)", d.OccupancyShare)
+	}
+}
+
 // --- ITPM: the three binding branches ---------------------------------------
 
 func TestDerive_ITPMFloorBinds(t *testing.T) {

--- a/test/auth/rate_minute_test.go
+++ b/test/auth/rate_minute_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+package auth_test
+
+import (
+	"testing"
+
+	"hivenet_router/internal/auth"
+)
+
+// TestMinute_ITPMAllowsWithinRateDeniesOver verifies the input-tokens-per-minute
+// bucket admits input within the per-minute allowance and denies input that
+// would exceed it.
+func TestMinute_ITPMAllowsWithinRateDeniesOver(t *testing.T) {
+	l := auth.NewMinuteRateLimiter()
+	if !l.AllowInputTokens("k1", "m", 1000, 600) {
+		t.Fatal("first 600-token request must fit a 1000/min bucket")
+	}
+	if l.AllowInputTokens("k1", "m", 1000, 600) {
+		t.Error("second 600-token request must be denied (1200 > 1000/min)")
+	}
+	// A different key has its own independent bucket.
+	if !l.AllowInputTokens("k2", "m", 1000, 600) {
+		t.Error("a different key's bucket must be independent")
+	}
+}
+
+// TestMinute_ITPMDisabledWhenZero verifies a zero limit disables the cap.
+func TestMinute_ITPMDisabledWhenZero(t *testing.T) {
+	l := auth.NewMinuteRateLimiter()
+	for i := 0; i < 100; i++ {
+		if !l.AllowInputTokens("k1", "m", 0, 1_000_000) {
+			t.Fatalf("limit 0 must disable the cap, denied at i=%d", i)
+		}
+	}
+}
+
+// TestMinute_FullContextInputFits verifies a single full-context request fits the
+// ITPM burst — the loader guarantees ITPM capacity >= max_input_tokens, so a
+// legitimate max-size prompt is never throttled by its own rate bucket.
+func TestMinute_FullContextInputFits(t *testing.T) {
+	l := auth.NewMinuteRateLimiter()
+	if !l.AllowInputTokens("k1", "m", 519_540, 262_144) {
+		t.Error("a full-context request (input = max_input_tokens) must fit the ITPM burst")
+	}
+}
+
+// TestMinute_TinyFloodPassesITPM verifies ITPM does NOT stop a tiny-request
+// flood: thousands of 100-token requests fit a large ITPM bucket, which is why
+// RPM (not ITPM) is the flood guard.
+func TestMinute_TinyFloodPassesITPM(t *testing.T) {
+	l := auth.NewMinuteRateLimiter()
+	admitted := 0
+	for i := 0; i < 1000; i++ {
+		if l.AllowInputTokens("k1", "m", 520_000, 100) {
+			admitted++
+		}
+	}
+	if admitted != 1000 {
+		t.Errorf("ITPM must admit a tiny-request flood (520000/100 = 5200 capacity); admitted %d/1000", admitted)
+	}
+}
+
+// TestMinute_OTPMChargeDrainsAndExhausts verifies output charging drains the OTPM
+// bucket and that OutputExhausted then blocks new requests, with the charge
+// capped at one minute's capacity.
+func TestMinute_OTPMChargeDrainsAndExhausts(t *testing.T) {
+	l := auth.NewMinuteRateLimiter()
+	if l.OutputExhausted("k1", "m", 1000) {
+		t.Fatal("a fresh OTPM bucket must not be exhausted")
+	}
+	// A single huge response drains at most a full minute's capacity.
+	l.ChargeOutputTokens("k1", "m", 1000, 50_000)
+	if !l.OutputExhausted("k1", "m", 1000) {
+		t.Error("after output over the per-minute rate, the OTPM bucket must be exhausted")
+	}
+	// A disabled OTPM cap is never exhausted.
+	if l.OutputExhausted("k1", "m", 0) {
+		t.Error("limit 0 must disable OTPM (never exhausted)")
+	}
+}

--- a/test/auth/rpm_burst_test.go
+++ b/test/auth/rpm_burst_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+package auth_test
+
+import (
+	"testing"
+
+	"hivenet_router/internal/auth"
+)
+
+// TestRPM_CertifiedBurstWindow verifies the RPM burst is the certified short
+// window when configured, instead of a full minute's quota. A 60/min rate with a
+// 10s window bursts 10, not 60.
+func TestRPM_CertifiedBurstWindow(t *testing.T) {
+	l := auth.NewInMemoryLimiter()
+	l.SetRPMBurstWindow(10) // 10s of a 60/min rate → burst 10
+
+	admitted := 0
+	for i := 0; i < 20; i++ {
+		if ok, _, _ := l.AllowRequest("t", "m", 60); ok {
+			admitted++
+		}
+	}
+	if admitted != 10 {
+		t.Errorf("a 10s certified burst of a 60/min rate must admit 10, got %d", admitted)
+	}
+
+	// The legacy default (no window) bursts a full minute — 6× the certified burst.
+	def := auth.NewInMemoryLimiter()
+	admittedDef := 0
+	for i := 0; i < 20; i++ {
+		if ok, _, _ := def.AllowRequest("t", "m", 60); ok {
+			admittedDef++
+		}
+	}
+	if admittedDef != 20 {
+		t.Errorf("the legacy full-minute burst must admit all 20, got %d", admittedDef)
+	}
+}
+
+// TestTinyFloodStoppedByRPM_NotITPM verifies RPM and ITPM are complementary axes:
+// a flood of tiny (100-token) requests is stopped by the request-rate cap while
+// the input-token-rate cap has ample room, so RPM — not ITPM — is the flood guard.
+func TestTinyFloodStoppedByRPM_NotITPM(t *testing.T) {
+	rpm := auth.NewInMemoryLimiter()    // default burst = rpm = 96
+	itpm := auth.NewMinuteRateLimiter() // 520,000 tokens/min
+
+	rpmAdmitted, itpmAdmitted := 0, 0
+	for i := 0; i < 300; i++ {
+		if ok, _, _ := rpm.AllowRequest("t", "m", 96); ok {
+			rpmAdmitted++
+		}
+		if itpm.AllowInputTokens("t", "m", 520_000, 100) {
+			itpmAdmitted++
+		}
+	}
+	if rpmAdmitted >= 300 {
+		t.Errorf("RPM must stop the tiny-request flood; admitted %d/300", rpmAdmitted)
+	}
+	if itpmAdmitted != 300 {
+		t.Errorf("ITPM must NOT stop the flood (520000/100 = 5200 capacity); admitted %d/300", itpmAdmitted)
+	}
+}


### PR DESCRIPTION
## Serverless per-key caps (B4) + per-model default derivation

On a **serverless** replica many keys share the box, so this adds four **per-key** caps for fairness/anti-abuse. Box safety stays the global occupancy budget (B2) and shed gate (B3), so the caps are **intentionally oversubscribed** — not sized to sum to the box. All four are **inert on a reserved replica** and inert unless the key declares the cap, so reserved and legacy traffic is unaffected.

### The four caps
1. **Occupancy share** — a per-key token-weighted in-flight budget parallel to the global one: the key's footprint must stay within `max_occupancy_share × admit_budget_tokens`. Reuses the reservation machinery via a second controller; both reservations release together on every exit path (`admission.Reservations`). Deny → 429 `rate_limit_exceeded`.
2. **ITPM / OTPM** — per-key input/output tokens-per-minute buckets (`MinuteRateLimiter`, kept separate from `RateLimiter` so its interface and fakes stay stable). Input is charged at admission; output is metered **post-response** and throttles the key's next request once its rate is spent. Deny → 429 `rate_limit_exceeded`.
3. **RPM burst fix** — the token bucket's burst was hardcoded to a full minute's quota (a key could spend its whole minute instantly, 6× the certified ~10s burst). It's now a configurable window.

### `DeriveKeyDefaults` (§3d)
A **pure** function: a model's certified limits → its four per-key defaults (occupancy share, ITPM, OTPM, RPM), derived per the documented rules rather than copying a frozen constant block, so each model's caps track its own envelope.

### Design decisions to sanity-check
- **RPM burst defaults to legacy (full minute); the certified window is opt-in via `RPMBurstSeconds`.** The certified burst value is per-model benchmark data that isn't in this repo, and changing the default would alter existing rate-limiting for every key (and break tests that encode `burst = rpm`). So I fixed the *hardcoding* and left the default conservative — same pattern as RL-3's admit fraction. Flip it in config once validated.
- **No processor/domain changes.** All B4 logic lives in the handler + auth package. OTPM charges post-response in `writeSuccessResponse` where the token totals are already available (streaming and non-streaming), so the processor and `PendingRequest` are untouched.
- **Reset on reload.** The ITPM/OTPM limiter is reset on SIGHUP alongside `rateLimiter` so updated caps apply immediately; the per-key occupancy controller is **not** reset (that would drop live in-flight reservations).
- **Keying.** Occupancy share and ITPM/OTPM are keyed per-(key, model).

### Honest limitation
The §3d acceptance asks the derivation to reproduce the **full 5-model fleet table**, but the raw `router_limits.yaml` inputs aren't in this repo. So the derivation is validated by **exhaustive branch tests** (share floor, ITPM floor/ceiling/share binding, OTPM, RPM) plus the **gemma-4-31b reference row** (ITPM/RPM integer-exact; share/OTPM within tolerance since they depend on the exact certified ceilings). A full 5-model fixture just needs those numbers.

### Tests
- `test/auth/derive_test.go` (9): every formula branch + the gemma reference row.
- `test/auth/rate_minute_test.go` (5): ITPM allow/deny/disable, full-context input fits, tiny-flood passes ITPM, OTPM drain+exhaust.
- `test/auth/rpm_burst_test.go` (2): certified burst window (10 vs legacy 60), tiny flood stopped by RPM not ITPM.
- `test/admission/` (1): per-key oversubscription is independent (3 keys × 0.40 coexist).
- `test/api/b4_perkey_test.go` (5): per-key share denies over-share, within-share passes, ITPM denies over-rate, **reserved bypasses all caps**, full-context passes all caps.

Full suite passes under `-race`; gofmt + lint clean.
