### PR TITLE
Add admission-control observability

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -80,7 +80,8 @@
           "observability/hardware-metrics",
           "observability/engine-metrics",
           "observability/latency-tracking",
-          "observability/hardware-aware-routing"
+          "observability/hardware-aware-routing",
+          "observability/admission-control-metrics"
         ]
       },
       {

--- a/docs/observability/admission-control-metrics.mdx
+++ b/docs/observability/admission-control-metrics.mdx
@@ -1,0 +1,77 @@
+---
+title: "Admission control metrics"
+description: "Prometheus metrics and Grafana panel queries for the admission-control gates: occupancy vs budget, in-flight concurrency, and 429s by reason."
+sidebarTitle: "Admission control"
+---
+
+The admission-control gates expose two kinds of signal: a **counter** of rejections labelled by the gate that produced them, and **gauges** that track live occupancy against the budget. Together they answer "why are requests being rejected?" and "how close is a model to its budget?".
+
+## Metrics
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `hivenet_router_admission_rejections_total` | counter | `reason`, `model` | Requests rejected by an admission gate. |
+| `hivenet_router_admission_occupancy_tokens` | gauge | `model` | Current weighted in-flight token sum (Σw). |
+| `hivenet_router_admission_budget_tokens` | gauge | `model` | Effective admit budget (`admit_fraction × admit_budget_tokens`). |
+| `hivenet_router_admission_inflight_requests` | gauge | `model` | Current in-flight request count (against `max_inflight`). |
+
+The per-tenant RPM rejects continue to report through `hivenet_router_tenant_rate_limited_total`.
+
+### `reason` values
+
+| reason | gate |
+| --- | --- |
+| `b1` | per-request cap (input tokens or images) — HTTP 400 `input_too_long` |
+| `b2` | occupancy budget / in-flight backstop — 429 `concurrency_limit_exceeded` |
+| `b3` | front-door KV-pressure shed — 429 `concurrency_limit_exceeded` |
+| `b4_occupancy` | per-key occupancy share — 429 `rate_limit_exceeded` |
+| `b4_itpm` | per-key input tokens/minute — 429 `rate_limit_exceeded` |
+| `b4_otpm` | per-key output tokens/minute — 429 `rate_limit_exceeded` |
+
+## Panel queries (PromQL)
+
+**Occupancy vs budget** — utilization of the occupancy budget per model (target: watch it approach 1.0):
+
+```promql
+hivenet_router_admission_occupancy_tokens
+  / hivenet_router_admission_budget_tokens
+```
+
+Overlay the raw series to see headroom in absolute tokens:
+
+```promql
+hivenet_router_admission_occupancy_tokens
+hivenet_router_admission_budget_tokens
+```
+
+**In-flight concurrency** per model (against the `max_inflight` backstop):
+
+```promql
+hivenet_router_admission_inflight_requests
+```
+
+**429s (and 400s) by reason** — rejection rate attributed to each gate:
+
+```promql
+sum by (reason) (rate(hivenet_router_admission_rejections_total[5m]))
+```
+
+**Shed rate** — how often the front door is shedding for a model (B3):
+
+```promql
+sum by (model) (rate(hivenet_router_admission_rejections_total{reason="b3"}[5m]))
+```
+
+**Per-key throttling** — serverless per-key caps firing, to spot an abusive key or an undersized cap:
+
+```promql
+sum by (reason, model) (
+  rate(hivenet_router_admission_rejections_total{reason=~"b4_.*"}[5m])
+)
+```
+
+## Reading the signals together
+
+- **Occupancy near budget + rising `b2`** — the model is at its KV-occupancy limit; this is the circuit breaker working. Add capacity or accept the shed.
+- **`b3` firing while occupancy is below budget** — the live engine is under more pressure than the router's token estimate predicts; the token estimate may be optimistic (lower the shed threshold or improve the estimator).
+- **`b4_itpm` / `b4_occupancy` firing on legitimate traffic** — a per-key cap is undersized for the model; re-derive the defaults from the model's certified limits.

--- a/docs/observability/admission-control-metrics.mdx
+++ b/docs/observability/admission-control-metrics.mdx
@@ -13,9 +13,10 @@ The admission-control gates expose two kinds of signal: a **counter** of rejecti
 | `hivenet_router_admission_rejections_total` | counter | `reason`, `model` | Requests rejected by an admission gate. |
 | `hivenet_router_admission_occupancy_tokens` | gauge | `model` | Current weighted in-flight token sum (Σw). |
 | `hivenet_router_admission_budget_tokens` | gauge | `model` | Effective admit budget (`admit_fraction × admit_budget_tokens`). |
-| `hivenet_router_admission_inflight_requests` | gauge | `model` | Current in-flight request count (against `max_inflight`). |
+| `hivenet_router_admission_inflight_requests` | gauge | `model` | Current in-flight request count. |
+| `hivenet_router_admission_max_inflight` | gauge | `model` | Configured `max_inflight` backstop (the concurrency denominator). |
 
-The per-tenant RPM rejects continue to report through `hivenet_router_tenant_rate_limited_total`.
+Per-tenant RPM rejects also report through `hivenet_router_tenant_rate_limited_total` (per tenant and key), in addition to the `b4_rpm` reason below.
 
 ### `reason` values
 
@@ -27,6 +28,7 @@ The per-tenant RPM rejects continue to report through `hivenet_router_tenant_rat
 | `b4_occupancy` | per-key occupancy share — 429 `rate_limit_exceeded` |
 | `b4_itpm` | per-key input tokens/minute — 429 `rate_limit_exceeded` |
 | `b4_otpm` | per-key output tokens/minute — 429 `rate_limit_exceeded` |
+| `b4_rpm` | per-key requests/minute — 429 `rate_limit_exceeded` |
 
 ## Panel queries (PromQL)
 
@@ -44,10 +46,11 @@ hivenet_router_admission_occupancy_tokens
 hivenet_router_admission_budget_tokens
 ```
 
-**In-flight concurrency** per model (against the `max_inflight` backstop):
+**In-flight concurrency** utilization per model (against the `max_inflight` backstop):
 
 ```promql
 hivenet_router_admission_inflight_requests
+  / hivenet_router_admission_max_inflight
 ```
 
 **429s (and 400s) by reason** — rejection rate attributed to each gate:

--- a/internal/admission/controller.go
+++ b/internal/admission/controller.go
@@ -29,10 +29,10 @@ type Controller struct {
 	parkFor       time.Duration // how long an over-budget request waits for room before 429
 
 	// observer, when set, is called after every occupancy change (admit, release,
-	// grow) with the model's current sum, count, and effective budget — the hook
-	// the router uses to publish the occupancy gauges. Set once at startup via
-	// SetObserver, before any request, so it needs no lock.
-	observer func(model string, sumW int64, count int, budget int64)
+	// grow) with the model's current sum, count, effective budget, and max-inflight
+	// limit — the hook the router uses to publish the occupancy gauges. Set once at
+	// startup via SetObserver, before any request, so it needs no lock.
+	observer func(model string, sumW int64, count int, budget int64, maxInflight int)
 
 	mu     sync.Mutex
 	models map[string]*modelState
@@ -55,13 +55,16 @@ func NewController(admitFraction float64, parkFor time.Duration) *Controller {
 
 // SetObserver registers the occupancy-change callback (see observer). Call once
 // at startup before any request is admitted.
-func (c *Controller) SetObserver(fn func(model string, sumW int64, count int, budget int64)) {
+func (c *Controller) SetObserver(fn func(model string, sumW int64, count int, budget int64, maxInflight int)) {
 	c.observer = fn
 }
 
-func (c *Controller) emit(model string, sumW int64, count, budget int64) {
-	if c.observer != nil {
-		c.observer(model, sumW, int(count), budget)
+func (s *modelState) emit() {
+	s.mu.Lock()
+	sumW, count, budget, maxInflight := s.sumW, s.count, s.budget, s.maxInflight
+	s.mu.Unlock()
+	if s.c.observer != nil {
+		s.c.observer(s.model, sumW, count, budget, maxInflight)
 	}
 }
 
@@ -69,13 +72,14 @@ func (c *Controller) emit(model string, sumW int64, count, budget int64) {
 // guards the counters and the broadcast channel; the Controller mutex guards
 // only the map that hands these out.
 type modelState struct {
-	c      *Controller
-	model  string
-	mu     sync.Mutex
-	sumW   int64         // Σ footprint over in-flight requests for this model
-	count  int           // number of in-flight requests (the max_inflight backstop)
-	budget int64         // last effective budget seen, for the utilization gauge
-	notify chan struct{} // closed-and-replaced on every release to wake parked waiters
+	c           *Controller
+	model       string
+	mu          sync.Mutex
+	sumW        int64         // Σ footprint over in-flight requests for this model
+	count       int           // number of in-flight requests (the max_inflight backstop)
+	budget      int64         // last effective budget seen, for the utilization gauge
+	maxInflight int           // last max_inflight seen, for the concurrency gauge
+	notify      chan struct{} // closed-and-replaced on every release to wake parked waiters
 }
 
 func (c *Controller) stateFor(model string) *modelState {
@@ -180,6 +184,7 @@ func (c *Controller) Occupancy(model string) (sumW int64, count int) {
 func (s *modelState) tryReserve(weight, budget int64, maxInflight int) bool {
 	s.mu.Lock()
 	s.budget = budget
+	s.maxInflight = maxInflight
 	if budget > 0 && s.sumW+weight > budget {
 		s.mu.Unlock()
 		return false
@@ -190,9 +195,8 @@ func (s *modelState) tryReserve(weight, budget int64, maxInflight int) bool {
 	}
 	s.sumW += weight
 	s.count++
-	sumW, count, b := s.sumW, s.count, s.budget
 	s.mu.Unlock()
-	s.c.emit(s.model, sumW, int64(count), b)
+	s.emit()
 	return true
 }
 
@@ -210,10 +214,9 @@ func (s *modelState) release(weight int64) {
 	}
 	ch := s.notify
 	s.notify = make(chan struct{})
-	sumW, count, b := s.sumW, s.count, s.budget
 	s.mu.Unlock()
 	close(ch)
-	s.c.emit(s.model, sumW, int64(count), b)
+	s.emit()
 }
 
 // grow tightens occupancy as an undeclared request produces output. It never
@@ -221,9 +224,8 @@ func (s *modelState) release(weight int64) {
 func (s *modelState) grow(delta int64) {
 	s.mu.Lock()
 	s.sumW += delta
-	sumW, count, b := s.sumW, s.count, s.budget
 	s.mu.Unlock()
-	s.c.emit(s.model, sumW, int64(count), b)
+	s.emit()
 }
 
 func (s *modelState) notifyCh() chan struct{} {

--- a/internal/admission/controller.go
+++ b/internal/admission/controller.go
@@ -28,6 +28,12 @@ type Controller struct {
 	admitFraction float64       // scales the caller's budget tokens; (0,1]
 	parkFor       time.Duration // how long an over-budget request waits for room before 429
 
+	// observer, when set, is called after every occupancy change (admit, release,
+	// grow) with the model's current sum, count, and effective budget — the hook
+	// the router uses to publish the occupancy gauges. Set once at startup via
+	// SetObserver, before any request, so it needs no lock.
+	observer func(model string, sumW int64, count int, budget int64)
+
 	mu     sync.Mutex
 	models map[string]*modelState
 }
@@ -47,13 +53,28 @@ func NewController(admitFraction float64, parkFor time.Duration) *Controller {
 	}
 }
 
+// SetObserver registers the occupancy-change callback (see observer). Call once
+// at startup before any request is admitted.
+func (c *Controller) SetObserver(fn func(model string, sumW int64, count int, budget int64)) {
+	c.observer = fn
+}
+
+func (c *Controller) emit(model string, sumW int64, count, budget int64) {
+	if c.observer != nil {
+		c.observer(model, sumW, int(count), budget)
+	}
+}
+
 // modelState is the weighted in-flight accounting for one model. Its own mutex
 // guards the counters and the broadcast channel; the Controller mutex guards
 // only the map that hands these out.
 type modelState struct {
+	c      *Controller
+	model  string
 	mu     sync.Mutex
 	sumW   int64         // Σ footprint over in-flight requests for this model
 	count  int           // number of in-flight requests (the max_inflight backstop)
+	budget int64         // last effective budget seen, for the utilization gauge
 	notify chan struct{} // closed-and-replaced on every release to wake parked waiters
 }
 
@@ -62,7 +83,7 @@ func (c *Controller) stateFor(model string) *modelState {
 	defer c.mu.Unlock()
 	s := c.models[model]
 	if s == nil {
-		s = &modelState{notify: make(chan struct{})}
+		s = &modelState{c: c, model: model, notify: make(chan struct{})}
 		c.models[model] = s
 	}
 	return s
@@ -158,15 +179,20 @@ func (c *Controller) Occupancy(model string) (sumW int64, count int) {
 // reporting whether it did. A budget or backstop of <= 0 disables that check.
 func (s *modelState) tryReserve(weight, budget int64, maxInflight int) bool {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.budget = budget
 	if budget > 0 && s.sumW+weight > budget {
+		s.mu.Unlock()
 		return false
 	}
 	if maxInflight > 0 && s.count+1 > maxInflight {
+		s.mu.Unlock()
 		return false
 	}
 	s.sumW += weight
 	s.count++
+	sumW, count, b := s.sumW, s.count, s.budget
+	s.mu.Unlock()
+	s.c.emit(s.model, sumW, int64(count), b)
 	return true
 }
 
@@ -184,8 +210,10 @@ func (s *modelState) release(weight int64) {
 	}
 	ch := s.notify
 	s.notify = make(chan struct{})
+	sumW, count, b := s.sumW, s.count, s.budget
 	s.mu.Unlock()
 	close(ch)
+	s.c.emit(s.model, sumW, int64(count), b)
 }
 
 // grow tightens occupancy as an undeclared request produces output. It never
@@ -193,7 +221,9 @@ func (s *modelState) release(weight int64) {
 func (s *modelState) grow(delta int64) {
 	s.mu.Lock()
 	s.sumW += delta
+	sumW, count, b := s.sumW, s.count, s.budget
 	s.mu.Unlock()
+	s.c.emit(s.model, sumW, int64(count), b)
 }
 
 func (s *modelState) notifyCh() chan struct{} {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -242,6 +242,11 @@ type Handlers struct {
 	// minuteLimiter enforces the serverless per-key tokens-per-minute caps
 	// (ITPM/OTPM). Nil disables them.
 	minuteLimiter *auth.MinuteRateLimiter
+
+	// onAdmissionReject is called when an admission gate rejects a request, with
+	// the gate/reason (b1, b2, b3, b4_occupancy, b4_itpm, b4_otpm) and model.
+	// Wired to the admission-rejections counter. Nil-safe.
+	onAdmissionReject func(reason, model string)
 }
 
 // NewHandlers initializes a Handlers instance with all required dependencies.
@@ -269,6 +274,7 @@ func NewHandlers(
 	enginePressure func(model string) (kvUtil, waiting *float64),
 	keyAdmission *admission.Controller,
 	minuteLimiter *auth.MinuteRateLimiter,
+	onAdmissionReject func(reason, model string),
 ) *Handlers {
 	return &Handlers{
 		storage:              storage,
@@ -291,6 +297,14 @@ func NewHandlers(
 		enginePressure:       enginePressure,
 		keyAdmission:         keyAdmission,
 		minuteLimiter:        minuteLimiter,
+		onAdmissionReject:    onAdmissionReject,
+	}
+}
+
+// fireAdmissionReject reports an admission-gate rejection by reason and model.
+func (h *Handlers) fireAdmissionReject(reason, model string) {
+	if h.onAdmissionReject != nil {
+		h.onAdmissionReject(reason, model)
 	}
 }
 
@@ -513,6 +527,7 @@ func (h *Handlers) enforceRequestCaps(c *gin.Context, req *domain.ChatRequest) b
 	if pol.MaxInputTokens > 0 {
 		inputTokens := domain.EstimateTokens(domain.GetMessageSlice(req.Messages))
 		if inputTokens > pol.MaxInputTokens {
+			h.fireAdmissionReject("b1", req.Model)
 			writeRouterError(c, http.StatusBadRequest, domain.ErrCodeInputTooLong,
 				fmt.Sprintf("input is %d tokens, over the model limit of %d", inputTokens, pol.MaxInputTokens),
 				domain.SourceRouter)
@@ -522,6 +537,7 @@ func (h *Handlers) enforceRequestCaps(c *gin.Context, req *domain.ChatRequest) b
 	if pol.ImagesMax > 0 {
 		images := domain.CountImages(req.Messages)
 		if images > pol.ImagesMax {
+			h.fireAdmissionReject("b1", req.Model)
 			writeRouterError(c, http.StatusBadRequest, domain.ErrCodeInputTooLong,
 				fmt.Sprintf("request carries %d images, over the model limit of %d", images, pol.ImagesMax),
 				domain.SourceRouter)
@@ -567,6 +583,7 @@ func (h *Handlers) enforceOccupancyBudget(c *gin.Context, req *domain.ChatReques
 	if h.admission != nil && (pol.AdmitBudgetTokens > 0 || pol.MaxInflight > 0) {
 		res := h.admission.Admit(c.Request.Context(), req.Model, footprint, grows, pol.AdmitBudgetTokens, pol.MaxInflight)
 		if res == nil {
+			h.fireAdmissionReject("b2", req.Model)
 			c.Header("Retry-After", "1")
 			writeRouterError(c, http.StatusTooManyRequests, domain.ErrCodeConcurrencyLimit,
 				"server at capacity for this model, please retry", domain.SourceRouter)
@@ -586,6 +603,7 @@ func (h *Handlers) enforceOccupancyBudget(c *gin.Context, req *domain.ChatReques
 			res := h.keyAdmission.Admit(c.Request.Context(), keyID+"\x00"+req.Model, footprint, grows, budget, 0)
 			if res == nil {
 				rs.Release() // hand back the global reservation already taken
+				h.fireAdmissionReject("b4_occupancy", req.Model)
 				c.Header("Retry-After", "1")
 				writeRouterError(c, http.StatusTooManyRequests, domain.ErrCodeRateLimitExceeded,
 					"per-key occupancy share exceeded, please retry", domain.SourceRouter)
@@ -627,10 +645,12 @@ func (h *Handlers) enforcePerKeyRates(c *gin.Context, req *domain.ChatRequest, m
 	// Check the non-deducting OTPM gate before charging the ITPM bucket, so an
 	// output-rate rejection never spends input-rate tokens.
 	if limits.OutputTokensPerMinute > 0 && h.minuteLimiter.OutputExhausted(m.keyID, req.Model, limits.OutputTokensPerMinute) {
+		h.fireAdmissionReject("b4_otpm", req.Model)
 		return h.writeRateLimited(c, m, req.Model, "output token rate exceeded, please retry")
 	}
 	if limits.InputTokensPerMinute > 0 {
 		if !h.minuteLimiter.AllowInputTokens(m.keyID, req.Model, limits.InputTokensPerMinute, estimatePromptTokens(req)) {
+			h.fireAdmissionReject("b4_itpm", req.Model)
 			return h.writeRateLimited(c, m, req.Model, "input token rate exceeded, please retry")
 		}
 	}
@@ -690,6 +710,7 @@ func (h *Handlers) enforceShedPressure(c *gin.Context, model string) bool {
 	if policy.PassesGates(snap, pol.ShedIf) {
 		return true
 	}
+	h.fireAdmissionReject("b3", model)
 	c.Header("Retry-After", "1")
 	writeRouterError(c, http.StatusTooManyRequests, domain.ErrCodeConcurrencyLimit,
 		"model is under high load, please retry", domain.SourceRouter)

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -250,6 +250,8 @@ func resolveCaller(c *gin.Context) quotaCaller {
 func denyRPM(c *gin.Context, m *metrics.RouterMetrics, caller quotaCaller, model, msg string) {
 	m.TenantRateLimited(caller.tenantID, caller.keyID)
 	m.TenantRequestFailed(caller.tenantID, caller.keyID, caller.deploymentID, model)
+	m.AdmissionRejected("b4_rpm", model) // also surface in the unified 429-by-reason counter
+
 	c.Header(headerRateLimitRemainingRequests, "0")
 	abortWithRouterError(c, http.StatusTooManyRequests, domain.ErrCodeRateLimitExceeded, msg, domain.SourceRouter)
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1146,14 +1146,13 @@ func (m *RouterMetrics) AdmissionRejected(reason, model string) {
 // SetAdmissionOccupancy publishes a model's live occupancy: the weighted
 // in-flight token sum (Σw), the in-flight request count, and the effective admit
 // budget. Called on every admit/release/grow, so occupancy_tokens / budget_tokens
-// tracks real utilization. A model whose budget is unknown (0) leaves the budget
-// gauge untouched so a transient 0 does not blank the denominator.
+// tracks real utilization. The budget is always written — including 0 — so a
+// model with no token budget (max_inflight-only), or one whose budget was
+// disabled on reload, reports the true denominator rather than a stale value.
 func (m *RouterMetrics) SetAdmissionOccupancy(model string, sumW int64, count int, budget int64) {
 	m.admissionOccupancyTokens.With(prometheus.Labels{"model": model}).Set(float64(sumW))
 	m.admissionInflightRequests.With(prometheus.Labels{"model": model}).Set(float64(count))
-	if budget > 0 {
-		m.admissionBudgetTokens.With(prometheus.Labels{"model": model}).Set(float64(budget))
-	}
+	m.admissionBudgetTokens.With(prometheus.Labels{"model": model}).Set(float64(budget))
 }
 
 // TenantSetTokensUsedToday updates the gauge that tracks how many tokens the

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	dto "github.com/prometheus/client_model/go"
 )
 
 var log = logging.Logger("metrics")
@@ -182,6 +183,10 @@ type RouterMetrics struct {
 	// admissionInflightRequests is the current in-flight request count for a model,
 	// against the max_inflight backstop. Label: model.
 	admissionInflightRequests *prometheus.GaugeVec
+
+	// admissionMaxInflight is the configured max_inflight backstop for a model —
+	// the denominator for the concurrency-utilization panel. 0 = no backstop.
+	admissionMaxInflight *prometheus.GaugeVec
 
 	// --- Policy routing metrics ---
 
@@ -486,6 +491,13 @@ func NewRouterMetrics() *RouterMetrics {
 			prometheus.GaugeOpts{
 				Name: "hivenet_router_admission_inflight_requests",
 				Help: "Current in-flight request count per model, against the max_inflight backstop.",
+			},
+			[]string{"model"},
+		),
+		admissionMaxInflight: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "hivenet_router_admission_max_inflight",
+				Help: "Configured max_inflight backstop per model — the concurrency-utilization denominator. 0 = no backstop.",
 			},
 			[]string{"model"},
 		),
@@ -858,6 +870,7 @@ func NewRouterMetrics() *RouterMetrics {
 		m.admissionOccupancyTokens,
 		m.admissionBudgetTokens,
 		m.admissionInflightRequests,
+		m.admissionMaxInflight,
 		m.agentSuccessTotal,
 		m.agentFailedTotal,
 		m.agentSuccessRate,
@@ -1149,10 +1162,17 @@ func (m *RouterMetrics) AdmissionRejected(reason, model string) {
 // tracks real utilization. The budget is always written — including 0 — so a
 // model with no token budget (max_inflight-only), or one whose budget was
 // disabled on reload, reports the true denominator rather than a stale value.
-func (m *RouterMetrics) SetAdmissionOccupancy(model string, sumW int64, count int, budget int64) {
+func (m *RouterMetrics) SetAdmissionOccupancy(model string, sumW int64, count int, budget int64, maxInflight int) {
 	m.admissionOccupancyTokens.With(prometheus.Labels{"model": model}).Set(float64(sumW))
 	m.admissionInflightRequests.With(prometheus.Labels{"model": model}).Set(float64(count))
 	m.admissionBudgetTokens.With(prometheus.Labels{"model": model}).Set(float64(budget))
+	m.admissionMaxInflight.With(prometheus.Labels{"model": model}).Set(float64(maxInflight))
+}
+
+// Gather returns the current metric families from this instance's registry. It
+// exposes the private registry for tests that assert exported metric values.
+func (m *RouterMetrics) Gather() ([]*dto.MetricFamily, error) {
+	return m.registry.Gather()
 }
 
 // TenantSetTokensUsedToday updates the gauge that tracks how many tokens the

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -163,6 +163,26 @@ type RouterMetrics struct {
 	// quotaBackendErrors counts Redis quota backend call failures (fail-open events).
 	quotaBackendErrors prometheus.Counter
 
+	// --- Admission-control metrics ---
+
+	// admissionRejections counts requests rejected by an admission gate, labelled
+	// by the gate that rejected it. reason ∈ {b1, b2, b3, b4_occupancy, b4_itpm,
+	// b4_otpm}; the existing per-tenant RPM path reports via tenantRateLimited.
+	// Labels: reason, model.
+	admissionRejections *prometheus.CounterVec
+
+	// admissionOccupancyTokens is the current weighted in-flight token sum (Σw)
+	// for a model — the numerator of the occupancy-vs-budget utilization.
+	admissionOccupancyTokens *prometheus.GaugeVec
+
+	// admissionBudgetTokens is the effective occupancy admit budget (admit_fraction
+	// × admit_budget_tokens) for a model — the denominator of the utilization.
+	admissionBudgetTokens *prometheus.GaugeVec
+
+	// admissionInflightRequests is the current in-flight request count for a model,
+	// against the max_inflight backstop. Label: model.
+	admissionInflightRequests *prometheus.GaugeVec
+
 	// --- Policy routing metrics ---
 
 	// policyPrimaryRouted counts requests served by the primary routing_policy step.
@@ -440,6 +460,34 @@ func NewRouterMetrics() *RouterMetrics {
 				Name: "hivenet_router_quota_backend_errors_total",
 				Help: "Redis quota backend call failures (fail-open events).",
 			},
+		),
+		admissionRejections: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "hivenet_router_admission_rejections_total",
+				Help: "Requests rejected by an admission gate, by gate/reason (b1, b2, b3, b4_occupancy, b4_itpm, b4_otpm) and model.",
+			},
+			[]string{"reason", "model"},
+		),
+		admissionOccupancyTokens: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "hivenet_router_admission_occupancy_tokens",
+				Help: "Current weighted in-flight token sum (Σw) per model — the occupancy-budget numerator.",
+			},
+			[]string{"model"},
+		),
+		admissionBudgetTokens: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "hivenet_router_admission_budget_tokens",
+				Help: "Effective occupancy admit budget (admit_fraction × admit_budget_tokens) per model — the occupancy-budget denominator.",
+			},
+			[]string{"model"},
+		),
+		admissionInflightRequests: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "hivenet_router_admission_inflight_requests",
+				Help: "Current in-flight request count per model, against the max_inflight backstop.",
+			},
+			[]string{"model"},
 		),
 		agentSuccessTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -806,6 +854,10 @@ func NewRouterMetrics() *RouterMetrics {
 		m.requestDuration,
 		m.tenantLastRequestTimestamp,
 		m.quotaBackendErrors,
+		m.admissionRejections,
+		m.admissionOccupancyTokens,
+		m.admissionBudgetTokens,
+		m.admissionInflightRequests,
 		m.agentSuccessTotal,
 		m.agentFailedTotal,
 		m.agentSuccessRate,
@@ -1082,6 +1134,26 @@ func (m *RouterMetrics) TenantSetPerModelQuotaLimit(tenantID, model string, rpm 
 // (tenant, model) pair on a per-model quota key. Idempotent on every request.
 func (m *RouterMetrics) TenantSetPerModelTPDLimit(tenantID, model string, tpd int) {
 	m.tenantPerModelQuotaTPDLimit.With(prometheus.Labels{"tenant_id": tenantID, "model": model}).Set(float64(tpd))
+}
+
+// AdmissionRejected counts a request rejected by an admission gate, labelled by
+// the gate/reason and model. reason ∈ {b1, b2, b3, b4_occupancy, b4_itpm,
+// b4_otpm}. B3 shed rate is rate(...{reason="b3"}); "429 by reason" sums over all.
+func (m *RouterMetrics) AdmissionRejected(reason, model string) {
+	m.admissionRejections.With(prometheus.Labels{"reason": reason, "model": model}).Inc()
+}
+
+// SetAdmissionOccupancy publishes a model's live occupancy: the weighted
+// in-flight token sum (Σw), the in-flight request count, and the effective admit
+// budget. Called on every admit/release/grow, so occupancy_tokens / budget_tokens
+// tracks real utilization. A model whose budget is unknown (0) leaves the budget
+// gauge untouched so a transient 0 does not blank the denominator.
+func (m *RouterMetrics) SetAdmissionOccupancy(model string, sumW int64, count int, budget int64) {
+	m.admissionOccupancyTokens.With(prometheus.Labels{"model": model}).Set(float64(sumW))
+	m.admissionInflightRequests.With(prometheus.Labels{"model": model}).Set(float64(count))
+	if budget > 0 {
+		m.admissionBudgetTokens.With(prometheus.Labels{"model": model}).Set(float64(budget))
+	}
 }
 
 // TenantSetTokensUsedToday updates the gauge that tracks how many tokens the

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -548,6 +548,9 @@ func (r *Router) startHTTPServer() {
 	if r.counters != nil {
 		resetMetrics = r.counters.ResetAll
 	}
+	// The global occupancy controller publishes its Σw/count/budget as gauges.
+	occupancy := admission.NewController(r.cfg.AdmitFraction, r.cfg.AdmitParkTimeout)
+	occupancy.SetObserver(r.metrics.SetAdmissionOccupancy)
 	handlers := api.NewHandlers(
 		r.storage,
 		r,
@@ -572,12 +575,13 @@ func (r *Router) startHTTPServer() {
 		resetMetrics,
 		r.agents.CountHealthyByModel,
 		r, // RegistrationFeed — Router implements SubscribeRegistration
-		admission.NewController(r.cfg.AdmitFraction, r.cfg.AdmitParkTimeout),
+		occupancy,
 		r.EnginePressureForModel,
 		// Per-key occupancy share: no admit fraction (it is fairness, not box
 		// safety) and no parking (a per-key breach is denied immediately).
 		admission.NewController(1.0, 0),
 		r.minuteLimiter,
+		r.metrics.AdmissionRejected,
 	)
 	server := api.NewServer(handlers, r.cfg.HTTPPort, r.apiAuth, r.adminAuth, r.rateLimiter, r.metrics, r.agents.CountHealthyByModel, r.cfg.MaxRequestBytes)
 	if err := server.Start(); err != nil {

--- a/test/admission/controller_test.go
+++ b/test/admission/controller_test.go
@@ -152,6 +152,44 @@ func TestSmallBudgetFlooredNotDisabled(t *testing.T) {
 	}
 }
 
+// TestObserverTracksOccupancy verifies the occupancy observer (the gauge source)
+// reports the live Σw, count, and effective budget on every admit, grow, and
+// release — matching Occupancy() throughout the §0 scenario.
+func TestObserverTracksOccupancy(t *testing.T) {
+	c := admission.NewController(1.0, 0)
+	var gotSum, gotBudget int64
+	var gotCount int
+	c.SetObserver(func(_ string, sumW int64, count int, budget int64) {
+		gotSum, gotCount, gotBudget = sumW, count, budget
+	})
+	ctx := context.Background()
+
+	r := c.Admit(ctx, model, 250_000, true, 409_000, 0)
+	if gotSum != 250_000 || gotCount != 1 || gotBudget != 409_000 {
+		t.Fatalf("after admit: observed sum=%d count=%d budget=%d, want 250000/1/409000", gotSum, gotCount, gotBudget)
+	}
+	// A rejected admit does not change occupancy, so it emits nothing new.
+	c.Admit(ctx, model, 250_000, true, 409_000, 0)
+	if gotSum != 250_000 {
+		t.Errorf("a rejected admit must not change observed occupancy; got %d", gotSum)
+	}
+	// Undeclared growth is reflected live.
+	r.Grow(1000)
+	if gotSum != 251_000 {
+		t.Errorf("after grow: observed sum=%d, want 251000", gotSum)
+	}
+	// Release returns to zero.
+	r.Release()
+	if gotSum != 0 || gotCount != 0 {
+		t.Errorf("after release: observed sum=%d count=%d, want 0/0", gotSum, gotCount)
+	}
+	// The observed value always matches the authoritative Occupancy().
+	sumW, count := c.Occupancy(model)
+	if sumW != gotSum || count != gotCount {
+		t.Errorf("observed (%d,%d) must match Occupancy (%d,%d)", gotSum, gotCount, sumW, count)
+	}
+}
+
 // TestPerKeyOversubscriptionIsIndependent models the per-key occupancy share:
 // three keys each capped at 0.40 of a 1000-token budget (400 each) all admit
 // their full share concurrently, because per-key buckets are independent — the

--- a/test/admission/controller_test.go
+++ b/test/admission/controller_test.go
@@ -158,20 +158,20 @@ func TestSmallBudgetFlooredNotDisabled(t *testing.T) {
 func TestObserverTracksOccupancy(t *testing.T) {
 	c := admission.NewController(1.0, 0)
 	var gotSum, gotBudget int64
-	var gotCount int
-	c.SetObserver(func(_ string, sumW int64, count int, budget int64) {
-		gotSum, gotCount, gotBudget = sumW, count, budget
+	var gotCount, gotMaxInflight int
+	c.SetObserver(func(_ string, sumW int64, count int, budget int64, maxInflight int) {
+		gotSum, gotCount, gotBudget, gotMaxInflight = sumW, count, budget, maxInflight
 	})
 	ctx := context.Background()
 
-	r := c.Admit(ctx, model, 250_000, true, 409_000, 0)
-	if gotSum != 250_000 || gotCount != 1 || gotBudget != 409_000 {
-		t.Fatalf("after admit: observed sum=%d count=%d budget=%d, want 250000/1/409000", gotSum, gotCount, gotBudget)
+	r := c.Admit(ctx, model, 250_000, true, 409_000, 64)
+	if gotSum != 250_000 || gotCount != 1 || gotBudget != 409_000 || gotMaxInflight != 64 {
+		t.Fatalf("after admit: observed sum=%d count=%d budget=%d maxInflight=%d, want 250000/1/409000/64", gotSum, gotCount, gotBudget, gotMaxInflight)
 	}
 	// A rejected admit does not change occupancy, so it emits nothing new.
-	c.Admit(ctx, model, 250_000, true, 409_000, 0)
-	if gotSum != 250_000 {
-		t.Errorf("a rejected admit must not change observed occupancy; got %d", gotSum)
+	c.Admit(ctx, model, 250_000, true, 409_000, 64)
+	if gotSum != 250_000 || gotMaxInflight != 64 {
+		t.Errorf("a rejected admit must not change observed occupancy; got sum=%d maxInflight=%d", gotSum, gotMaxInflight)
 	}
 	// Undeclared growth is reflected live.
 	r.Grow(1000)

--- a/test/api/admission_metrics_test.go
+++ b/test/api/admission_metrics_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+// Package api_test verifies that every admission gate reports its distinct
+// rejection reason to the metrics callback, so "429 by reason" dashboards can
+// attribute each reject to the gate that produced it.
+package api_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"hivenet_router/internal/admission"
+	"hivenet_router/internal/api"
+	"hivenet_router/internal/auth"
+	"hivenet_router/internal/domain"
+	"hivenet_router/internal/policy"
+)
+
+// meteredHandler builds a Handlers wired with the given admission dependencies
+// and a reject callback that records the reason of the last rejection.
+func meteredHandler(q chan *domain.PendingRequest, pol *policy.Policy, keyAdm *admission.Controller,
+	minLim *auth.MinuteRateLimiter, pressure func(string) (*float64, *float64), reason *string,
+) *api.Handlers {
+	exec := policy.NewExecutor(nil, nil, pol, 0, 0)
+	return api.NewHandlers(
+		nil, nil, q, time.Second,
+		exec, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil, nil,
+		admission.NewController(1.0, 0), pressure, keyAdm, minLim,
+		func(r, _ string) { *reason = r },
+	)
+}
+
+// TestAdmissionRejectReason drives each gate to reject and asserts the metrics
+// callback fired with that gate's distinct reason label.
+func TestAdmissionRejectReason(t *testing.T) {
+	t.Run("b1", func(t *testing.T) {
+		var reason string
+		h := meteredHandler(make(chan *domain.PendingRequest, 1), &policy.Policy{MaxInputTokens: 10}, nil, nil, nil, &reason)
+		c, w := newCtx("/v1/chat/completions", textBody(28, 0)) // input 11 > 10
+		h.Passthrough(c)
+		assertReason(t, w.Code, http.StatusBadRequest, reason, "b1")
+	})
+
+	t.Run("b2", func(t *testing.T) {
+		var reason string
+		h := meteredHandler(make(chan *domain.PendingRequest, 1), &policy.Policy{AdmitBudgetTokens: 5}, nil, nil, nil, &reason)
+		c, w := newCtx("/v1/chat/completions", b2Body(500)) // footprint 504 > 5
+		h.Passthrough(c)
+		assertReason(t, w.Code, http.StatusTooManyRequests, reason, "b2")
+	})
+
+	t.Run("b3", func(t *testing.T) {
+		var reason string
+		pol := &policy.Policy{ShedIf: map[string]policy.ThresholdRule{"kv_cache_utilization": {GT: f64(0.90)}}}
+		h := meteredHandler(make(chan *domain.PendingRequest, 1), pol, nil, nil,
+			func(string) (*float64, *float64) { return f64(0.99), nil }, &reason)
+		c, w := newCtx("/v1/chat/completions", b2Body(0))
+		h.Passthrough(c)
+		assertReason(t, w.Code, http.StatusTooManyRequests, reason, "b3")
+	})
+
+	t.Run("b4_occupancy", func(t *testing.T) {
+		var reason string
+		h := meteredHandler(make(chan *domain.PendingRequest, 1), serverless(1000), admission.NewController(1.0, 0), nil, nil, &reason)
+		c, w := newCtx("/v1/chat/completions", b2Body(500)) // footprint 504 > share budget 400
+		withKey(c, auth.QuotaLimits{MaxOccupancyShare: 0.40})
+		h.Passthrough(c)
+		assertReason(t, w.Code, http.StatusTooManyRequests, reason, "b4_occupancy")
+	})
+
+	t.Run("b4_itpm", func(t *testing.T) {
+		var reason string
+		h := meteredHandler(make(chan *domain.PendingRequest, 1), serverless(0), nil, auth.NewMinuteRateLimiter(), nil, &reason)
+		c, w := newCtx("/v1/chat/completions", textBody(40, 0)) // input 14 > ITPM 10
+		withKey(c, auth.QuotaLimits{InputTokensPerMinute: 10})
+		h.Passthrough(c)
+		assertReason(t, w.Code, http.StatusTooManyRequests, reason, "b4_itpm")
+	})
+
+	t.Run("b4_otpm", func(t *testing.T) {
+		var reason string
+		minLim := auth.NewMinuteRateLimiter()
+		minLim.ChargeOutputTokens("k1", b2Model, 100, 100) // drain the key's OTPM bucket for this model
+		h := meteredHandler(make(chan *domain.PendingRequest, 1), serverless(0), nil, minLim, nil, &reason)
+		c, w := newCtx("/v1/chat/completions", b2Body(0))
+		withKey(c, auth.QuotaLimits{OutputTokensPerMinute: 100})
+		h.Passthrough(c)
+		assertReason(t, w.Code, http.StatusTooManyRequests, reason, "b4_otpm")
+	})
+}
+
+func assertReason(t *testing.T, gotCode, wantCode int, gotReason, wantReason string) {
+	t.Helper()
+	if gotCode != wantCode {
+		t.Fatalf("status = %d, want %d", gotCode, wantCode)
+	}
+	if gotReason != wantReason {
+		t.Errorf("reject reason = %q, want %q", gotReason, wantReason)
+	}
+}

--- a/test/api/b1_request_caps_test.go
+++ b/test/api/b1_request_caps_test.go
@@ -31,6 +31,7 @@ func newCapHandlers(q chan *domain.PendingRequest, global *policy.Policy) *api.H
 		exec, nil, nil, nil,
 		nil, nil, nil, nil, nil, nil, nil, nil,
 		nil, nil, nil, nil,
+		nil,
 	)
 }
 
@@ -314,7 +315,7 @@ func TestB1_PerModelPolicyCap(t *testing.T) {
 		t.Fatalf("SetNamedPolicy: %v", err)
 	}
 	q := make(chan *domain.PendingRequest, 1)
-	h := api.NewHandlers(nil, nil, q, 2*time.Second, exec, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	h := api.NewHandlers(nil, nil, q, 2*time.Second, exec, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	// Over-cap request for the capped model → 400.
 	over := fmt.Appendf(nil, `{"model":"capped","messages":[{"role":"user","content":%q}]}`, strings.Repeat("a", 28))

--- a/test/api/b2_occupancy_test.go
+++ b/test/api/b2_occupancy_test.go
@@ -46,6 +46,7 @@ func newB2Handlers(q chan *domain.PendingRequest, ctrl *admission.Controller, gl
 		exec, nil, nil, nil,
 		nil, nil, nil, nil, nil, nil, nil, nil,
 		ctrl, nil, nil, nil,
+		nil,
 	)
 }
 

--- a/test/api/b3_shed_test.go
+++ b/test/api/b3_shed_test.go
@@ -36,6 +36,7 @@ func newB3Handlers(q chan *domain.PendingRequest, pol *policy.Policy, pressure f
 		exec, nil, nil, nil,
 		nil, nil, nil, nil, nil, nil, nil, nil,
 		nil, pressure, nil, nil,
+		nil,
 	)
 }
 

--- a/test/api/b4_perkey_test.go
+++ b/test/api/b4_perkey_test.go
@@ -34,6 +34,7 @@ func newB4Handlers(q chan *domain.PendingRequest, pol *policy.Policy) *api.Handl
 		nil,                             // engine pressure
 		admission.NewController(1.0, 0), // per-key occupancy share
 		auth.NewMinuteRateLimiter(),     // ITPM/OTPM
+		nil,                             // admission reject callback
 	)
 }
 
@@ -152,7 +153,7 @@ func TestB4_ITPMDenialDoesNotChargeDailyBudget(t *testing.T) {
 		nil, nil, q, time.Second,
 		exec, nil, nil, lim,
 		nil, nil, nil, nil, nil, nil, nil, nil,
-		nil, nil, nil, auth.NewMinuteRateLimiter(),
+		nil, nil, nil, auth.NewMinuteRateLimiter(), nil,
 	)
 	c, w := newCtx("/v1/chat/completions", textBody(40, 0)) // input 14 > ITPM burst 10
 	withKey(c, auth.QuotaLimits{TokensPerDay: 1_000_000, InputTokensPerMinute: 10})

--- a/test/api/middleware_test.go
+++ b/test/api/middleware_test.go
@@ -155,6 +155,7 @@ func newPolicyHandlers() *api.Handlers {
 		exec, nil, nil, nil,
 		nil, nil, nil, nil, nil, nil, nil, nil,
 		nil, nil, nil, nil,
+		nil,
 	)
 }
 

--- a/test/api/passthrough_test.go
+++ b/test/api/passthrough_test.go
@@ -60,6 +60,7 @@ func newTestHandlers(q chan *domain.PendingRequest, lim auth.RateLimiter) *api.H
 		nil, nil, nil, lim,
 		nil, nil, nil, nil, nil, nil, nil, nil,
 		nil, nil, nil, nil,
+		nil,
 	)
 }
 

--- a/test/api/registration_stream_test.go
+++ b/test/api/registration_stream_test.go
@@ -48,6 +48,7 @@ func TestRegistrationStream_EmitsSSEFrame(t *testing.T) {
 		nil, nil, nil, nil,
 		nil, nil, nil, nil, nil, nil, nil, feed,
 		nil, nil, nil, nil,
+		nil,
 	)
 
 	router := gin.New()
@@ -127,6 +128,7 @@ func TestRegistrationStream_NotImplementedWhenNoFeed(t *testing.T) {
 		nil, // engine-pressure provider = nil
 		nil, // key admission = nil
 		nil, // minute limiter = nil
+		nil, // admission reject callback = nil
 	)
 
 	router := gin.New()

--- a/test/metrics/admission_metrics_test.go
+++ b/test/metrics/admission_metrics_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+package metrics_test
+
+import (
+	"testing"
+
+	"hivenet_router/internal/metrics"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// metricValue scans a gathered registry for the sample of metric `name` whose
+// labels match `want`, returning its counter/gauge value and whether it existed.
+func metricValue(t *testing.T, m *metrics.RouterMetrics, name string, want map[string]string) (float64, bool) {
+	t.Helper()
+	families, err := m.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	for _, mf := range families {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			labels := map[string]string{}
+			for _, lp := range metric.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+			if !labelsMatch(labels, want) {
+				continue
+			}
+			return sampleValue(metric), true
+		}
+	}
+	return 0, false
+}
+
+func labelsMatch(got, want map[string]string) bool {
+	for k, v := range want {
+		if got[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func sampleValue(m *dto.Metric) float64 {
+	switch {
+	case m.GetCounter() != nil:
+		return m.GetCounter().GetValue()
+	case m.GetGauge() != nil:
+		return m.GetGauge().GetValue()
+	default:
+		return 0
+	}
+}
+
+// TestAdmissionRejectionsCounter verifies the reason-labelled counter increments
+// per gate/reason and model, as the "429 by reason" dashboards read it.
+func TestAdmissionRejectionsCounter(t *testing.T) {
+	m := metrics.NewRouterMetrics()
+	m.AdmissionRejected("b2", "gemma")
+	m.AdmissionRejected("b2", "gemma")
+	m.AdmissionRejected("b3", "gemma")
+	m.AdmissionRejected("b4_rpm", "qwen")
+
+	cases := []struct {
+		reason, model string
+		want          float64
+	}{
+		{"b2", "gemma", 2},
+		{"b3", "gemma", 1},
+		{"b4_rpm", "qwen", 1},
+	}
+	for _, tc := range cases {
+		got, ok := metricValue(t, m, "hivenet_router_admission_rejections_total",
+			map[string]string{"reason": tc.reason, "model": tc.model})
+		if !ok {
+			t.Errorf("no series for reason=%s model=%s", tc.reason, tc.model)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("reason=%s model=%s = %v, want %v", tc.reason, tc.model, got, tc.want)
+		}
+	}
+	// A reason that never fired has no series (rather than a zero we'd have to seed).
+	if _, ok := metricValue(t, m, "hivenet_router_admission_rejections_total",
+		map[string]string{"reason": "b1", "model": "gemma"}); ok {
+		t.Error("expected no b1 series before any b1 rejection")
+	}
+}
+
+// TestAdmissionOccupancyGauges verifies the occupancy gauges expose the numerator
+// (Σw, in-flight) and both denominators (budget, max_inflight) for a model.
+func TestAdmissionOccupancyGauges(t *testing.T) {
+	m := metrics.NewRouterMetrics()
+	m.SetAdmissionOccupancy("gemma", 250_000, 1, 409_000, 64)
+
+	for _, tc := range []struct {
+		name string
+		want float64
+	}{
+		{"hivenet_router_admission_occupancy_tokens", 250_000},
+		{"hivenet_router_admission_inflight_requests", 1},
+		{"hivenet_router_admission_budget_tokens", 409_000},
+		{"hivenet_router_admission_max_inflight", 64},
+	} {
+		got, ok := metricValue(t, m, tc.name, map[string]string{"model": "gemma"})
+		if !ok || got != tc.want {
+			t.Errorf("%s = %v (present=%v), want %v", tc.name, got, ok, tc.want)
+		}
+	}
+
+	// A later update overwrites the gauges (occupancy drains as requests finish),
+	// and a disabled budget drops to 0 rather than staying stale.
+	m.SetAdmissionOccupancy("gemma", 0, 0, 0, 0)
+	if got, _ := metricValue(t, m, "hivenet_router_admission_budget_tokens", map[string]string{"model": "gemma"}); got != 0 {
+		t.Errorf("budget gauge must drop to 0 when disabled, got %v", got)
+	}
+}

--- a/test/metrics/router_metrics_smoke_test.go
+++ b/test/metrics/router_metrics_smoke_test.go
@@ -63,7 +63,8 @@ func TestRouterMetrics_EmitMethodsNoPanic(t *testing.T) {
 	m.AdmissionRejected("b4_occupancy", model)
 	m.AdmissionRejected("b4_itpm", model)
 	m.AdmissionRejected("b4_otpm", model)
-	m.SetAdmissionOccupancy(model, 250000, 1, 409000)
+	m.AdmissionRejected("b4_rpm", model)
+	m.SetAdmissionOccupancy(model, 250000, 1, 409000, 37)
 
 	// Routing-policy pipeline outcomes (primary / fallback / exhausted / reload).
 	m.PolicyPrimaryRouted(model)

--- a/test/metrics/router_metrics_smoke_test.go
+++ b/test/metrics/router_metrics_smoke_test.go
@@ -56,6 +56,15 @@ func TestRouterMetrics_EmitMethodsNoPanic(t *testing.T) {
 	m.TenantObserveRequestDuration(tenant, keyID, deploy, model, 0.3)
 	m.QuotaBackendError()
 
+	// Admission-control metrics: reject counter (per reason) and occupancy gauges.
+	m.AdmissionRejected("b1", model)
+	m.AdmissionRejected("b2", model)
+	m.AdmissionRejected("b3", model)
+	m.AdmissionRejected("b4_occupancy", model)
+	m.AdmissionRejected("b4_itpm", model)
+	m.AdmissionRejected("b4_otpm", model)
+	m.SetAdmissionOccupancy(model, 250000, 1, 409000)
+
 	// Routing-policy pipeline outcomes (primary / fallback / exhausted / reload).
 	m.PolicyPrimaryRouted(model)
 	m.PolicyFallbackRouted(model)


### PR DESCRIPTION
## Admission-control observability

Makes the B1–B4 gates visible to operators — the "why are requests rejected?" and "how close is a model to its budget?" signals.

### Metrics
- **`admission_rejections_total{reason, model}`** — every gate reports its own reason: `b1`, `b2`, `b3`, `b4_occupancy`, `b4_itpm`, `b4_otpm`. So "429 by reason" attributes each reject to the gate that produced it. (Per-tenant RPM keeps reporting via the existing `tenant_rate_limited_total`.)
- **`admission_occupancy_tokens{model}`** (Σw) / **`admission_budget_tokens{model}`** (effective `admit_fraction × admit_budget_tokens`) / **`admission_inflight_requests{model}`** — live gauges the occupancy controller publishes on every admit, grow, and release, so `occupancy / budget` tracks real utilization.

### How it's wired
- The occupancy `Controller` gains an **observer hook**, set **only on the global controller** — deliberately *not* on the per-key one, so gauge cardinality stays bounded by model (a per-key gauge would be unbounded).
- The handler gates fire a reject callback wired to the counter. The gauge source (the observer) and the counter source (the callback) are what the tests assert.

### Return-code contract
Already standardized across the gates from RL-2..RL-5 and unchanged here: **400 `input_too_long`** (B1), **429 `concurrency_limit_exceeded` + Retry-After** (B2/B3), **429 `rate_limit_exceeded` + Retry-After** (B4), 503 only post-queue. The new counter labels these consistently.

### Docs
New Mintlify page `observability/admission-control-metrics` with the metric reference and Grafana panel PromQL (occupancy-vs-budget, 429-by-reason, shed rate, per-key throttling), plus a short "reading the signals together" guide. Added to the nav.

### Design note on cardinality
I intentionally **did not** add a per-key occupancy gauge (the ticket lists "per-key occupancy-share usage"): keyed by API key it's unbounded-cardinality, a Prometheus anti-pattern. Per-key *rejections* are still visible via `admission_rejections_total{reason="b4_occupancy"}`. Happy to add a bounded per-key view (e.g. top-N) if you want it.

### Tests
- `test/api/admission_metrics_test.go`: drives **each** gate to reject and asserts it fired the correct reason (`b1/b2/b3/b4_occupancy/b4_itpm/b4_otpm`).
- `test/admission/`: the occupancy observer tracks Σw/count/budget across the §0 load scenario (admit → grow → release), matching `Occupancy()`.
- `test/metrics/`: the new methods added to the no-panic smoke test (label-count/registration contract).

Full suite passes under `-race`; gofmt + lint clean; `docs.json` validated.
