### PR TITLE
Fix critical-review findings across the admission gates (RL-1..RL-7)

### DIFF
--- a/internal/admission/controller.go
+++ b/internal/admission/controller.go
@@ -19,6 +19,7 @@ package admission
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -80,6 +81,10 @@ type modelState struct {
 	budget      int64         // last effective budget seen, for the utilization gauge
 	maxInflight int           // last max_inflight seen, for the concurrency gauge
 	notify      chan struct{} // closed-and-replaced on every release to wake parked waiters
+
+	// lastActive is the unix-nano time of the last stateFor lookup, read by
+	// SweepIdle. Atomic so the janitor never contends with the hot path.
+	lastActive atomic.Int64
 }
 
 func (c *Controller) stateFor(model string) *modelState {
@@ -90,7 +95,36 @@ func (c *Controller) stateFor(model string) *modelState {
 		s = &modelState{c: c, model: model, notify: make(chan struct{})}
 		c.models[model] = s
 	}
+	s.lastActive.Store(time.Now().UnixNano())
 	return s
+}
+
+// SweepIdle evicts model states that hold nothing in flight and have not been
+// touched for at least ttl, returning how many were removed. This bounds the
+// map on controllers whose key space is unbounded (the per-key occupancy
+// controller is keyed by key×model, and keys can be minted programmatically);
+// an evicted state carries no history — its counters were zero — so recreation
+// on the next request is indistinguishable from having kept it.
+//
+// stateFor stamps lastActive before the caller reserves, so with a ttl of
+// minutes a state can only be evicted long after any admit/release cycle that
+// references it; a reservation still in flight keeps sumW/count non-zero and
+// is never evicted.
+func (c *Controller) SweepIdle(ttl time.Duration) int {
+	cutoff := time.Now().Add(-ttl).UnixNano()
+	removed := 0
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for model, s := range c.models {
+		s.mu.Lock()
+		idle := s.sumW == 0 && s.count == 0 && s.lastActive.Load() < cutoff
+		s.mu.Unlock()
+		if idle {
+			delete(c.models, model)
+			removed++
+		}
+	}
+	return removed
 }
 
 // Admit reserves footprint tokens for a request against model's budget, parking

--- a/internal/api/handlers-admin.go
+++ b/internal/api/handlers-admin.go
@@ -221,21 +221,28 @@ type apiKeyEntryRequest struct {
 	ExpiresAt     string      `json:"expires_at"`
 	AllowedModels []string    `json:"allowed_models"`
 	Quota         apiKeyQuota `json:"quota"`
+
+	// MaxOccupancyShare is the key-level serverless occupancy share, matching
+	// the static auth.yaml field of the same name (it sits outside quota there
+	// too, because it is a fraction of the replica pool's admit budget rather
+	// than a per-minute rate). Valid range (0, 1]; 0 means unset.
+	MaxOccupancyShare float64 `json:"max_occupancy_share"`
 }
 
 // upsertAPIKeyRequest is the JSON body for PUT /admin/api-keys/:id.
 // Wraps a key entry plus the registry version. The :id URL parameter is the
 // source of truth for the entry ID; any id field in the body is ignored.
 type upsertAPIKeyRequest struct {
-	Version       string      `json:"version"`
-	KeyHash       string      `json:"key_hash"`
-	KeyPreview    string      `json:"key_preview"`
-	Owner         string      `json:"owner"`
-	Name          string      `json:"name"`
-	Enabled       bool        `json:"enabled"`
-	ExpiresAt     string      `json:"expires_at"`
-	AllowedModels []string    `json:"allowed_models"`
-	Quota         apiKeyQuota `json:"quota"`
+	Version           string      `json:"version"`
+	KeyHash           string      `json:"key_hash"`
+	KeyPreview        string      `json:"key_preview"`
+	Owner             string      `json:"owner"`
+	Name              string      `json:"name"`
+	Enabled           bool        `json:"enabled"`
+	ExpiresAt         string      `json:"expires_at"`
+	AllowedModels     []string    `json:"allowed_models"`
+	Quota             apiKeyQuota `json:"quota"`
+	MaxOccupancyShare float64     `json:"max_occupancy_share"` // see apiKeyEntryRequest
 }
 
 // replaceAPIKeysRequest is the JSON body for POST /admin/api-keys/replace.
@@ -251,12 +258,15 @@ type replaceAPIKeysRequest struct {
 func (k apiKeyEntryRequest) toEntry() (auth.DynamicKeyEntry, error) {
 	expiresAt, err := auth.ParseExpiresAtRFC3339(k.ExpiresAt)
 	if err != nil {
-		return auth.DynamicKeyEntry{}, err
+		return auth.DynamicKeyEntry{}, fmt.Errorf("invalid expires_at: %w", err)
 	}
 	quota, err := k.Quota.Validate(fmt.Sprintf("key %q", k.ID))
 	if err != nil {
 		return auth.DynamicKeyEntry{}, err
 	}
+	// The share sits at the key level, like the static auth.yaml field; the
+	// registry validates its (0,1] range on every mutation.
+	quota.MaxOccupancyShare = k.MaxOccupancyShare
 	return auth.DynamicKeyEntry{
 		ID:            k.ID,
 		KeyHash:       k.KeyHash,
@@ -268,6 +278,35 @@ func (k apiKeyEntryRequest) toEntry() (auth.DynamicKeyEntry, error) {
 		AllowedModels: k.AllowedModels,
 		Quota:         quota,
 	}, nil
+}
+
+// validateKeyAdmission runs the cross-config admission invariants for one
+// dynamic key against the policies currently in force — the same check static
+// auth.yaml keys get at startup and on reload: on a serverless policy the key
+// can reach, its ITPM bucket must hold at least one maximum-size prompt, or
+// the cap silently shrinks the model's usable context for that key (the D16
+// failure). Rejecting at upsert keeps the misconfiguration out of the
+// registry, mirroring how the static loader refuses to start on it.
+func (h *Handlers) validateKeyAdmission(e auth.DynamicKeyEntry) error {
+	if h.executor == nil {
+		return nil
+	}
+	check := func(p *policy.Policy) error {
+		if p == nil || !p.IsServerless() || p.MaxInputTokens <= 0 || !p.GovernsAnyOf(e.AllowedModels) {
+			return nil
+		}
+		label := fmt.Sprintf("key %q on serverless models %v", e.ID, p.Models)
+		return auth.ValidateITPMCoversMaxInput(label, e.Quota.InputTokensPerMinute, p.MaxInputTokens)
+	}
+	if err := check(h.executor.GetPolicy()); err != nil {
+		return err
+	}
+	for _, p := range h.executor.GetNamedPolicies() {
+		if err := check(p); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // writeRegistryError translates a registry-level error into a 409 (stale
@@ -301,18 +340,23 @@ func (h *Handlers) UpsertAPIKey(c *gin.Context) {
 		return
 	}
 	entry, err := apiKeyEntryRequest{
-		ID:            c.Param("id"),
-		KeyHash:       req.KeyHash,
-		KeyPreview:    req.KeyPreview,
-		Owner:         req.Owner,
-		Name:          req.Name,
-		Enabled:       req.Enabled,
-		ExpiresAt:     req.ExpiresAt,
-		AllowedModels: req.AllowedModels,
-		Quota:         req.Quota,
+		ID:                c.Param("id"),
+		KeyHash:           req.KeyHash,
+		KeyPreview:        req.KeyPreview,
+		Owner:             req.Owner,
+		Name:              req.Name,
+		Enabled:           req.Enabled,
+		ExpiresAt:         req.ExpiresAt,
+		AllowedModels:     req.AllowedModels,
+		Quota:             req.Quota,
+		MaxOccupancyShare: req.MaxOccupancyShare,
 	}.toEntry()
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid expires_at: " + err.Error()})
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := h.validateKeyAdmission(entry); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 	if err := h.keyRegistry.Upsert(req.Version, entry); err != nil {
@@ -370,7 +414,11 @@ func (h *Handlers) ReplaceAPIKeys(c *gin.Context) {
 	for i, k := range req.Keys {
 		entry, err := k.toEntry()
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("key[%d]: invalid expires_at: %s", i, err)})
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("key[%d]: %s", i, err)})
+			return
+		}
+		if err := h.validateKeyAdmission(entry); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("key[%d]: %s", i, err)})
 			return
 		}
 		entries = append(entries, entry)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1037,8 +1037,15 @@ func (h *Handlers) writeSuccessResponse(c *gin.Context, pending *domain.PendingR
 
 	if resp.Body == nil {
 		c.Writer.Write(resp.RawBytes) //nolint:errcheck
-		h.chargeOutputRate(c, req, m, resp.Usage.CompletionTokens)
-		h.learnInputTokens(req, pending, resp.Usage.PromptTokens, usageExact)
+		// A provider-fallback response is served off-box on the operator's cloud
+		// account: it consumes no local decode throughput (so no OTPM charge) and
+		// its prompt_tokens come from the PROVIDER's tokenizer, which must not
+		// teach the local model's learned ratio. The occupancy reservation was
+		// already released when the processor handed the request to the provider.
+		if !resp.ServedByProvider() {
+			h.chargeOutputRate(c, req, m, resp.Usage.CompletionTokens)
+			h.learnInputTokens(req, pending, resp.Usage.PromptTokens, usageExact)
+		}
 		return
 	}
 	// Streaming: flush SSE chunks as they arrive so tokens appear progressively.

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -572,14 +572,36 @@ func (h *Handlers) enforceRequestCaps(c *gin.Context, req *domain.ChatRequest, i
 	return true
 }
 
+// healthyReplicas returns the pool-size multiplier for a model's per-replica
+// admission limits: the number of healthy replicas serving it, floored at 1.
+// The floor matters twice — with no healthy-count source wired (tests) the
+// limits apply as-is, and with zero healthy replicas a bare multiply would zero
+// the budget, which the controller reads as "no budget limit" (gate off) at the
+// exact moment the pool is most fragile.
+func (h *Handlers) healthyReplicas(model string) int {
+	if h.healthyAgentCount == nil {
+		return 1
+	}
+	if n := h.healthyAgentCount(model); n > 1 {
+		return n
+	}
+	return 1
+}
+
 // enforceOccupancyBudget applies the KV-occupancy admit budget: the request is
 // admitted only while the model's weighted in-flight token sum plus this
 // request's footprint stays within admit_fraction × admit_budget_tokens, and the
-// in-flight request count stays within max_inflight. The footprint is the input
-// estimate plus the declared max_tokens (reserved up front); an undeclared
-// request reserves only its input and grows as output streams. Over budget, it
-// parks briefly for capacity to free, then returns 429 concurrency_limit_exceeded
-// with Retry-After.
+// in-flight request count stays within max_inflight. admit_budget_tokens and
+// max_inflight are PER-REPLICA numbers (what the benchmark certifies for one
+// box), so both are scaled by the number of healthy replicas serving the model —
+// the pool's capacity is the sum of its replicas', and holding N replicas to one
+// replica's budget would waste (N−1)/N of it. Routing spreads the admitted load;
+// a single hot replica is handled by the per-agent exclude_if gates and the B3
+// shed, not by this counter. The footprint is the input estimate plus the
+// declared max_tokens (reserved up front); an undeclared request reserves only
+// its input and grows as output streams. Over budget, it parks briefly for
+// capacity to free, then returns 429 concurrency_limit_exceeded with
+// Retry-After.
 //
 // It returns the reservations (which the caller MUST release exactly once on
 // every exit path) and whether the request was admitted. An empty slice with
@@ -610,9 +632,16 @@ func (h *Handlers) enforceOccupancyBudget(c *gin.Context, req *domain.ChatReques
 	footprint := inputEstimate + declared
 	grows := declared == 0
 
+	// Scale the per-replica limits to the live pool size. Recomputed per request,
+	// so the budget tracks replicas joining/leaving; a shrink only affects new
+	// admissions (existing reservations release their recorded weight unchanged).
+	replicas := h.healthyReplicas(req.Model)
+	poolBudget := pol.AdmitBudgetTokens * replicas
+	poolInflight := pol.MaxInflight * replicas
+
 	// Global occupancy budget (all replicas).
 	if h.admission != nil && (pol.AdmitBudgetTokens > 0 || pol.MaxInflight > 0) {
-		res := h.admission.Admit(c.Request.Context(), req.Model, footprint, grows, pol.AdmitBudgetTokens, pol.MaxInflight)
+		res := h.admission.Admit(c.Request.Context(), req.Model, footprint, grows, poolBudget, poolInflight)
 		if res == nil {
 			h.fireAdmissionReject("b2", req.Model)
 			c.Header("Retry-After", "1")
@@ -624,13 +653,15 @@ func (h *Handlers) enforceOccupancyBudget(c *gin.Context, req *domain.ChatReques
 	}
 
 	// Per-key occupancy share (serverless replicas only): the key's in-flight
-	// footprint must stay within max_occupancy_share × admit_budget_tokens. This
-	// is anti-abuse fairness, not box safety (the global budget above is), so the
+	// footprint must stay within max_occupancy_share × the pool budget — the same
+	// replica-scaled pool the global gate admits against, so a share keeps meaning
+	// "this fraction of what the pool can hold" as replicas come and go. This is
+	// anti-abuse fairness, not box safety (the global budget above is), so the
 	// shares are intentionally oversubscribed and no admit fraction is applied.
 	if pol.IsServerless() && pol.AdmitBudgetTokens > 0 && h.keyAdmission != nil {
 		if share := quotaLimitsFromContext(c).MaxOccupancyShare; share > 0 {
 			_, keyID, _ := callerIDs(c)
-			budget := int(share * float64(pol.AdmitBudgetTokens))
+			budget := int(share * float64(poolBudget))
 			res := h.keyAdmission.Admit(c.Request.Context(), keyID+"\x00"+req.Model, footprint, grows, budget, 0)
 			if res == nil {
 				rs.Release() // hand back the global reservation already taken

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -399,22 +399,32 @@ func (h *Handlers) Passthrough(c *gin.Context) {
 	if !h.authorizeModel(c, req.Model) {
 		return
 	}
-	if !h.enforceRequestCaps(c, &req) {
-		return
-	}
-	if !h.enforceShedPressure(c, req.Model) {
-		return
-	}
-	// Compute the input estimate once, so the value reserved for occupancy and the
-	// value the reservation is later trued up against are identical — the shared
-	// estimator can shift between calls as other requests complete.
+	// Compute the input estimate once, so B1, the occupancy reservation, the
+	// per-key ITPM charge, and the later true-up all see the same value — the
+	// shared estimator can shift between calls as other requests complete.
 	inputEstimate := h.estimatePromptTokens(&req)
-	// Occupancy admit budget. The reservation is released on every exit path
-	// below via this single defer — success, error, timeout, disconnect, and the
-	// daily-budget reject that may follow — so a slot is never leaked.
-	reservation, admitted := h.enforceOccupancyBudget(c, &req, inputEstimate)
-	if !admitted {
-		return
+	// /v1/messages/count_tokens is a stateless tokenizer lookup: it holds no KV
+	// cache and generates nothing, so charging it against the occupancy budget or
+	// the per-key token buckets would double-bill every client that counts before
+	// it sends (Claude Code does exactly that). It skips the admission gates and
+	// is guarded by the per-key RPM flood limit alone.
+	countOnly := path == "/v1/messages/count_tokens"
+	var reservation admission.Reservations
+	if !countOnly {
+		if !h.enforceRequestCaps(c, &req, inputEstimate) {
+			return
+		}
+		if !h.enforceShedPressure(c, req.Model) {
+			return
+		}
+		// Occupancy admit budget. The reservation is released on every exit path
+		// below via this single defer — success, error, timeout, disconnect, and
+		// the daily-budget reject that may follow — so a slot is never leaked.
+		var admitted bool
+		reservation, admitted = h.enforceOccupancyBudget(c, &req, inputEstimate)
+		if !admitted {
+			return
+		}
 	}
 	defer reservation.Release()
 
@@ -430,7 +440,7 @@ func (h *Handlers) Passthrough(c *gin.Context) {
 	// Per-key rate caps before the daily-budget charge: reserveInputBudget
 	// deducts daily tokens, so charging it only after the cheaper per-minute
 	// caps means a rate rejection never spends a tenant's daily budget.
-	if !h.enforcePerKeyRates(c, &req, m) {
+	if !countOnly && !h.enforcePerKeyRates(c, &req, m, inputEstimate) {
 		return
 	}
 	if !h.reserveInputBudget(c, &req, m) {
@@ -515,21 +525,24 @@ func (h *Handlers) authorizeModel(c *gin.Context, model string) bool {
 }
 
 // enforceRequestCaps applies the per-request hard caps declared by the model's
-// policy: the estimated text prompt must fit max_input_tokens and the image
-// count must fit images_max. The two caps are complementary — the token cap
-// bounds text, the image cap bounds image payloads (an image's token cost is
-// invisible to the len/4 estimator, so counting images is how they are bounded;
-// a textless image request therefore passes the token cap by design and is held
-// only by images_max). Each caps the worst single request and returns a clean
-// 400 input_too_long; aggregate load safety is a separate concern handled at
-// admission, not here.
+// policy: the estimated prompt must fit max_input_tokens and the image count
+// must fit images_max. inputTokens is the same admission estimate B2 reserves
+// (learned per-model ratio over message text, system prompt, and tool
+// definitions), so B1's accuracy tracks B2's and an Anthropic system prompt or
+// a tool-schema payload cannot slip under the cap. The two caps are
+// complementary — the token cap bounds text, the image cap bounds image
+// payloads (an image's token cost is invisible to a byte estimator, so counting
+// images is how they are bounded; a textless image request therefore passes the
+// token cap by design and is held only by images_max). Each caps the worst
+// single request and returns a clean 400 input_too_long; aggregate load safety
+// is a separate concern handled at admission, not here.
 //
 // The governing policy is resolved per model (named override, else the global
 // policy). A cap of zero is "unset" and disables that check, so the gate is a
 // no-op when both caps are zero, or when no policy/executor is configured
 // (tests). This gate never inspects or clamps max_tokens: the router applies no
 // output limit anywhere.
-func (h *Handlers) enforceRequestCaps(c *gin.Context, req *domain.ChatRequest) bool {
+func (h *Handlers) enforceRequestCaps(c *gin.Context, req *domain.ChatRequest, inputTokens int) bool {
 	if h.executor == nil {
 		return true
 	}
@@ -538,7 +551,6 @@ func (h *Handlers) enforceRequestCaps(c *gin.Context, req *domain.ChatRequest) b
 		return true
 	}
 	if pol.MaxInputTokens > 0 {
-		inputTokens := domain.EstimateTokens(domain.GetMessageSlice(req.Messages))
 		if inputTokens > pol.MaxInputTokens {
 			h.fireAdmissionReject("b1", req.Model)
 			writeRouterError(c, http.StatusBadRequest, domain.ErrCodeInputTooLong,
@@ -586,6 +598,12 @@ func (h *Handlers) enforceOccupancyBudget(c *gin.Context, req *domain.ChatReques
 	declared := req.MaxCompletionTokens
 	if declared == 0 {
 		declared = req.MaxTokens
+	}
+	// A negative max_tokens is not a declaration (the backend will reject or
+	// ignore it) — treat it as undeclared rather than letting it shrink the
+	// charged footprint below the input estimate.
+	if declared < 0 {
+		declared = 0
 	}
 	// Declared output is reserved up front; an undeclared request reserves only
 	// its input and grows live (grows=true), matching how the processor meters it.
@@ -641,12 +659,14 @@ func quotaLimitsFromContext(c *gin.Context) auth.QuotaLimits {
 }
 
 // enforcePerKeyRates applies the serverless per-key token-per-minute caps: it
-// charges the request's estimated input tokens against the key's ITPM bucket and
-// rejects when the key's OTPM bucket is already drained by recent output. Both
-// deny with 429 rate_limit_exceeded + Retry-After. Inert unless the request
-// lands on a serverless policy and the key declares the cap. Returns false after
-// writing the 429.
-func (h *Handlers) enforcePerKeyRates(c *gin.Context, req *domain.ChatRequest, m reqMeta) bool {
+// charges the request's estimated input tokens (inputEstimate — the same value
+// the occupancy budget reserved, so the two gates never disagree about a
+// request's size) against the key's ITPM bucket and rejects when the key's OTPM
+// bucket is already drained by recent output. Both deny with 429
+// rate_limit_exceeded + Retry-After. Inert unless the request lands on a
+// serverless policy and the key declares the cap. Returns false after writing
+// the 429.
+func (h *Handlers) enforcePerKeyRates(c *gin.Context, req *domain.ChatRequest, m reqMeta, inputEstimate int) bool {
 	if h.minuteLimiter == nil || h.executor == nil {
 		return true
 	}
@@ -662,7 +682,7 @@ func (h *Handlers) enforcePerKeyRates(c *gin.Context, req *domain.ChatRequest, m
 		return h.writeRateLimited(c, m, req.Model, "output token rate exceeded, please retry")
 	}
 	if limits.InputTokensPerMinute > 0 {
-		if !h.minuteLimiter.AllowInputTokens(m.keyID, req.Model, limits.InputTokensPerMinute, h.estimatePromptTokens(req)) {
+		if !h.minuteLimiter.AllowInputTokens(m.keyID, req.Model, limits.InputTokensPerMinute, inputEstimate) {
 			h.fireAdmissionReject("b4_itpm", req.Model)
 			return h.writeRateLimited(c, m, req.Model, "input token rate exceeded, please retry")
 		}

--- a/internal/auth/dynamic_key.go
+++ b/internal/auth/dynamic_key.go
@@ -128,6 +128,16 @@ func normalizeAndValidateKeyEntry(e *DynamicKeyEntry) error {
 	if e.Name == "" {
 		return fmt.Errorf("auth: key entry %q: name must not be empty", e.ID)
 	}
+	// The same quota bounds static keys get at load (static_key.go): a share
+	// outside (0,1] would let one key out-reserve the whole pool, and negative
+	// per-minute buckets are nonsense. Enforced here — not only in the HTTP
+	// DTO layer — so every registry mutation path is covered.
+	if err := validateOccupancyShare(fmt.Sprintf("key entry %q", e.ID), e.Quota.MaxOccupancyShare); err != nil {
+		return err
+	}
+	if e.Quota.InputTokensPerMinute < 0 || e.Quota.OutputTokensPerMinute < 0 {
+		return fmt.Errorf("auth: key entry %q: input_tokens_per_minute and output_tokens_per_minute must be >= 0", e.ID)
+	}
 	return nil
 }
 

--- a/internal/auth/dynamic_key.go
+++ b/internal/auth/dynamic_key.go
@@ -128,10 +128,11 @@ func normalizeAndValidateKeyEntry(e *DynamicKeyEntry) error {
 	if e.Name == "" {
 		return fmt.Errorf("auth: key entry %q: name must not be empty", e.ID)
 	}
-	// The same quota bounds static keys get at load (static_key.go): a share
-	// outside (0,1] would let one key out-reserve the whole pool, and negative
-	// per-minute buckets are nonsense. Enforced here — not only in the HTTP
-	// DTO layer — so every registry mutation path is covered.
+	// The same quota bounds static keys get at load (static_key.go):
+	// max_occupancy_share must be in (0, 1] (0 means unset) — above 1 one key
+	// could out-reserve the whole pool — and negative per-minute buckets are
+	// nonsense. Enforced here — not only in the HTTP DTO layer — so every
+	// registry mutation path is covered.
 	if err := validateOccupancyShare(fmt.Sprintf("key entry %q", e.ID), e.Quota.MaxOccupancyShare); err != nil {
 		return err
 	}

--- a/internal/auth/quota.go
+++ b/internal/auth/quota.go
@@ -289,9 +289,13 @@ func (l *InMemoryLimiter) Reset() {
 //
 //   - An RPM bucket is evicted once it is full: a token bucket refills within
 //     its burst window, so a full bucket is byte-for-byte what a fresh one
-//     would be — eviction is lossless. (A racing request that just loaded the
-//     limiter can at worst have one deduction land on the orphaned bucket,
-//     forgiving a single request per sweep — negligible against any real rate.)
+//     would be. Eviction is lossless up to one race: requests that loaded the
+//     limiter pointer in the instant the sweep deleted it deduct on the
+//     orphaned bucket, and those deductions are forgotten when the next
+//     request recreates a fresh one. That forgives at most the requests in
+//     flight during that microsecond window, once per sweep — negligible
+//     against any per-minute rate, and not worth the tombstone protocol that
+//     true losslessness would need.
 //   - A daily bucket is evicted once its UTC day has passed: rollover discards
 //     its counter anyway, so a stale-day bucket is dead weight.
 func (l *InMemoryLimiter) SweepIdle() int {

--- a/internal/auth/quota.go
+++ b/internal/auth/quota.go
@@ -6,6 +6,7 @@ package auth
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -281,6 +282,44 @@ func (l *InMemoryLimiter) Reset() {
 	l.dailyBuckets.Range(func(k, _ any) bool { l.dailyBuckets.Delete(k); return true })
 }
 
+// SweepIdle evicts limiter state that carries no information, bounding memory
+// when keys are minted programmatically (every key×model pair that ever made a
+// request otherwise lives in these maps until restart). Returns how many
+// entries were removed.
+//
+//   - An RPM bucket is evicted once it is full: a token bucket refills within
+//     its burst window, so a full bucket is byte-for-byte what a fresh one
+//     would be — eviction is lossless. (A racing request that just loaded the
+//     limiter can at worst have one deduction land on the orphaned bucket,
+//     forgiving a single request per sweep — negligible against any real rate.)
+//   - A daily bucket is evicted once its UTC day has passed: rollover discards
+//     its counter anyway, so a stale-day bucket is dead weight.
+func (l *InMemoryLimiter) SweepIdle() int {
+	removed := 0
+	now := time.Now()
+	l.rpmLimiters.Range(func(k, v any) bool {
+		lim := v.(*rate.Limiter)
+		if lim.TokensAt(now) >= float64(lim.Burst()) {
+			l.rpmLimiters.Delete(k)
+			removed++
+		}
+		return true
+	})
+	today := utcDayIndex()
+	l.dailyBuckets.Range(func(k, v any) bool {
+		b := v.(*dailyBucket)
+		b.mu.Lock()
+		stale := b.day != today
+		b.mu.Unlock()
+		if stale {
+			l.dailyBuckets.Delete(k)
+			removed++
+		}
+		return true
+	})
+	return removed
+}
+
 // utcDayIndex returns the number of complete UTC days since the Unix epoch.
 func utcDayIndex() int {
 	return int(time.Now().UTC().Unix() / 86400)
@@ -419,6 +458,25 @@ func (l *BadgerLimiter) Flush() {
 		b.mu.Unlock()
 		return true
 	})
+}
+
+// SweepIdle extends the in-memory sweep with the badger preload gates: an
+// initOnce entry is keyed by "(bucket):(dayIndex)" and exists to make the
+// first touch of a bucket on a given day re-read the persisted counter. Past
+// days' gates will never fire again, so they are dropped. Today's gates (and
+// today's daily buckets) are deliberately kept — deleting either would let a
+// bucket reappear without its persisted used-count.
+func (l *BadgerLimiter) SweepIdle() int {
+	removed := l.InMemoryLimiter.SweepIdle()
+	todaySuffix := fmt.Sprintf(":%d", utcDayIndex())
+	l.initOnce.Range(func(k, _ any) bool {
+		if !strings.HasSuffix(k.(string), todaySuffix) {
+			l.initOnce.Delete(k)
+			removed++
+		}
+		return true
+	})
+	return removed
 }
 
 // StartPeriodicFlush launches a background goroutine that calls Flush on every

--- a/internal/auth/rate_minute.go
+++ b/internal/auth/rate_minute.go
@@ -89,3 +89,21 @@ func (l *MinuteRateLimiter) ChargeOutputTokens(tenantID, model string, limit, co
 func (l *MinuteRateLimiter) Reset() {
 	l.buckets.Range(func(k, _ any) bool { l.buckets.Delete(k); return true })
 }
+
+// SweepIdle evicts every full bucket, bounding memory when keys are minted
+// programmatically. A tokens-per-minute bucket refills completely within one
+// minute of idleness, so a full bucket is identical to the fresh one the next
+// request would create — eviction is lossless. Returns how many were removed.
+func (l *MinuteRateLimiter) SweepIdle() int {
+	removed := 0
+	now := time.Now()
+	l.buckets.Range(func(k, v any) bool {
+		lim := v.(*rate.Limiter)
+		if lim.TokensAt(now) >= float64(lim.Burst()) {
+			l.buckets.Delete(k)
+			removed++
+		}
+		return true
+	})
+	return removed
+}

--- a/internal/domain/openai.go
+++ b/internal/domain/openai.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 // New ChatRequest that covers text generation, vision and audio, with extensible fields for future use.
@@ -128,6 +129,20 @@ type ChatResponse struct {
 	HttpHeaders http.Header   `json:"-"`
 	RawBytes    []byte        `json:"-"`
 	Body        io.ReadCloser `json:"-"` // non-nil for streaming responses; handler must Close
+}
+
+// providerProcessedByPrefix marks a response served by a cloud provider
+// fallback (OpenAI/Anthropic) instead of a local agent; the providers stamp
+// ProcessedBy as "provider:<engine>".
+const providerProcessedByPrefix = "provider:"
+
+// ServedByProvider reports whether this response came from the cloud provider
+// fallback rather than a local GPU replica. Provider tokens are billed to the
+// operator's provider account and consume no local KV cache or decode
+// throughput, so the local-resource accounting (OTPM charge, estimator
+// learning) must skip them.
+func (r *ChatResponse) ServedByProvider() bool {
+	return strings.HasPrefix(r.ProcessedBy, providerProcessedByPrefix)
 }
 
 // Choice represents a response choice

--- a/internal/domain/openai.go
+++ b/internal/domain/openai.go
@@ -30,6 +30,14 @@ type ChatRequest struct {
 	// string or an array of text content blocks; SystemText decodes both.
 	System json.RawMessage `json:"system,omitempty"`
 
+	// Tools holds the tool/function definitions (both dialects use "tools").
+	// Kept raw: the router never interprets them, but their JSON is rendered
+	// into the prompt by the backend and tokenized like any other input, so the
+	// token estimator must count these bytes — an agentic request can carry tens
+	// of KB of tool schemas that would otherwise be invisible to admission and
+	// would poison the learned tokens-per-byte ratio.
+	Tools json.RawMessage `json:"tools,omitempty"`
+
 	// Sampling & Controls
 	Temperature float64 `json:"temperature,omitempty"`
 	TopP        float64 `json:"top_p,omitempty"`
@@ -82,7 +90,7 @@ func (m *ChatCompletionMessage) UnmarshalJSON(data []byte) error {
 }
 
 type ContentPart struct {
-	Type       string            `json:"type"`                  // "text", "image_url", "input_audio"
+	Type       string            `json:"type"`                  // "text", "image_url", "input_audio" (OpenAI); "image" (Anthropic)
 	Text       string            `json:"text,omitempty"`        // If type is "text"
 	ImageURL   *ImageURLConfig   `json:"image_url,omitempty"`   // If type is "image_url"
 	InputAudio *InputAudioConfig `json:"input_audio,omitempty"` // If type is "input_audio"
@@ -134,6 +142,39 @@ type Usage struct {
 	PromptTokens     int `json:"prompt_tokens"`
 	CompletionTokens int `json:"completion_tokens"`
 	TotalTokens      int `json:"total_tokens"`
+}
+
+// UnmarshalJSON also accepts the Anthropic usage shape (input_tokens /
+// output_tokens, no total), normalizing it into the OpenAI-named fields.
+// Without this, every /v1/messages response parsed as zero usage, so the
+// Anthropic dialect silently escaped output metering, OTPM charging, the
+// occupancy true-up, and estimator learning. Marshaling is unchanged (OpenAI
+// names); TotalTokens is synthesized when absent so "usage present" checks
+// (TotalTokens > 0) hold for both dialects.
+func (u *Usage) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+		TotalTokens      int `json:"total_tokens"`
+		InputTokens      int `json:"input_tokens"`
+		OutputTokens     int `json:"output_tokens"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	u.PromptTokens = raw.PromptTokens
+	u.CompletionTokens = raw.CompletionTokens
+	u.TotalTokens = raw.TotalTokens
+	if u.PromptTokens == 0 && raw.InputTokens > 0 {
+		u.PromptTokens = raw.InputTokens
+	}
+	if u.CompletionTokens == 0 && raw.OutputTokens > 0 {
+		u.CompletionTokens = raw.OutputTokens
+	}
+	if u.TotalTokens == 0 && u.PromptTokens+u.CompletionTokens > 0 {
+		u.TotalTokens = u.PromptTokens + u.CompletionTokens
+	}
+	return nil
 }
 
 type Message struct {
@@ -229,26 +270,32 @@ func SystemText(req *ChatRequest) string {
 }
 
 // PromptTextBytes returns the total bytes of estimable prompt text — message
-// content plus any top-level system prompt — and the message count, for the
-// token estimator. Non-text content (images) is not byte-estimable and is
-// bounded separately by the per-request image cap.
+// content, any top-level system prompt, and the raw tool-definition JSON — and
+// the message count, for the token estimator. Tool schemas are rendered into
+// the prompt and tokenized by the backend, so counting their bytes keeps the
+// estimate (and the learned ratio, which divides exact prompt_tokens by these
+// bytes) honest for agentic requests. Non-text content (images) is not
+// byte-estimable and is bounded separately by the per-request image cap.
 func PromptTextBytes(req *ChatRequest) (textBytes, messageCount int) {
 	for _, s := range GetMessageSlice(req.Messages) {
 		textBytes += len(s)
 	}
 	textBytes += len(SystemText(req))
+	textBytes += len(req.Tools)
 	return textBytes, len(req.Messages)
 }
 
-// CountImages returns the number of image_url content parts across all messages.
-// Text-only messages (Content is a plain string) carry no images and contribute
-// zero. Used by the per-request image cap; audio and text parts are ignored.
+// CountImages returns the number of image content parts across all messages:
+// OpenAI "image_url" parts and Anthropic "image" blocks (the /v1/messages
+// dialect) both count, so neither dialect can slip images past the per-request
+// image cap. Text-only messages (Content is a plain string) carry no images and
+// contribute zero. Audio and text parts are ignored.
 func CountImages(messages []ChatCompletionMessage) int {
 	count := 0
 	for _, message := range messages {
 		if parts, ok := message.Content.([]ContentPart); ok {
 			for _, part := range parts {
-				if part.Type == "image_url" {
+				if part.Type == "image_url" || part.Type == "image" {
 					count++
 				}
 			}

--- a/internal/policy/types.go
+++ b/internal/policy/types.go
@@ -40,9 +40,13 @@ type Policy struct {
 	MaxInputTokens int `yaml:"max_input_tokens" json:"max_input_tokens,omitempty"`
 	// ImagesMax rejects any single request carrying more images than this.
 	ImagesMax int `yaml:"images_max" json:"images_max,omitempty"`
-	// AdmitBudgetTokens caps the total KV-cache tokens in flight per replica.
+	// AdmitBudgetTokens caps the KV-cache tokens in flight PER REPLICA (the
+	// benchmark-certified capacity of one box). At enforcement the router scales
+	// it by the number of healthy replicas serving the model, so the pool's
+	// admit budget grows and shrinks with the pool.
 	AdmitBudgetTokens int `yaml:"admit_budget_tokens" json:"admit_budget_tokens,omitempty"`
-	// MaxInflight caps the number of concurrent in-flight requests per replica.
+	// MaxInflight caps concurrent in-flight requests PER REPLICA; scaled by the
+	// healthy replica count at enforcement, like AdmitBudgetTokens.
 	MaxInflight int `yaml:"max_inflight" json:"max_inflight,omitempty"`
 	// ShedIf holds front-door shed thresholds; only kv_cache_utilization and
 	// waiting_requests are accepted (see knownShedIfFields in loader.go).

--- a/internal/policy/types.go
+++ b/internal/policy/types.go
@@ -3,7 +3,11 @@
 
 package policy
 
-import "hivenet_router/internal/domain"
+import (
+	"slices"
+
+	"hivenet_router/internal/domain"
+)
 
 // Policy is the top-level routing configuration loaded from a YAML file.
 // It contains a primary routing step, an optional fallback chain, and an
@@ -76,6 +80,24 @@ func (p *Policy) EffectiveMode() PolicyMode {
 // IsServerless reports whether per-key caps apply to this policy's replicas.
 func (p *Policy) IsServerless() bool {
 	return p.EffectiveMode() == ModeServerless
+}
+
+// GovernsAnyOf reports whether a key restricted to keyModels could send a
+// request governed by this policy: a key with no model list may call any
+// model, a policy with no Models list is the global policy governing every
+// model, and otherwise the two sets must intersect. Shared by the startup,
+// reload, and admin-API cross-config validations so they agree on
+// reachability.
+func (p *Policy) GovernsAnyOf(keyModels []string) bool {
+	if len(keyModels) == 0 || len(p.Models) == 0 {
+		return true
+	}
+	for _, km := range keyModels {
+		if slices.Contains(p.Models, km) {
+			return true
+		}
+	}
+	return false
 }
 
 // FallbackProvider configures a last-resort closed-source model provider.

--- a/internal/router/admission_config.go
+++ b/internal/router/admission_config.go
@@ -5,7 +5,6 @@ package router
 
 import (
 	"fmt"
-	"slices"
 
 	"hivenet_router/internal/auth"
 	"hivenet_router/internal/config"
@@ -88,17 +87,28 @@ func ValidateAdmissionInvariants(policies []*policy.Policy, keys []auth.APIKeyEn
 }
 
 // keyReachesPolicy reports whether a key could send a request to a model
-// governed by policy p. A key with no Models list may call any model; a policy
-// with no Models list governs every model (the global/default policy). Otherwise
-// the two model sets must intersect.
+// governed by policy p (see policy.GovernsAnyOf — shared with the admin API's
+// per-key validation so the two checks cannot drift).
 func keyReachesPolicy(k auth.APIKeyEntry, p *policy.Policy) bool {
-	if len(k.Models) == 0 || len(p.Models) == 0 {
-		return true
+	return p.GovernsAnyOf(k.Models)
+}
+
+// dynamicKeysAsEntries converts the dynamic registry's current keys into the
+// config-shaped entries ValidateAdmissionInvariants consumes, carrying the one
+// field the cross-config check reads (the flat ITPM bucket) plus the model
+// list and a label. Nil registry (static/no-auth mode) yields nil.
+func dynamicKeysAsEntries(reg *auth.DynamicKeyProvider) []auth.APIKeyEntry {
+	if reg == nil {
+		return nil
 	}
-	for _, km := range k.Models {
-		if slices.Contains(p.Models, km) {
-			return true
-		}
+	keys := reg.ListKeys()
+	out := make([]auth.APIKeyEntry, 0, len(keys))
+	for _, e := range keys {
+		out = append(out, auth.APIKeyEntry{
+			KeyPreview: e.ID,
+			Models:     e.AllowedModels,
+			Quota:      auth.QuotaConfig{InputTokensPerMinute: e.Quota.InputTokensPerMinute},
+		})
 	}
-	return false
+	return out
 }

--- a/internal/router/processor.go
+++ b/internal/router/processor.go
@@ -265,6 +265,16 @@ func (p *RequestProcessor) dispatchWithPolicy(pending *domain.PendingRequest) {
 					pending.Error <- domain.NewRouterError(domain.ErrCodeRequestTimeout, "Request timed out before provider fallback could be attempted", domain.SourceRouter)
 					return
 				}
+				// The provider serves this request off-box on the operator's cloud
+				// account: it consumes no local KV cache, so free the occupancy
+				// reservation now rather than holding phantom load against the local
+				// budget for the provider call's duration — fallback fires exactly
+				// when the local pool is degraded and admission headroom matters
+				// most. Release is idempotent, so the handler's own deferred release
+				// stays safe.
+				if pending.Reservation != nil {
+					pending.Reservation.Release()
+				}
 				if resp, provErr := p.tryProviderFallback(pending, fp.Engine, fp.Model); provErr == nil {
 					p.metrics.RequestRouted("cloud", fp.Engine, fp.Model, pending.TenantID)
 					p.metrics.PolicyProviderFallbackRouted(pending.Request.Model)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -146,6 +146,14 @@ type Router struct {
 	// take effect immediately.
 	minuteLimiter *auth.MinuteRateLimiter
 
+	// occupancy is the global KV-occupancy admit controller (B2), keyed per
+	// model; keyAdmission is the per-key occupancy-share controller (B4), keyed
+	// per key×model. Both live on the Router so the periodic GC can sweep their
+	// idle state (keyAdmission's key space is unbounded when keys are minted
+	// programmatically).
+	occupancy    *admission.Controller
+	keyAdmission *admission.Controller
+
 	// keyRegistry is the mutable in-memory API key registry (dynamic mode).
 	// Nil when running in static-key or no-auth mode — guards against SIGHUP reload.
 	keyRegistry *auth.DynamicKeyProvider
@@ -295,7 +303,11 @@ func New(cfg *config.Config) (*Router, error) {
 		adminAuth:            auth.NewAtomicProvider(adminProv),
 		rateLimiter:          rateLimiter,
 		minuteLimiter:        auth.NewMinuteRateLimiter(),
-		keyRegistry:          keyRegistry,
+		occupancy:            admission.NewController(cfg.AdmitFraction, cfg.AdmitParkTimeout),
+		// Per-key occupancy share: no admit fraction (it is fairness, not box
+		// safety) and no parking (a per-key breach is denied immediately).
+		keyAdmission: admission.NewController(1.0, 0),
+		keyRegistry:  keyRegistry,
 	}
 	// Refresh tenant quota gauges whenever the dynamic key registry changes,
 	// so the Grafana $tenant_id variable picks up newly-pushed keys without
@@ -480,6 +492,9 @@ func (r *Router) Start() error {
 			if n := r.sessionManager.CleanupExpired(); n > 0 {
 				log.Infof("Session GC: removed %d expired sessions", n)
 			}
+			if n := r.sweepLimiterState(); n > 0 {
+				log.Infof("Limiter GC: removed %d idle rate/occupancy entries", n)
+			}
 		}
 	}()
 
@@ -550,8 +565,7 @@ func (r *Router) startHTTPServer() {
 		resetMetrics = r.counters.ResetAll
 	}
 	// The global occupancy controller publishes its Σw/count/budget as gauges.
-	occupancy := admission.NewController(r.cfg.AdmitFraction, r.cfg.AdmitParkTimeout)
-	occupancy.SetObserver(r.metrics.SetAdmissionOccupancy)
+	r.occupancy.SetObserver(r.metrics.SetAdmissionOccupancy)
 	handlers := api.NewHandlers(
 		r.storage,
 		r,
@@ -576,11 +590,9 @@ func (r *Router) startHTTPServer() {
 		resetMetrics,
 		r.agents.CountHealthyByModel,
 		r, // RegistrationFeed — Router implements SubscribeRegistration
-		occupancy,
+		r.occupancy,
 		r.EnginePressureForModel,
-		// Per-key occupancy share: no admit fraction (it is fairness, not box
-		// safety) and no parking (a per-key breach is denied immediately).
-		admission.NewController(1.0, 0),
+		r.keyAdmission,
 		r.minuteLimiter,
 		r.metrics.AdmissionRejected,
 		tokenizer.NewEstimator(),
@@ -612,6 +624,39 @@ func (r *Router) validateProviderPolicy(p *policy.Policy) error {
 		}
 	}
 	return nil
+}
+
+// limiterIdleTTL is how long an occupancy state must sit empty before the GC
+// evicts it. Rate buckets need no TTL (a full bucket is evicted on sight —
+// refill makes that lossless); occupancy states are evicted only once idle
+// well past any admit/park/release cycle.
+const limiterIdleTTL = 15 * time.Minute
+
+// sweepLimiterState evicts idle per-key/per-tenant limiter state — RPM and
+// daily buckets, ITPM/OTPM buckets, and occupancy counters — returning the
+// total removed. These maps grow with every key×model pair that ever made a
+// request and are never cleared by traffic, so without this sweep memory grows
+// without bound when keys are minted programmatically (e.g. one key per user
+// session via the admin API). Eviction is lossless: buckets are only removed
+// when full (identical to the fresh bucket the next request creates) or when
+// their UTC day has passed, and occupancy states only when they hold nothing
+// in flight. Usage history is unaffected — cumulative token accounting lives
+// in the Prometheus tenant counters and the audit log, never in these maps.
+func (r *Router) sweepLimiterState() int {
+	n := 0
+	if s, ok := r.rateLimiter.(interface{ SweepIdle() int }); ok {
+		n += s.SweepIdle()
+	}
+	if r.minuteLimiter != nil {
+		n += r.minuteLimiter.SweepIdle()
+	}
+	if r.occupancy != nil {
+		n += r.occupancy.SweepIdle(limiterIdleTTL)
+	}
+	if r.keyAdmission != nil {
+		n += r.keyAdmission.SweepIdle(limiterIdleTTL)
+	}
+	return n
 }
 
 // checkAdmissionAgainstKeys validates proposed policies against the API keys

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -615,16 +615,19 @@ func (r *Router) validateProviderPolicy(p *policy.Policy) error {
 }
 
 // checkAdmissionAgainstKeys validates proposed policies against the API keys
-// currently on disk, so a reload cannot introduce a serverless key whose input
-// bucket no longer covers a model's context. A key-read error is logged and
-// treated as "cannot validate" (nil) so an unrelated auth.yaml problem does not
-// block a policy reload — that problem surfaces on the auth reload path instead.
+// currently in force — the static list on disk plus the dynamic registry — so a
+// policy reload cannot introduce a serverless key whose input bucket no longer
+// covers a model's context, regardless of how that key was created. A key-read
+// error is logged and treated as "cannot validate" (nil) so an unrelated
+// auth.yaml problem does not block a policy reload — that problem surfaces on
+// the auth reload path instead.
 func (r *Router) checkAdmissionAgainstKeys(policies []*policy.Policy) error {
 	keys, err := admissionKeysFromConfig(r.cfg)
 	if err != nil {
 		log.Warnf("SIGHUP: could not read auth keys to validate policy admission invariants (%v) — skipping that check", err)
-		return nil
+		keys = nil
 	}
+	keys = append(keys, dynamicKeysAsEntries(r.keyRegistry)...)
 	return ValidateAdmissionInvariants(policies, keys)
 }
 

--- a/internal/router/stream_token_meter.go
+++ b/internal/router/stream_token_meter.go
@@ -23,9 +23,10 @@ import (
 // by the time the totals are known, so the caller deducts from the budget and
 // records metrics after the stream completes — it cannot reject mid-stream.
 //
-// Anthropic (/v1/messages) events use a different shape (usage in message_start /
-// message_delta); until that is parsed, those streams fall back to the
-// text-accumulation estimate, which omits the system prompt and non-text blocks.
+// Anthropic (/v1/messages) events are parsed too: message_start carries the
+// exact input_tokens, message_delta the cumulative output_tokens, and
+// content_block_delta the streamed text — so both dialects yield exact usage
+// and live content observation.
 //
 // Exported so the streaming token metering can be tested in isolation.
 type SSETokenMeter struct {
@@ -92,8 +93,12 @@ func (m *SSETokenMeter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// sseChunk is the minimal subset of an OpenAI streaming chunk we need: the
-// per-delta text content and the optional terminal usage object.
+// sseChunk is the minimal union of the OpenAI and Anthropic streaming shapes we
+// need. OpenAI: per-delta text under choices[].delta.content plus the optional
+// terminal usage object. Anthropic: message_start carries usage.input_tokens
+// under "message", content_block_delta carries text under a top-level "delta",
+// and message_delta carries the cumulative usage.output_tokens at the top
+// level. The field sets do not collide, so one struct decodes both dialects.
 type sseChunk struct {
 	Choices []struct {
 		Delta struct {
@@ -103,7 +108,18 @@ type sseChunk struct {
 	Usage *struct {
 		PromptTokens     int `json:"prompt_tokens"`
 		CompletionTokens int `json:"completion_tokens"`
+		InputTokens      int `json:"input_tokens"`  // Anthropic message_delta (rare here)
+		OutputTokens     int `json:"output_tokens"` // Anthropic message_delta (cumulative)
 	} `json:"usage"`
+	Message *struct { // Anthropic message_start
+		Usage struct {
+			InputTokens  int `json:"input_tokens"`
+			OutputTokens int `json:"output_tokens"`
+		} `json:"usage"`
+	} `json:"message"`
+	Delta *struct { // Anthropic content_block_delta
+		Text string `json:"text"`
+	} `json:"delta"`
 }
 
 func (m *SSETokenMeter) parseLine(line []byte) {
@@ -124,19 +140,43 @@ func (m *SSETokenMeter) parseLine(line []byte) {
 		m.usagePrompt = c.Usage.PromptTokens
 		m.usageCompletion = c.Usage.CompletionTokens
 	}
+	// Anthropic message_start: the exact prompt count arrives before any output.
+	// Usage is exact from this point; output_tokens is refined by message_delta.
+	if c.Message != nil && c.Message.Usage.InputTokens > 0 {
+		m.haveUsage = true
+		m.usagePrompt = c.Message.Usage.InputTokens
+		if c.Message.Usage.OutputTokens > m.usageCompletion {
+			m.usageCompletion = c.Message.Usage.OutputTokens
+		}
+	}
+	// Anthropic message_delta: cumulative output count; the last one wins.
+	if c.Usage != nil && c.Usage.OutputTokens > m.usageCompletion {
+		m.usageCompletion = c.Usage.OutputTokens
+		if c.Usage.InputTokens > 0 {
+			m.usagePrompt = c.Usage.InputTokens
+			m.haveUsage = true
+		}
+	}
+	deliver := func(text string) {
+		m.content.WriteString(text)
+		if m.onContent != nil {
+			m.onContent(text)
+		}
+	}
 	for _, ch := range c.Choices {
 		if ch.Delta.Content != "" {
-			m.content.WriteString(ch.Delta.Content)
-			if m.onContent != nil {
-				m.onContent(ch.Delta.Content)
-			}
+			deliver(ch.Delta.Content)
 		}
+	}
+	if c.Delta != nil && c.Delta.Text != "" {
+		deliver(c.Delta.Text)
 	}
 }
 
 // HaveUsage reports whether the stream carried an exact backend usage object
-// (stream_options.include_usage). When false, Tokens returns an estimate, which
-// the caller must not feed back into the learned estimator.
+// (OpenAI stream_options.include_usage, or Anthropic message_start/
+// message_delta). When false, Tokens returns an estimate, which the caller must
+// not feed back into the learned estimator.
 func (m *SSETokenMeter) HaveUsage() bool { return m.haveUsage }
 
 // Tokens returns the prompt and completion token counts for the stream. It

--- a/internal/tokenizer/estimator.go
+++ b/internal/tokenizer/estimator.go
@@ -28,6 +28,16 @@ const (
 	// perMessageOverhead floors the estimate so a textless (image/tool-only)
 	// request is still counted rather than measured as zero.
 	perMessageOverhead = 4
+
+	// minRatio / maxRatio bound each observed sample before it is folded into
+	// the EWMA. Real tokenizers sit between ~20 bytes/token (padding-heavy
+	// prompts) and ~1 byte/token (dense CJK / emoji text); a sample outside
+	// that band means the reported prompt_tokens covered content the byte
+	// count cannot see (a dialect quirk, unmodeled request fields) and would
+	// poison the model's ratio — clamping keeps one bad sample from swinging
+	// every subsequent estimate.
+	minRatio = 1.0 / 20.0
+	maxRatio = 1.0
 )
 
 // Estimator holds a per-model tokens-per-byte ratio, learned from backend usage.
@@ -85,6 +95,12 @@ func (e *Estimator) Observe(model string, textBytes, promptTokens int) {
 		return
 	}
 	obs := float64(promptTokens) / float64(textBytes)
+	if obs < minRatio {
+		obs = minRatio
+	}
+	if obs > maxRatio {
+		obs = maxRatio
+	}
 	e.mu.Lock()
 	cur, ok := e.ratio[model]
 	if !ok {

--- a/test/admission/controller_test.go
+++ b/test/admission/controller_test.go
@@ -431,3 +431,63 @@ func TestConcurrentAdmitReleaseNoLeak(t *testing.T) {
 		t.Fatalf("after all admit/release pairs, occupancy must be zero; got sumW=%d count=%d", sumW, count)
 	}
 }
+
+// TestSweepIdle_EvictsEmptyIdleState verifies the janitor removes a model
+// state once it holds nothing in flight and its idle TTL has passed, and that
+// a later request simply recreates it from zero.
+func TestSweepIdle_EvictsEmptyIdleState(t *testing.T) {
+	c := admission.NewController(1.0, 0)
+	res := c.Admit(context.Background(), model, 100, false, 1000, 0)
+	if res == nil {
+		t.Fatal("admit failed")
+	}
+	res.Release()
+
+	// A negative TTL puts the cutoff in the future, so the just-released empty
+	// state is idle-eligible immediately.
+	if n := c.SweepIdle(-time.Second); n != 1 {
+		t.Fatalf("SweepIdle removed %d states, want 1", n)
+	}
+	if sumW, count := c.Occupancy(model); sumW != 0 || count != 0 {
+		t.Errorf("evicted model must read zero occupancy, got sumW=%d count=%d", sumW, count)
+	}
+	// The next request recreates the state transparently.
+	res2 := c.Admit(context.Background(), model, 100, false, 1000, 0)
+	if res2 == nil {
+		t.Fatal("admit after eviction failed")
+	}
+	res2.Release()
+}
+
+// TestSweepIdle_KeepsInFlightState verifies a state with a live reservation is
+// never evicted, regardless of TTL.
+func TestSweepIdle_KeepsInFlightState(t *testing.T) {
+	c := admission.NewController(1.0, 0)
+	res := c.Admit(context.Background(), model, 100, false, 1000, 0)
+	if res == nil {
+		t.Fatal("admit failed")
+	}
+	defer res.Release()
+
+	if n := c.SweepIdle(-time.Second); n != 0 {
+		t.Fatalf("SweepIdle removed %d states while a reservation is in flight, want 0", n)
+	}
+	if sumW, count := c.Occupancy(model); sumW != 100 || count != 1 {
+		t.Errorf("in-flight occupancy must survive the sweep, got sumW=%d count=%d", sumW, count)
+	}
+}
+
+// TestSweepIdle_RespectsTTL verifies a recently-touched empty state is kept
+// until the TTL elapses.
+func TestSweepIdle_RespectsTTL(t *testing.T) {
+	c := admission.NewController(1.0, 0)
+	res := c.Admit(context.Background(), model, 100, false, 1000, 0)
+	if res == nil {
+		t.Fatal("admit failed")
+	}
+	res.Release()
+
+	if n := c.SweepIdle(time.Hour); n != 0 {
+		t.Fatalf("SweepIdle removed %d states inside the TTL, want 0", n)
+	}
+}

--- a/test/api/admin_keys_admission_test.go
+++ b/test/api/admin_keys_admission_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+// Black-box tests for the dynamic admin key API's admission validation: a key
+// created at runtime must pass the same cross-config invariants a static
+// auth.yaml key passes at startup — an ITPM bucket that cannot hold one
+// maximum-size prompt on a reachable serverless model is rejected with 400
+// instead of silently capping that key's usable context.
+package api_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"hivenet_router/internal/api"
+	"hivenet_router/internal/auth"
+	"hivenet_router/internal/policy"
+
+	"github.com/gin-gonic/gin"
+)
+
+// newAdminKeyHandlers builds a Handlers with a live dynamic key registry and
+// an executor serving pol for every model.
+func newAdminKeyHandlers(pol *policy.Policy) (*api.Handlers, *auth.DynamicKeyProvider) {
+	exec := policy.NewExecutor(nil, nil, pol, 0, 0)
+	reg := auth.NewDynamicKeyProvider()
+	h := api.NewHandlers(
+		nil, nil, nil, time.Second,
+		exec, nil, nil, nil,
+		nil, nil, nil, nil, reg, nil, nil, nil,
+		nil, nil, nil, nil,
+		nil, nil,
+	)
+	return h, reg
+}
+
+// upsertKey drives PUT /admin/api-keys/k1 with the given quota block and
+// occupancy share, returning the recorder.
+func upsertKey(t *testing.T, h *api.Handlers, quota map[string]any, share float64) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{
+		"version":             "v1",
+		"key_hash":            strings.Repeat("ab", 32),
+		"owner":               "acme",
+		"name":                "runtime-key",
+		"enabled":             true,
+		"quota":               quota,
+		"max_occupancy_share": share,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPut, "/admin/api-keys/k1", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Params = gin.Params{{Key: "id", Value: "k1"}}
+	h.UpsertAPIKey(c)
+	return w
+}
+
+// TestAdminUpsert_RejectsITPMBelowMaxInput verifies the D16 invariant at key
+// creation: on a serverless policy with max_input_tokens 262144, a key whose
+// ITPM bucket is smaller can never admit a full-context prompt, so the upsert
+// is a 400 — the runtime analogue of the static loader refusing to start.
+func TestAdminUpsert_RejectsITPMBelowMaxInput(t *testing.T) {
+	h, reg := newAdminKeyHandlers(&policy.Policy{Mode: policy.ModeServerless, MaxInputTokens: 262144})
+	w := upsertKey(t, h, map[string]any{"input_tokens_per_minute": 100000}, 0)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for an ITPM below max_input_tokens, got %d (%s)", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "input_tokens_per_minute") {
+		t.Errorf("error must name the violated invariant, got %s", w.Body.String())
+	}
+	if _, n := reg.Version(); n != 0 {
+		t.Errorf("a rejected key must not enter the registry, got %d keys", n)
+	}
+}
+
+// TestAdminUpsert_AcceptsCompliantKey verifies a key whose ITPM covers the
+// context and whose share is in range is accepted, and that the share reaches
+// the stored quota (the value the B4 occupancy gate reads).
+func TestAdminUpsert_AcceptsCompliantKey(t *testing.T) {
+	h, reg := newAdminKeyHandlers(&policy.Policy{Mode: policy.ModeServerless, MaxInputTokens: 262144})
+	w := upsertKey(t, h, map[string]any{"input_tokens_per_minute": 524288}, 0.4)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for a compliant key, got %d (%s)", w.Code, w.Body.String())
+	}
+	key, ok := reg.GetKey("k1")
+	if !ok {
+		t.Fatal("key not found after upsert")
+	}
+	if key.Quota.MaxOccupancyShare != 0.4 {
+		t.Errorf("max_occupancy_share = %v, want 0.4", key.Quota.MaxOccupancyShare)
+	}
+}
+
+// TestAdminUpsert_RejectsShareOutOfRange verifies the registry's share bound
+// surfaces as a 400 through the admin API.
+func TestAdminUpsert_RejectsShareOutOfRange(t *testing.T) {
+	h, _ := newAdminKeyHandlers(&policy.Policy{})
+	w := upsertKey(t, h, map[string]any{}, 1.5)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for share 1.5, got %d (%s)", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "max_occupancy_share") {
+		t.Errorf("error must name max_occupancy_share, got %s", w.Body.String())
+	}
+}
+
+// TestAdminUpsert_ReservedPolicySkipsITPMCheck verifies the cross-check only
+// binds where per-key caps apply: on a reserved-mode policy a small ITPM is
+// accepted (B4 is inert there).
+func TestAdminUpsert_ReservedPolicySkipsITPMCheck(t *testing.T) {
+	h, _ := newAdminKeyHandlers(&policy.Policy{Mode: policy.ModeReserved, MaxInputTokens: 262144})
+	w := upsertKey(t, h, map[string]any{"input_tokens_per_minute": 100000}, 0)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 on a reserved policy, got %d (%s)", w.Code, w.Body.String())
+	}
+}

--- a/test/api/b2_occupancy_test.go
+++ b/test/api/b2_occupancy_test.go
@@ -305,3 +305,61 @@ func TestB2_NegativeMaxTokens_TreatedAsUndeclared(t *testing.T) {
 		t.Fatalf("reservation must be released; got sumW=%d count=%d", sumW, count)
 	}
 }
+
+// newB2PoolHandlers is newB2Handlers plus a healthy-replica count source, so
+// the per-replica budget scaling is live.
+func newB2PoolHandlers(q chan *domain.PendingRequest, ctrl *admission.Controller, global *policy.Policy, healthy func(string) int) *api.Handlers {
+	exec := policy.NewExecutor(nil, nil, global, 0, 0)
+	return api.NewHandlers(
+		nil, nil, q, time.Second,
+		exec, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, healthy, nil,
+		ctrl, nil, nil, nil,
+		nil, nil,
+	)
+}
+
+// TestB2_BudgetScalesWithHealthyReplicas verifies admit_budget_tokens is a
+// per-replica number: with two healthy replicas the pool admits a footprint
+// that one replica's budget alone would reject.
+func TestB2_BudgetScalesWithHealthyReplicas(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	ctrl := admission.NewController(1.0, 0)
+	// footprint = input(4) + declared(80) = 84: over one replica's budget of 50,
+	// under the two-replica pool budget of 100.
+	h := newB2PoolHandlers(q, ctrl, &policy.Policy{AdmitBudgetTokens: 50}, func(string) int { return 2 })
+	c, w := newCtx("/v1/chat/completions", b2Body(80))
+
+	done := make(chan struct{})
+	go func() { h.Passthrough(c); close(done) }()
+	select {
+	case pending := <-q:
+		pending.Response <- &domain.ChatResponse{RawBytes: []byte(`{"ok":true}`)}
+	case <-time.After(time.Second):
+		t.Fatal("a footprint within the scaled pool budget must be admitted")
+	}
+	<-done
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+// TestB2_ZeroHealthyReplicas_KeepsGateEnforcing verifies the replica multiplier
+// floors at 1: with zero healthy replicas the budget must not multiply to zero,
+// which the controller would read as "no budget limit" — disabling the gate at
+// the exact moment the pool has no capacity at all.
+func TestB2_ZeroHealthyReplicas_KeepsGateEnforcing(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	ctrl := admission.NewController(1.0, 0)
+	h := newB2PoolHandlers(q, ctrl, &policy.Policy{AdmitBudgetTokens: 50}, func(string) int { return 0 })
+	c, w := newCtx("/v1/chat/completions", b2Body(100)) // footprint 104 > 50
+
+	h.Passthrough(c)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 with zero healthy replicas, got %d", w.Code)
+	}
+	if len(q) != 0 {
+		t.Errorf("an over-budget request must not be queued, depth=%d", len(q))
+	}
+}

--- a/test/api/b2_occupancy_test.go
+++ b/test/api/b2_occupancy_test.go
@@ -278,3 +278,30 @@ func TestB2_MaxInflightBackstop(t *testing.T) {
 		t.Fatalf("occupancy must be zero once the first request completes; got sumW=%d count=%d", sumW, count)
 	}
 }
+
+// TestB2_NegativeMaxTokens_TreatedAsUndeclared verifies a negative max_tokens
+// cannot shrink the charged footprint: it is treated as undeclared (input-only
+// reservation that grows with output), not subtracted from the input estimate.
+func TestB2_NegativeMaxTokens_TreatedAsUndeclared(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	ctrl := admission.NewController(1.0, 0)
+	h := newB2Handlers(q, ctrl, &policy.Policy{AdmitBudgetTokens: 1_000_000}, time.Second)
+	body := []byte(`{"model":"gemma","messages":[{"role":"user","content":"hi"}],"max_tokens":-1000}`)
+	c, _ := newCtx("/v1/chat/completions", body)
+
+	done := make(chan struct{})
+	go func() { h.Passthrough(c); close(done) }()
+	select {
+	case pending := <-q:
+		if sumW, count := ctrl.Occupancy(b2Model); sumW <= 0 || count != 1 {
+			t.Errorf("footprint must be the positive input estimate, not input-1000; got sumW=%d count=%d", sumW, count)
+		}
+		pending.Response <- &domain.ChatResponse{RawBytes: []byte(`{"ok":true}`)}
+	case <-time.After(time.Second):
+		t.Fatal("request was not enqueued")
+	}
+	<-done
+	if sumW, count := ctrl.Occupancy(b2Model); sumW != 0 || count != 0 {
+		t.Fatalf("reservation must be released; got sumW=%d count=%d", sumW, count)
+	}
+}

--- a/test/api/b4_perkey_test.go
+++ b/test/api/b4_perkey_test.go
@@ -183,3 +183,31 @@ func runAndRespond(t *testing.T, h *api.Handlers, c *gin.Context, q chan *domain
 	}
 	<-done
 }
+
+// TestB4_ShareScalesWithHealthyReplicas verifies the per-key occupancy share is
+// a fraction of the replica-scaled pool budget — the same pool the global gate
+// admits against — so a key's slice grows with the pool. With two healthy
+// replicas, share 0.40 of a 1000-per-replica budget is 800; a 504-token
+// footprint that a single replica's share (400) would deny must pass.
+func TestB4_ShareScalesWithHealthyReplicas(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	exec := policy.NewExecutor(nil, nil, serverless(1000), 0, 0)
+	h := api.NewHandlers(
+		nil, nil, q, time.Second,
+		exec, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil,
+		func(string) int { return 2 }, nil,
+		admission.NewController(1.0, 0),
+		nil,
+		admission.NewController(1.0, 0),
+		auth.NewMinuteRateLimiter(),
+		nil, nil,
+	)
+	c, w := newCtx("/v1/chat/completions", b2Body(500)) // footprint 504
+	withKey(c, auth.QuotaLimits{MaxOccupancyShare: 0.40})
+
+	runAndRespond(t, h, c, q)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 within the scaled per-key share, got %d", w.Code)
+	}
+}

--- a/test/api/count_tokens_test.go
+++ b/test/api/count_tokens_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+// Black-box tests for two admission-gate boundaries: the B1 input cap must see
+// the same estimate B2 reserves (learned estimator over message text + the
+// Anthropic top-level system prompt), and /v1/messages/count_tokens — a
+// stateless tokenizer lookup that holds no KV cache — must skip the admission
+// gates rather than be billed like an inference call.
+package api_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"hivenet_router/internal/admission"
+	"hivenet_router/internal/api"
+	"hivenet_router/internal/domain"
+	"hivenet_router/internal/policy"
+	"hivenet_router/internal/tokenizer"
+)
+
+// newEstimatorHandlers builds a Handlers with a live estimator and admission
+// controller, whose executor serves global for every model.
+func newEstimatorHandlers(q chan *domain.PendingRequest, ctrl *admission.Controller, global *policy.Policy) *api.Handlers {
+	exec := policy.NewExecutor(nil, nil, global, 0, 0)
+	return api.NewHandlers(
+		nil, nil, q, time.Second,
+		exec, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil, nil,
+		ctrl, nil, nil, nil,
+		nil, tokenizer.NewEstimator(),
+	)
+}
+
+// TestB1_AnthropicSystemPromptCounted verifies the B1 input cap uses the same
+// estimate the occupancy budget reserves — including the Anthropic top-level
+// system prompt. Before the fix B1 counted only message text with the legacy
+// len/4 heuristic, so a huge system prompt sailed under max_input_tokens.
+func TestB1_AnthropicSystemPromptCounted(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	h := newEstimatorHandlers(q, admission.NewController(1.0, 0), &policy.Policy{MaxInputTokens: 10})
+	// The message alone estimates to ~5 tokens (under the cap of 10); the 400-
+	// byte system prompt pushes the estimate far over it.
+	body := []byte(`{"model":"m","system":"` + strings.Repeat("s", 400) + `","messages":[{"role":"user","content":"hi"}]}`)
+	c, w := newCtx("/v1/messages", body)
+
+	h.Passthrough(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for an over-cap system prompt, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), string(domain.ErrCodeInputTooLong)) {
+		t.Errorf("expected %q in body, got %s", domain.ErrCodeInputTooLong, w.Body.String())
+	}
+	if len(q) != 0 {
+		t.Errorf("a rejected request must not be queued, depth=%d", len(q))
+	}
+}
+
+// TestCountTokens_SkipsAdmissionGates verifies /v1/messages/count_tokens passes
+// the B1 input cap and the B2 occupancy budget untouched: it is a stateless
+// tokenizer lookup, so a prompt too big to INFER must still be countable, and
+// counting must never hold KV budget or burn per-key token buckets (a client
+// that counts before sending would otherwise be billed twice per request).
+func TestCountTokens_SkipsAdmissionGates(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	ctrl := admission.NewController(1.0, 0)
+	// Caps tight enough that the same body on /v1/messages would be rejected
+	// by B1 (input over 10) and B2 (footprint over budget 5) outright.
+	h := newEstimatorHandlers(q, ctrl, &policy.Policy{MaxInputTokens: 10, AdmitBudgetTokens: 5})
+	body := []byte(`{"model":"m","messages":[{"role":"user","content":"` + strings.Repeat("a", 400) + `"}]}`)
+	c, w := newCtx("/v1/messages/count_tokens", body)
+
+	done := make(chan struct{})
+	go func() { h.Passthrough(c); close(done) }()
+	select {
+	case pending := <-q:
+		if sumW, count := ctrl.Occupancy("m"); sumW != 0 || count != 0 {
+			t.Errorf("count_tokens must hold no occupancy reservation; got sumW=%d count=%d", sumW, count)
+		}
+		pending.Response <- &domain.ChatResponse{RawBytes: []byte(`{"input_tokens":123}`)}
+	case <-time.After(time.Second):
+		t.Fatal("count_tokens request was not enqueued — an admission gate rejected it")
+	}
+	<-done
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body %s)", w.Code, w.Body.String())
+	}
+}

--- a/test/api/token_learning_test.go
+++ b/test/api/token_learning_test.go
@@ -176,3 +176,37 @@ func TestDoesNotLearnFromStreamingEstimate(t *testing.T) {
 		t.Errorf("streaming estimate (non-exact) must not move the ratio: %.4f → %.4f", before, after)
 	}
 }
+
+// TestDoesNotLearnFromProviderFallback verifies a response served by the cloud
+// provider fallback is skipped for estimator learning: its prompt_tokens come
+// from the provider's tokenizer, not the local model's, so folding them in
+// would mis-calibrate the local ratio (and its output is likewise not local
+// decode work — the same guard skips the OTPM charge).
+func TestDoesNotLearnFromProviderFallback(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	est := tokenizer.NewEstimator()
+	h := learnHandler(q, est)
+	before := est.RatioFor(b2Model)
+	c, w := newCtx("/v1/chat/completions", b2Body(0))
+
+	done := make(chan struct{})
+	go func() { h.Passthrough(c); close(done) }()
+	select {
+	case pending := <-q:
+		pending.Response <- &domain.ChatResponse{
+			RawBytes:    []byte(`{"ok":true}`),
+			ProcessedBy: "provider:openai",
+			Usage:       domain.Usage{PromptTokens: 50, CompletionTokens: 5, TotalTokens: 55},
+		}
+	case <-time.After(time.Second):
+		t.Fatal("request was not enqueued")
+	}
+	<-done
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if after := est.RatioFor(b2Model); after != before {
+		t.Errorf("provider-served usage must not teach the local ratio: %.4f -> %.4f", before, after)
+	}
+}

--- a/test/auth/dynamic_key_admission_test.go
+++ b/test/auth/dynamic_key_admission_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+// Tests that the dynamic key registry enforces the same per-key quota bounds
+// static auth.yaml keys get at load: max_occupancy_share in (0,1] and
+// non-negative per-minute buckets. Enforced at the registry (not only the
+// admin HTTP layer), so every mutation path is covered.
+package auth_test
+
+import (
+	"strings"
+	"testing"
+
+	"hivenet_router/internal/auth"
+)
+
+const testHash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+func dynEntry(share float64, itpm int) auth.DynamicKeyEntry {
+	return auth.DynamicKeyEntry{
+		ID:         "k1",
+		KeyHash:    testHash,
+		KeyPreview: "sk-...k1",
+		Owner:      "acme",
+		Name:       "test-key",
+		Enabled:    true,
+		Quota: auth.QuotaLimits{
+			MaxOccupancyShare:    share,
+			InputTokensPerMinute: itpm,
+		},
+	}
+}
+
+// TestDynamicUpsert_RejectsShareOutOfRange verifies a share above 1 (one key
+// out-reserving the whole pool) or negative is rejected at Upsert, exactly as
+// the static loader rejects it.
+func TestDynamicUpsert_RejectsShareOutOfRange(t *testing.T) {
+	for _, share := range []float64{1.5, -0.1} {
+		reg := auth.NewDynamicKeyProvider()
+		err := reg.Upsert("v1", dynEntry(share, 0))
+		if err == nil || !strings.Contains(err.Error(), "max_occupancy_share") {
+			t.Errorf("share %v: expected max_occupancy_share error, got %v", share, err)
+		}
+	}
+}
+
+// TestDynamicUpsert_RejectsNegativeBuckets verifies negative ITPM/OTPM values
+// are rejected like the static QuotaConfig validation does.
+func TestDynamicUpsert_RejectsNegativeBuckets(t *testing.T) {
+	reg := auth.NewDynamicKeyProvider()
+	if err := reg.Upsert("v1", dynEntry(0, -5)); err == nil {
+		t.Error("expected an error for a negative input_tokens_per_minute")
+	}
+}
+
+// TestDynamicUpsert_ValidShareAccepted verifies an in-range share is stored and
+// surfaces on the key entry (the value the B4 occupancy gate reads at request
+// time).
+func TestDynamicUpsert_ValidShareAccepted(t *testing.T) {
+	reg := auth.NewDynamicKeyProvider()
+	if err := reg.Upsert("v1", dynEntry(0.4, 600000)); err != nil {
+		t.Fatalf("valid entry rejected: %v", err)
+	}
+	got, ok := reg.GetKey("k1")
+	if !ok {
+		t.Fatal("key not found after upsert")
+	}
+	if got.Quota.MaxOccupancyShare != 0.4 || got.Quota.InputTokensPerMinute != 600000 {
+		t.Errorf("quota not carried: %+v", got.Quota)
+	}
+}
+
+// TestDynamicReplaceAll_ValidatesEveryEntry verifies ReplaceAll runs the same
+// validation per entry and applies nothing on failure.
+func TestDynamicReplaceAll_ValidatesEveryEntry(t *testing.T) {
+	reg := auth.NewDynamicKeyProvider()
+	bad := dynEntry(2.0, 0)
+	bad.ID = "k2"
+	bad.KeyHash = strings.Repeat("ab", 32)
+	if err := reg.ReplaceAll("v1", []auth.DynamicKeyEntry{dynEntry(0.4, 0), bad}); err == nil {
+		t.Fatal("expected ReplaceAll to reject the out-of-range share")
+	}
+	if _, n := reg.Version(); n != 0 {
+		t.Errorf("a failed ReplaceAll must apply nothing, registry has %d keys", n)
+	}
+}

--- a/test/auth/sweep_test.go
+++ b/test/auth/sweep_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+// Tests for the limiter janitor: idle bucket state is evicted losslessly (a
+// full token bucket is identical to the fresh one the next request creates),
+// while any bucket still carrying information — a partial drain — survives.
+package auth_test
+
+import (
+	"testing"
+	"time"
+
+	"hivenet_router/internal/auth"
+)
+
+// TestSweepIdle_KeepsDrainedRPMBucket verifies a bucket that still remembers a
+// recent deduction is not evicted — evicting it would forgive the drain.
+func TestSweepIdle_KeepsDrainedRPMBucket(t *testing.T) {
+	l := auth.NewInMemoryLimiter()
+	// rpm 60 → refilling the deducted token takes a full second; the bucket is
+	// still partial when the sweep runs immediately after.
+	if allowed, _, _ := l.AllowRequest("t1", "", 60); !allowed {
+		t.Fatal("first request must pass")
+	}
+	if n := l.SweepIdle(); n != 0 {
+		t.Fatalf("SweepIdle evicted %d entries, want 0 (bucket is mid-refill)", n)
+	}
+}
+
+// TestSweepIdle_EvictsRefilledRPMBucket verifies a bucket is evicted once it
+// has refilled to full — at that point it is byte-for-byte the bucket a fresh
+// request would create, so eviction is lossless.
+func TestSweepIdle_EvictsRefilledRPMBucket(t *testing.T) {
+	l := auth.NewInMemoryLimiter()
+	// rpm 60000 → the single deducted token refills in ~1ms.
+	if allowed, _, _ := l.AllowRequest("t1", "", 60000); !allowed {
+		t.Fatal("first request must pass")
+	}
+	time.Sleep(50 * time.Millisecond)
+	if n := l.SweepIdle(); n != 1 {
+		t.Fatalf("SweepIdle evicted %d entries, want 1 (bucket refilled to full)", n)
+	}
+	// The next request recreates the bucket transparently.
+	if allowed, _, _ := l.AllowRequest("t1", "", 60000); !allowed {
+		t.Error("request after eviction must pass on a fresh bucket")
+	}
+}
+
+// TestSweepIdle_KeepsTodaysDailyBucket verifies the daily counter for the
+// current UTC day survives the sweep — it holds the tenant's used count and
+// must live until its day rolls over.
+func TestSweepIdle_KeepsTodaysDailyBucket(t *testing.T) {
+	l := auth.NewInMemoryLimiter()
+	allowed, remaining, _ := l.AllowInputTokens("t1", "", 1000, 400)
+	if !allowed {
+		t.Fatal("input tokens must be allowed")
+	}
+	l.SweepIdle()
+	// The used count must be intact: a second charge sees the earlier one.
+	allowed, remaining2, _ := l.AllowInputTokens("t1", "", 1000, 100)
+	if !allowed {
+		t.Fatal("second charge must be allowed")
+	}
+	if remaining2 >= remaining {
+		t.Errorf("daily used count must survive the sweep: remaining went %d -> %d", remaining, remaining2)
+	}
+}
+
+// TestMinuteSweepIdle_FullEvictedPartialKept verifies the ITPM/OTPM janitor:
+// an untouched (full) bucket is evicted, a partially-drained one is kept.
+func TestMinuteSweepIdle_FullEvictedPartialKept(t *testing.T) {
+	l := auth.NewMinuteRateLimiter()
+	// OutputExhausted creates the bucket without deducting — it stays full.
+	if l.OutputExhausted("t-full", "m", 1000) {
+		t.Fatal("fresh bucket must not be exhausted")
+	}
+	// AllowInputTokens deducts half the bucket — it carries state.
+	if !l.AllowInputTokens("t-drained", "m", 1000, 500) {
+		t.Fatal("input charge must be allowed")
+	}
+
+	if n := l.SweepIdle(); n != 1 {
+		t.Fatalf("SweepIdle evicted %d buckets, want exactly 1 (the full one)", n)
+	}
+	// The drained bucket still remembers its charge: another 600 must not fit.
+	if l.AllowInputTokens("t-drained", "m", 1000, 600) {
+		t.Error("drained bucket must have survived the sweep and deny an over-charge")
+	}
+}

--- a/test/domain/prompt_bytes_test.go
+++ b/test/domain/prompt_bytes_test.go
@@ -74,3 +74,58 @@ func jsonString(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)
 }
+
+// TestPromptTextBytes_IncludesTools verifies the prompt-byte count covers the
+// raw tool-definition JSON: the backend renders tool schemas into the prompt
+// and tokenizes them, so leaving them out would both under-estimate agentic
+// requests at admission and inflate the learned tokens-per-byte ratio when the
+// exact prompt_tokens (which include the schemas) are divided by the bytes.
+func TestPromptTextBytes_IncludesTools(t *testing.T) {
+	tools := `[{"type":"function","function":{"name":"read_file","description":"Read a file from disk","parameters":{"type":"object","properties":{"path":{"type":"string"}}}}}]`
+	body := `{
+		"model": "gemma",
+		"messages": [{"role": "user", "content": "hi"}],
+		"tools": ` + tools + `
+	}`
+	var req domain.ChatRequest
+	if err := json.Unmarshal([]byte(body), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	withTools, _ := domain.PromptTextBytes(&req)
+
+	req.Tools = nil
+	withoutTools, _ := domain.PromptTextBytes(&req)
+
+	if withTools <= withoutTools {
+		t.Errorf("tool definitions must contribute bytes: with=%d without=%d", withTools, withoutTools)
+	}
+	if got := withTools - withoutTools; got < len(tools)-10 {
+		t.Errorf("tools contributed %d bytes, want ~%d", got, len(tools))
+	}
+}
+
+// TestCountImages_AnthropicImageBlocks verifies the image cap sees the
+// Anthropic /v1/messages image shape ({"type":"image","source":...}) as well as
+// the OpenAI image_url shape — otherwise an Anthropic-dialect request could
+// carry unlimited images past images_max.
+func TestCountImages_AnthropicImageBlocks(t *testing.T) {
+	body := `{
+		"model": "gemma",
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "what is in these?"},
+				{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "aGk="}},
+				{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "aGk="}},
+				{"type": "image_url", "image_url": {"url": "http://x/y.png"}}
+			]}
+		]
+	}`
+	var req domain.ChatRequest
+	if err := json.Unmarshal([]byte(body), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := domain.CountImages(req.Messages); got != 3 {
+		t.Errorf("CountImages = %d, want 3 (2 Anthropic blocks + 1 OpenAI part)", got)
+	}
+}

--- a/test/domain/usage_test.go
+++ b/test/domain/usage_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+package domain_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"hivenet_router/internal/domain"
+)
+
+// TestUsage_UnmarshalOpenAIShape verifies the OpenAI usage shape still decodes
+// exactly as before the Anthropic normalization was added.
+func TestUsage_UnmarshalOpenAIShape(t *testing.T) {
+	var u domain.Usage
+	if err := json.Unmarshal([]byte(`{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}`), &u); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if u.PromptTokens != 10 || u.CompletionTokens != 5 || u.TotalTokens != 15 {
+		t.Errorf("got %+v, want 10/5/15", u)
+	}
+}
+
+// TestUsage_UnmarshalAnthropicShape verifies the Anthropic /v1/messages usage
+// shape (input_tokens/output_tokens, no total) is normalized into the OpenAI
+// fields with a synthesized total — without this every Anthropic response read
+// as zero usage, so the dialect silently escaped output metering, OTPM
+// charging, the occupancy true-up, and estimator learning.
+func TestUsage_UnmarshalAnthropicShape(t *testing.T) {
+	var u domain.Usage
+	if err := json.Unmarshal([]byte(`{"input_tokens":42,"output_tokens":7}`), &u); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if u.PromptTokens != 42 || u.CompletionTokens != 7 {
+		t.Errorf("got prompt=%d completion=%d, want 42/7", u.PromptTokens, u.CompletionTokens)
+	}
+	if u.TotalTokens != 49 {
+		t.Errorf("total must be synthesized: got %d, want 49", u.TotalTokens)
+	}
+}
+
+// TestUsage_UnmarshalEmpty verifies an absent/empty usage object stays zero, so
+// "usage present" checks (TotalTokens > 0) still fall back to estimation.
+func TestUsage_UnmarshalEmpty(t *testing.T) {
+	var u domain.Usage
+	if err := json.Unmarshal([]byte(`{}`), &u); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if u.PromptTokens != 0 || u.CompletionTokens != 0 || u.TotalTokens != 0 {
+		t.Errorf("empty usage must stay zero, got %+v", u)
+	}
+}

--- a/test/router/provider_fallback_test.go
+++ b/test/router/provider_fallback_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Hive Computing Services SA
+
+// Black-box tests for the provider-fallback interaction with admission
+// accounting: a request served by the cloud provider runs on the operator's
+// provider account, not local GPU capacity, so its occupancy reservation must
+// be released the moment the request leaves the local pool.
+package router_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"hivenet_router/internal/domain"
+	"hivenet_router/internal/metrics"
+	"hivenet_router/internal/policy"
+	"hivenet_router/internal/provider"
+	"hivenet_router/internal/router"
+)
+
+// fakeProvider returns a canned provider-stamped response.
+type fakeProvider struct{ calls atomic.Int32 }
+
+func (f *fakeProvider) Name() string { return "openai" }
+func (f *fakeProvider) Complete(_ context.Context, _ *domain.ChatRequest, _ string) (*domain.ChatResponse, error) {
+	f.calls.Add(1)
+	return &domain.ChatResponse{
+		RawBytes:    []byte(`{"ok":true}`),
+		ProcessedBy: "provider:openai",
+		Usage:       domain.Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15},
+	}, nil
+}
+
+var _ provider.Provider = (*fakeProvider)(nil)
+
+// fakeReservation records reservation lifecycle calls.
+type fakeReservation struct {
+	released atomic.Bool
+	grown    atomic.Int64
+}
+
+func (f *fakeReservation) Grow(tokens int) { f.grown.Add(int64(tokens)) }
+func (f *fakeReservation) Adjust(int)      {}
+func (f *fakeReservation) Release()        { f.released.Store(true) }
+
+var _ domain.Reservation = (*fakeReservation)(nil)
+
+// TestProviderFallback_ReleasesOccupancyReservation verifies the processor
+// frees the request's occupancy reservation when routing exhausts the local
+// pool and hands the request to the cloud provider — otherwise phantom load
+// would sit against the local KV budget for the provider call's duration,
+// exactly while the degraded pool needs its admission headroom.
+func TestProviderFallback_ReleasesOccupancyReservation(t *testing.T) {
+	// No agents for the model → Select fails → the provider fallback fires.
+	lister := &stubAgentLister{agents: map[string][]*domain.Agent{}}
+	stor := &stubStorage{}
+	m := metrics.NewRouterMetrics()
+	counters := metrics.NewUniversalCounterStore(stor, m)
+	eval := policy.NewEvaluator(stor, counters)
+	pol := &policy.Policy{
+		RoutingPolicy:    policy.PolicyStep{Strategy: "least-loaded", MaxTries: 1},
+		FallbackProvider: &policy.FallbackProvider{Engine: "openai", Model: "gpt-fallback"},
+	}
+	exec := policy.NewExecutor(lister, eval, pol, 3, 0)
+
+	fp := &fakeProvider{}
+	queue := make(chan *domain.PendingRequest, 1)
+	p := router.NewRequestProcessor(queue, exec, nil, m, counters, 10,
+		map[string]provider.Provider{"openai": fp}, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go p.Start(ctx)
+
+	pending := domain.NewPendingRequest("req-fallback", &domain.ChatRequest{Model: testModel}, time.Minute)
+	pending.Capability = domain.CapabilityLLM
+	pending.Ctx = context.Background()
+	res := &fakeReservation{}
+	pending.Reservation = res
+	queue <- pending
+
+	resp, err := awaitResult(t, pending)
+	if err != nil {
+		t.Fatalf("provider fallback must serve the request, got error: %v", err)
+	}
+	if !resp.ServedByProvider() {
+		t.Fatalf("response must be provider-stamped, got ProcessedBy=%q", resp.ProcessedBy)
+	}
+	if fp.calls.Load() != 1 {
+		t.Errorf("provider Complete calls = %d, want 1", fp.calls.Load())
+	}
+	if !res.released.Load() {
+		t.Error("the occupancy reservation must be released when the request goes to the provider")
+	}
+}

--- a/test/router/stream_token_meter_test.go
+++ b/test/router/stream_token_meter_test.go
@@ -165,3 +165,44 @@ func TestMeter_HandlesSplitWrites(t *testing.T) {
 		t.Errorf("expected the split event to be parsed and counted, got completion=%d", completion)
 	}
 }
+
+// TestMeter_ParsesAnthropicEvents verifies the meter reads the Anthropic
+// /v1/messages SSE dialect: exact input_tokens from message_start, cumulative
+// output_tokens from message_delta, and streamed text from content_block_delta
+// — so Anthropic streams get exact usage (metering, OTPM, estimator learning)
+// instead of silently falling back to estimation.
+func TestMeter_ParsesAnthropicEvents(t *testing.T) {
+	m := router.NewSSETokenMeter()
+	var streamed string
+	m.SetContentObserver(func(delta string) { streamed += delta })
+
+	chunks := []string{
+		"event: message_start\n",
+		`data: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":42,"output_tokens":1}}}` + "\n\n",
+		"event: content_block_delta\n",
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}` + "\n\n",
+		"event: content_block_delta\n",
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" world"}}` + "\n\n",
+		"event: message_delta\n",
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":9}}` + "\n\n",
+	}
+	for _, c := range chunks {
+		if _, err := m.Write([]byte(c)); err != nil {
+			t.Fatalf("Write returned error: %v", err)
+		}
+	}
+
+	if !m.HaveUsage() {
+		t.Fatal("Anthropic message_start must mark usage as exact")
+	}
+	prompt, completion := m.Tokens(nil)
+	if prompt != 42 {
+		t.Errorf("prompt = %d, want 42 (message_start input_tokens)", prompt)
+	}
+	if completion != 9 {
+		t.Errorf("completion = %d, want 9 (final message_delta output_tokens)", completion)
+	}
+	if streamed != "Hello world" {
+		t.Errorf("content observer saw %q, want %q", streamed, "Hello world")
+	}
+}

--- a/test/tokenizer/estimator_test.go
+++ b/test/tokenizer/estimator_test.go
@@ -161,3 +161,29 @@ func loadCorpus(t *testing.T) []string {
 	}
 	return corpus
 }
+
+// TestObserveClampsOutlierSamples verifies a wildly out-of-band sample (e.g. a
+// backend-reported prompt_tokens covering content the byte count cannot see)
+// is clamped before entering the EWMA, so one bad observation cannot swing
+// every subsequent estimate for the model.
+func TestObserveClampsOutlierSamples(t *testing.T) {
+	e := tokenizer.NewEstimator()
+
+	// 100 bytes reported as 5,000 tokens → 50 tokens/byte, far beyond any real
+	// tokenizer. The sample must be clamped to the 1 token/byte ceiling, so the
+	// ratio after one EWMA step stays at most alpha·1.0 + (1−alpha)·cold < 1.
+	e.Observe("m", 100, 5000)
+	if r := e.RatioFor("m"); r > 1.0 {
+		t.Errorf("ratio after absurd high sample = %.3f, must stay <= 1.0", r)
+	}
+
+	// 10,000 bytes reported as 1 token → 1/10,000 tokens/byte; the floor keeps
+	// the ratio from collapsing toward zero (which would admit everything).
+	e2 := tokenizer.NewEstimator()
+	for range 100 {
+		e2.Observe("m", 10_000, 1)
+	}
+	if r := e2.RatioFor("m"); r < 1.0/20.0-1e-9 {
+		t.Errorf("ratio after absurd low samples = %.5f, must stay >= 0.05", r)
+	}
+}


### PR DESCRIPTION
Critical review of the whole RL-1..RL-7 series (code and spec) found ten real defects, all fixed here with regression tests. Common theme: **the gates and the estimator disagreed about what a request contains.**

## Bugs fixed

### 1. B1 input cap could be bypassed with an Anthropic system prompt
`enforceRequestCaps` still used the legacy `len/4` count over **message text only**, while B2 reserved the learned estimate **including the top-level `system` prompt**. A `/v1/messages` request with a tiny message and a 300K-token system prompt sailed under `max_input_tokens`. B1 now checks the exact same estimate B2 reserves (computed once, shared by B1 / B2 / ITPM / true-up).

### 2. Image cap bypass in the Anthropic dialect
`CountImages` only counted OpenAI `"image_url"` parts. Anthropic image blocks are `{"type":"image","source":…}` — they were invisible, so a `/v1/messages` request could carry unlimited images past `images_max` (and its image tokens also polluted estimator learning, which keys off `CountImages == 0`). Both shapes count now.

### 3. Tool definitions poisoned the learned estimator
Tool/function JSON schemas are rendered into the prompt and tokenized by the backend (they appear in `usage.prompt_tokens`), but contributed **zero bytes** to `PromptTextBytes`. Two consequences: agentic requests were under-estimated at admission, and every tools-heavy response taught the estimator an inflated tokens-per-byte ratio (exact tokens ÷ too-few bytes), degrading estimates for *everyone* on that model. `ChatRequest` now captures `tools` raw and counts its bytes in both `Estimate` and `Observe`. As defense-in-depth, observed samples are clamped to a sane band (0.05–1.0 tokens/byte) so no single unmodeled request can swing the EWMA.

### 4. The Anthropic dialect escaped all usage-based accounting
`Usage` only parsed `prompt_tokens`/`completion_tokens`, and the SSE meter only parsed OpenAI chunks. Every `/v1/messages` response therefore read as **zero usage**: no daily output metering, no OTPM charge, no occupancy true-up, no estimator learning — on the dialect Claude Code uses. Fixed in both places: `Usage.UnmarshalJSON` normalizes `input_tokens`/`output_tokens` (total synthesized), and the meter parses `message_start` (exact input), `message_delta` (cumulative output) and `content_block_delta` (streamed text, feeding live occupancy growth).

### 5. `count_tokens` was billed like an inference call
`/v1/messages/count_tokens` went through every admission gate. A client that counts before sending (Claude Code's pattern) was charged **twice** per request on ITPM and held a phantom KV-occupancy reservation for a call that touches no KV cache — and a prompt over `max_input_tokens` couldn't even be *counted* (400). It now skips B1/B2/B3/B4 and stays guarded by the per-key RPM flood limit. (Note: it still charges the pre-existing daily token budget — that behavior predates this series; flag if you want it exempted too.)

### 6. Negative `max_tokens` shrank the charged footprint
`footprint = input + declared` with a negative declared value under-charged the budget (and disabled live growth). Negative is now treated as undeclared.

### 7. Occupancy budget capped the whole pool at ONE replica's budget
`admit_budget_tokens` / `max_inflight` are per-replica numbers (the benchmark certifies one box), but the occupancy counter is per model — with N healthy replicas, (N−1)/N of the pool's capacity was unreachable. Both limits are now scaled by the model's healthy replica count at enforcement (recomputed per request, so the budget tracks replicas joining/leaving; floored at 1 so zero healthy replicas can't zero the budget, which the controller would read as "gate off"). The per-key occupancy share scales off the same pool budget, so a share keeps meaning "this fraction of what the pool can hold". Routing spreads the admitted load; a single hot replica remains the job of the per-agent `exclude_if` gates and the B3 shed.

## Also in this PR
- ITPM now charges the identical estimate B2 reserved instead of re-running the estimator mid-request (the shared ratio can shift between calls).

### 8. Provider-fallback traffic was charged as local load
A request served by the OpenAI/Anthropic fallback runs on the operator's provider account — no local KV cache, no local decode. But the occupancy reservation was held for the whole provider call (phantom load against the local budget, exactly while the degraded pool needs headroom), the provider's `prompt_tokens` (a **different tokenizer**) taught the local model's learned ratio, and its output drained the per-key OTPM bucket. The processor now releases the reservation when the request goes to the provider, and provider-stamped responses (`ProcessedBy: "provider:*"`) skip estimator learning and the OTPM charge. Deliberately unchanged: RPM, ITPM, and daily-input are charged before routing (the server isn't known yet) and are the customer's commercial plan limits, which apply regardless of who answers.

### 9. Dynamic keys skipped the admission validations static keys get
A key created through the admin API bypassed every check the static `auth.yaml` path enforces — and could not even *declare* an occupancy share (the DTO had no field). Now: the registry bounds `max_occupancy_share` to (0,1] and rejects negative buckets on every mutation; the admin DTOs carry `max_occupancy_share`; upsert/replace run the ITPM ≥ `max_input_tokens` cross-check against live policies (400 at creation instead of a silent context cap); and policy reloads validate against dynamic keys too. The reachability rule is shared via `policy.GovernsAnyOf` so the three checks cannot drift.

### 10. Idle limiter state is now garbage-collected
Every key×model pair that ever made a request left permanent entries in the in-memory maps (RPM bucket, ITPM/OTPM buckets, per-key occupancy state, daily counters) — nothing removed them, so programmatic key issuance grew memory without bound until restart. The existing 5-minute GC ticker now sweeps them **losslessly**: rate buckets only when full (a full bucket is identical to the fresh one the next request creates), daily counters only after their UTC day passed, occupancy states only when empty and idle past a 15-minute TTL. Usage history is unaffected — cumulative token accounting lives in the Prometheus tenant counters and the audit log, never in these maps.
