### PR TITLE
RL-8: Document the built admission-control system

### DIFF
--- a/docs/observability/prometheus-metrics.mdx
+++ b/docs/observability/prometheus-metrics.mdx
@@ -142,6 +142,7 @@ For supported engines, each agent scrapes its local backend’s `/metrics` endpo
 | Policies | Primary routing, fallback, exhaustion, reloads, and connection resets |
 | Queue | Requests waiting for agent capacity |
 | Tenant and quota | Requests, tokens, limits, last use, and quota failures |
+| Admission control | Gate rejections by reason, live occupancy vs budget, in-flight concurrency |
 | HTTP | Router endpoint latency, active requests, and provider calls |
 
 ## Metric labels and cardinality
@@ -1252,6 +1253,20 @@ increase(
 
   Investigate any increase rather than treating it as a harmless background error.
 </Warning>
+
+## Admission-control metrics
+
+The admission gates publish a rejection counter and live occupancy gauges:
+
+| Metric | Type | Labels |
+| --- | --- | --- |
+| `hivenet_router_admission_rejections_total` | counter | `reason`, `model` |
+| `hivenet_router_admission_occupancy_tokens` | gauge | `model` |
+| `hivenet_router_admission_budget_tokens` | gauge | `model` |
+| `hivenet_router_admission_inflight_requests` | gauge | `model` |
+| `hivenet_router_admission_max_inflight` | gauge | `model` |
+
+The `reason` label attributes each rejection to the gate that produced it (`b1`, `b2`, `b3`, `b4_occupancy`, `b4_itpm`, `b4_otpm`, `b4_rpm`). See [Admission control metrics](/observability/admission-control-metrics) for the full label semantics and panel queries, and [Admission control](/routing/admission-control) for the gates themselves.
 
 ## Per-request duration by agent
 

--- a/docs/reference/configuration-reference.mdx
+++ b/docs/reference/configuration-reference.mdx
@@ -37,6 +37,9 @@ Complete reference for all Router and Agent CLI flags and environment variables.
 | `--remove-after` | — | `30s` | Remove agent after this without a heartbeat |
 | `--max-concurrent` | — | `50` | Max concurrent in-flight request forwards |
 | `--heartbeat-interval` | — | `5s` | Expected heartbeat cadence sent to agents in `RouterConfig` |
+| `HIVENET_ROUTER_ADMIT_FRACTION` | — | `0.90` | Scales a model's `admit_budget_tokens` into the effective occupancy budget (admission gate B2). Range (0,1]; out-of-range values keep the default. Shipped at 0.85, raised to 0.90 with the learned token estimator |
+| `HIVENET_ROUTER_ADMIT_PARK_TIMEOUT` | — | `250ms` | How long an over-budget request waits for occupancy to free before 429 (Go duration; `0` rejects immediately) |
+| `HIVENET_ROUTER_RPM_BURST_SECONDS` | — | `0` | Per-key RPM bucket burst window in seconds. `0` or ≥60 keeps the legacy full-minute burst; a short certified window (e.g. `10`) stops a key from spending its whole minute's quota in one instant |
 
 > **`--p2p-max-conns-per-ip` and agents behind a shared NAT.** go-libp2p's resource manager caps concurrent connections from a single source IP at **8** by default. When agents reach the router through one shared egress IP — e.g. a Kubernetes SNAT gateway, a Docker bridge, or any NAT — they all count against that single bucket, so the **9th agent's connection is accepted at TCP but reset during the Noise handshake** (the agent logs `failed to negotiate security protocol: EOF`). This flag raises that per-IP ceiling (default `32`). Keep it **≥ 2× the number of agents behind a single egress IP**, not equal to the agent count: a restarting agent briefly holds both its old (not yet timed out, see `--remove-after`) and its new connection, so a fleet-wide rollout transiently needs up to ~2× the slots. Agents that present distinct source IPs each get their own bucket and are unaffected.
 

--- a/docs/reference/detailed-architecture.mdx
+++ b/docs/reference/detailed-architecture.mdx
@@ -597,16 +597,19 @@ requests_per_minute_per_replica
 
 When zero healthy replicas exist, quota admission is skipped so routing can return the more accurate availability error.
 
-### 4. Model authorization and token admission
+### 4. Model authorization and admission gates
 
 The handler:
 
 - parses the top-level `model`
 - checks the key’s effective model allowlist
-- estimates input tokens
+- estimates input tokens with the per-model learned estimator (message text, Anthropic `system` prompt, tool JSON)
+- applies the [admission gates](/routing/admission-control) in order: the per-request input/image caps (400 `input_too_long`), the front-door KV-pressure shed, the KV-occupancy admit budget with its `max_inflight` backstop (429 `concurrency_limit_exceeded`, brief parking), and — on serverless policies — the per-key occupancy share and token-per-minute caps (429 `rate_limit_exceeded`)
 - checks the worst-case input plus requested output against the daily budget
 - charges admitted prompt tokens
 - preserves the original request bytes and headers
+
+The occupancy reservation taken here is held for the request’s lifetime — grown as undeclared output streams, reconciled to the backend’s exact `prompt_tokens`, and released on every exit path (or early, when the request fails over to a cloud provider). `/v1/messages/count_tokens` skips the admission gates: it is a stateless tokenizer lookup guarded by the request-rate quota alone.
 
 ### 5. Global request queue
 

--- a/docs/reference/detailed-architecture.mdx
+++ b/docs/reference/detailed-architecture.mdx
@@ -609,7 +609,17 @@ The handler:
 - charges admitted prompt tokens
 - preserves the original request bytes and headers
 
-The occupancy reservation taken here is held for the request’s lifetime — grown as undeclared output streams, reconciled to the backend’s exact `prompt_tokens`, and released on every exit path (or early, when the request fails over to a cloud provider). `/v1/messages/count_tokens` skips the admission gates: it is a stateless tokenizer lookup guarded by the request-rate quota alone.
+#### Reservation lifetime
+
+When the KV-occupancy gate admits a request, it books a slice of the model’s occupancy budget — a *reservation* that stays held from admission until the request fully finishes. Over that lifetime the reservation is:
+
+- **Grown as output streams.** If the client did not declare `max_tokens`, the router cannot size the output ahead of time, so it reserves an estimate and enlarges the reservation as real output tokens stream out. The booking flexes to match what is actually generated.
+- **Reconciled to the true input size.** Admission uses the *estimated* input token count. When the backend reports its exact `prompt_tokens`, the router corrects the reservation to that figure — the true-up — replacing the estimate with the real number.
+- **Released on every exit path.** Success, error, timeout, or client disconnect all return the reservation so the budget is freed for the next request. One case releases it early: when a request fails over to a cloud provider, the reservation is dropped the moment routing leaves the local backends, because provider generation consumes no local KV cache.
+
+#### `count_tokens` is exempt
+
+`POST /v1/messages/count_tokens` runs no model and consumes no KV cache — it only reports how many tokens a prompt *would* use. It therefore skips every admission gate (input/image caps, KV-pressure shed, occupancy budget, per-key token rates), since there is no generation to protect. It remains a stateless tokenizer lookup, guarded only by the request-rate quota so the endpoint cannot be flooded with counting calls.
 
 ### 5. Global request queue
 

--- a/docs/reference/detailed-architecture.mdx
+++ b/docs/reference/detailed-architecture.mdx
@@ -619,7 +619,7 @@ When the KV-occupancy gate admits a request, it books a slice of the model’s o
 
 #### `count_tokens` is exempt
 
-`POST /v1/messages/count_tokens` runs no model and consumes no KV cache — it only reports how many tokens a prompt *would* use. It therefore skips every admission gate (input/image caps, KV-pressure shed, occupancy budget, per-key token rates), since there is no generation to protect. It remains a stateless tokenizer lookup, guarded only by the request-rate quota so the endpoint cannot be flooded with counting calls.
+`POST /v1/messages/count_tokens` runs no model and consumes no KV cache — it only reports how many tokens a prompt *would* use. It therefore skips every admission gate (input/image caps, KV-pressure shed, occupancy budget, per-key token rates) and charges no token quota, since there is no generation to protect. It remains a stateless tokenizer lookup, guarded only by the request-rate quota so the endpoint cannot be flooded with counting calls.
 
 ### 5. Global request queue
 

--- a/docs/reference/error-codes.mdx
+++ b/docs/reference/error-codes.mdx
@@ -27,12 +27,14 @@ All Hivenet Router errors use a consistent JSON envelope.
 | Code | HTTP | Source | Retryable | Trigger |
 | --- | --- | --- | --- | --- |
 | `request_invalid` | 400 | router | No | Malformed JSON or missing required field (`model`, `messages`) |
+| `input_too_long` | 400 | router | No | Prompt over the policy's `max_input_tokens`, or more images than `images_max` (admission gate B1) |
 | `context_length_exceeded` | 400 | backend | No | Input tokens exceed the model's maximum context window |
 | `invalid_parameter` | 400 | backend | No | Invalid inference parameter (`temperature`, `top_p`, `max_tokens`, etc.) |
 | `unauthorized` | 401 | router | No | Missing or invalid API key |
 | `model_forbidden` | 403 | router | No | API key's model allowlist does not include the requested model |
 | `model_not_found` | 404 | router | No | No agents are registered for the requested model |
-| `rate_limit_exceeded` | 429 | router | Yes — after delay | Tenant's requests-per-minute bucket exhausted |
+| `rate_limit_exceeded` | 429 | router | Yes — after delay | A per-key cap: requests-per-minute, input/output tokens-per-minute, or occupancy share (admission gate B4) |
+| `concurrency_limit_exceeded` | 429 | router | Yes — after delay | KV-occupancy admit budget or `max_inflight` full, or the front-door KV-pressure shed fired (admission gates B2/B3). Carries `Retry-After` |
 | `token_limit_exceeded` | 429 | router | No — until UTC midnight | Tenant's daily token budget exhausted |
 | `no_agents_available` | 503 | router | Yes — backoff | Agents registered but all marked unhealthy |
 | `no_capacity` | 503 | router | Yes — immediately | All healthy agents are at full concurrency capacity |
@@ -46,11 +48,12 @@ All Hivenet Router errors use a consistent JSON envelope.
 
 | Code | Strategy |
 | --- | --- |
-| `request_invalid`, `context_length_exceeded`, `invalid_parameter` | **Do not retry.** Fix the request payload. |
+| `request_invalid`, `context_length_exceeded`, `invalid_parameter`, `input_too_long` | **Do not retry.** Fix the request payload — for `input_too_long`, shrink the prompt or drop images. |
 | `unauthorized`, `model_forbidden` | **Do not retry.** Fix credentials or request a different model. |
 | `model_not_found` | **Do not retry** until an agent for that model is running. Verify name via `GET /v1/models`. |
 | `token_limit_exceeded` | **Do not retry** until UTC midnight. Daily budget is exhausted. |
-| `rate_limit_exceeded` | Retry after `60 / rpm` seconds. Use exponential backoff with jitter. |
+| `rate_limit_exceeded` | Retry after `60 / rpm` seconds (or the `Retry-After` header). Use exponential backoff with jitter. |
+| `concurrency_limit_exceeded` | Retry after the `Retry-After` header with backoff + jitter — the pool is at its occupancy budget or shedding; capacity frees as in-flight requests complete. |
 | `no_capacity`, `agent_disconnected` | Retry immediately or after 1–2 s. Slot contention resolves quickly. |
 | `no_agents_available`, `backend_unavailable`, `queue_full` | Retry with exponential backoff (2 s, 4 s, 8 s…). Resolves when agents reconnect or backend finishes loading. |
 | `backend_error` | Retry once. If it recurs with the same input, investigate the backend (e.g. GPU OOM). |

--- a/docs/reference/error-codes.mdx
+++ b/docs/reference/error-codes.mdx
@@ -52,7 +52,7 @@ All Hivenet Router errors use a consistent JSON envelope.
 | `unauthorized`, `model_forbidden` | **Do not retry.** Fix credentials or request a different model. |
 | `model_not_found` | **Do not retry** until an agent for that model is running. Verify name via `GET /v1/models`. |
 | `token_limit_exceeded` | **Do not retry** until UTC midnight. Daily budget is exhausted. |
-| `rate_limit_exceeded` | Retry after `60 / rpm` seconds (or the `Retry-After` header). Use exponential backoff with jitter. |
+| `rate_limit_exceeded` | Retry after the `Retry-After` header when present (the serverless ITPM/OTPM/occupancy-share caps set it); otherwise — the front-door RPM limiter — retry after `60 / rpm` seconds. Use exponential backoff with jitter. |
 | `concurrency_limit_exceeded` | Retry after the `Retry-After` header with backoff + jitter — the pool is at its occupancy budget or shedding; capacity frees as in-flight requests complete. |
 | `no_capacity`, `agent_disconnected` | Retry immediately or after 1–2 s. Slot contention resolves quickly. |
 | `no_agents_available`, `backend_unavailable`, `queue_full` | Retry with exponential backoff (2 s, 4 s, 8 s…). Resolves when agents reconnect or backend finishes loading. |

--- a/docs/routing/admission-control.mdx
+++ b/docs/routing/admission-control.mdx
@@ -26,7 +26,7 @@ Every `/v1/chat/completions` and `/v1/messages` request passes the gates in this
 | 5 | **B4** — per-key OTPM (non-deducting check), then ITPM (deducting) | serverless only | 429 `rate_limit_exceeded` |
 | 6 | Daily token budget (input reserved up front) | keys with `tokens_per_day` | 429 `token_limit_exceeded` |
 
-All 429s carry a `Retry-After` header. Every rejection increments `hivenet_router_admission_rejections_total{reason, model}` — see [Admission control metrics](/observability/admission-control-metrics).
+Not every 429 carries a `Retry-After` header: `concurrency_limit_exceeded` (B2/B3) always sets it, `rate_limit_exceeded` sets it for the serverless B4 caps but **not** for the front-door RPM limiter, and `token_limit_exceeded` (daily budget) never sets it. Clients should honor `Retry-After` when present and fall back to their own backoff otherwise. Every rejection increments `hivenet_router_admission_rejections_total{reason, model}` — see [Admission control metrics](/observability/admission-control-metrics).
 
 ## The footprint formula
 
@@ -83,15 +83,15 @@ shed_if:
 - The signal is the **mean** across healthy replicas (a single hot replica is routing's job, shedding is warranted only when the pool as a whole is under pressure).
 - A missing signal **fails open**: engines that do not report KV utilization simply skip that dimension, and B2's static budget carries the safety.
 - Only `kv_cache_utilization` and `waiting_requests` are accepted in `shed_if`; an unknown field is a load-time error (a typo must not silently disable the shed).
-- 0.90 is more permissive than the industry de-facto 0.80; it leans on the learned estimator's accuracy. Lower it if preemption metrics show the estimate is optimistic.
+- The threshold gates **admission, not decode growth**: requests admitted below it keep allocating KV blocks as they generate, so shedding lowers the *rate* of preemption rather than eliminating it. 0.90 is more permissive than the industry de-facto 0.80, leaning on the learned estimator's accuracy; if the engine's preemption counter (e.g. vLLM's `num_preemptions_total`) climbs, the estimate is running optimistic — lower the threshold toward 0.80 to restore the cushion.
 
 ## B4 — serverless per-key caps
 
-Applied only when the governing policy declares `mode: serverless` (many keys sharing replicas). On `mode: reserved` (default — one client rents the whole replica) these are inert; B1/B2/B3 still protect the box.
+Applied only when the governing policy declares `mode: serverless` (many keys sharing replicas). On `mode: reserved` (default — one client rents the whole replica) the ITPM/OTPM/occupancy-share caps are inert; B1/B2/B3 still protect the box. RPM is the exception — it is a front-door quota that runs in every mode (see below).
 
 | Cap | Field | Mechanism |
 | --- | --- | --- |
-| Requests/min | `quota.requests_per_minute` | token bucket; burst = certified window via `HIVENET_ROUTER_RPM_BURST_SECONDS`, not the library's full-minute default |
+| Requests/min | `quota.requests_per_minute` | **enforced at the front door (pre-routing), not gated by mode** — listed here to show the full per-key rate picture, but it is the same quota that guards every request. Token bucket; burst = certified window via `HIVENET_ROUTER_RPM_BURST_SECONDS`, not the library's full-minute default |
 | Input tokens/min | `quota.input_tokens_per_minute` | bucket charged with the admission estimate **before** the daily budget, so a rate rejection never spends daily tokens |
 | Output tokens/min | `quota.output_tokens_per_minute` | metered **post-hoc** from real usage (never reserved); a key that over-produces is held off on its *next* request |
 | Occupancy share | `max_occupancy_share` (key-level) | the key's in-flight `Σw` must fit `share × pool_budget` — the same replica-scaled pool B2 admits against |

--- a/docs/routing/admission-control.mdx
+++ b/docs/routing/admission-control.mdx
@@ -1,77 +1,174 @@
 ---
 title: "Admission control"
-description: "Understand how Hivenet Router protects router and agent capacity before work enters the inference queue."
+description: "How Hivenet Router bounds KV-cache occupancy and per-key token rates before work enters the inference queue — the gate pipeline, the token estimator, and every limit it enforces."
 sidebarTitle: "Admission control"
 ---
 
-Admission control rejects or briefly parks work before it overloads a router, agent, or API key. It complements routing policies: routing chooses eligible capacity, while admission control decides whether the selected path can accept the request now.
+Admission control decides whether a request may enter the inference queue *now*. It complements routing: routing chooses which agent serves an admitted request; admission control bounds the total and per-key load so that the box never enters the regime where a KV-cache-bound engine silently degrades.
 
-## Operating modes
+## Why token-weighted admission
 
-Hivenet Router supports two admission modes:
+A GPU inference box under overload does not crash or return errors — the engine (vLLM and peers) **preempts, queues, or swaps**, and every request still returns HTTP 200 while latency inflates many-fold. The resource that decides latency is **instantaneous KV-cache occupancy**: the tokens held on the GPU right now. Request counts and daily totals cannot see it — a chat turn (~3K tokens) and a full-context coding request (~250K tokens) both count as "1 request", and three 250K requests in the same second overflow a ~409K-token pool while every per-minute gauge stays green.
 
-- **Reserved mode** accounts for capacity that has already been committed to active requests.
-- **Serverless mode** admits work against the capacity currently reported by the serving agents.
+The router therefore admits on **tokens in flight**, not request counts. Requests-per-minute and tokens-per-day are kept for the jobs they are good at (tiny-request flood guard, commercial budget); the occupancy budget is the gate that protects the latency SLO.
 
-Choose the mode that matches how your inference capacity is provisioned. Mixed fleets can use routing policies to separate pools with different operating assumptions.
+## The gate pipeline
 
-## Limits evaluated before admission
+Every `/v1/chat/completions` and `/v1/messages` request passes the gates in this order (`internal/api/handlers.go` `Passthrough`). Ordering is deliberate: cheap, deterministic rejections come first, and nothing charges the tenant's daily budget until every cheaper gate has passed.
 
-The router evaluates the request and the currently occupied capacity before forwarding work. The checks include:
+| # | Gate | Scope | Rejection |
+| --- | --- | --- | --- |
+| 0 | Per-key RPM (middleware) | every key | 429 `rate_limit_exceeded` |
+| 1 | **B1** — per-request caps (input tokens, images) | all replicas | 400 `input_too_long` |
+| 2 | **B3** — front-door KV-pressure shed | all replicas | 429 `concurrency_limit_exceeded` |
+| 3 | **B2** — occupancy admit budget + `max_inflight` backstop | all replicas | 429 `concurrency_limit_exceeded` |
+| 4 | **B4** — per-key occupancy share | serverless only | 429 `rate_limit_exceeded` |
+| 5 | **B4** — per-key OTPM (non-deducting check), then ITPM (deducting) | serverless only | 429 `rate_limit_exceeded` |
+| 6 | Daily token budget (input reserved up front) | keys with `tokens_per_day` | 429 `token_limit_exceeded` |
 
-- request token limits
-- request image limits
-- token-weighted occupancy budgets
-- per-key occupancy limits
-- input token-rate quotas
-- output token-rate quotas
+All 429s carry a `Retry-After` header. Every rejection increments `hivenet_router_admission_rejections_total{reason, model}` — see [Admission control metrics](/observability/admission-control-metrics).
 
-Token-weighted occupancy prevents a small number of large prompts from consuming the same budget as many small requests. Per-key budgets keep one credential from monopolizing shared capacity.
+## The footprint formula
 
-## Parking and rejection
+B2 and the per-key occupancy share charge each in-flight request a **footprint** `w`:
 
-When capacity may become available quickly, the router can park a request for a bounded period. The admission fraction and parking timeout are controlled by:
+```text
+w = input_estimate + declared_output
 
-- `HR_ADMIT_FRACTION`
-- `HR_ADMIT_PARK_TIMEOUT`
+declared_output = max_tokens (or max_completion_tokens), reserved up front
+                = 0 if undeclared — the reservation then GROWS as output streams,
+                  charged from the live SSE deltas
 
-If the request still cannot be admitted, the router returns an error without sending the request to an inference backend.
+admit while:  Σ w  (over in-flight requests)  +  w_new  ≤  budget
+```
+
+- **Declared `max_tokens`** is reserved in full at admission (the OpenAI/Azure posture): a client cannot under-declare and then blow the pool mid-stream, and over-declaring only self-limits its own admission.
+- **Undeclared `max_tokens`** reserves only the input, then grows per streamed output chunk (the Anthropic posture) — on vLLM an undeclared request may generate up to `max_model_len − input`, so a fake reservation would either truncate honest long outputs or pessimistically reserve the whole pool. A negative `max_tokens` is treated as undeclared.
+- The reservation is **released exactly once** on every exit path — success, error, timeout, client disconnect — and **released early** when the request fails over to a [cloud provider fallback](/routing/provider-fallback), since a provider-served request consumes no local KV cache.
+- When the backend reports exact `usage.prompt_tokens`, the reservation is **trued up** by `exact − estimate` and the exact count feeds the estimator (see below).
+
+## B1 — per-request caps
+
+The policy fields `max_input_tokens` and `images_max` bound the worst single request; either breach is a 400 `input_too_long` (not retryable — the request must shrink).
+
+- The input check uses the **same estimate B2 reserves** (learned per-model ratio over message text, the Anthropic top-level `system` prompt, and tool-definition JSON), so the two gates never disagree about a request's size.
+- Images are bounded by **count**, not tokens — image token cost is not byte-estimable, so `images_max` is the cap. Both the OpenAI `image_url` part and the Anthropic `image` block count.
+- There is deliberately **no output clamp**: the engine already bounds output at `max_model_len − input`, and clamping declared outputs while undeclared ones live-meter would punish the honest client. The benchmark's "admitted/certified output" numbers are disclosure bands, never router caps.
+
+## B2 — the occupancy admit budget
+
+The core gate. Per model, the router tracks the weighted in-flight sum `Σw` and admits while it fits the **effective pool budget**:
+
+```text
+pool_budget = admit_fraction × admit_budget_tokens × healthy_replicas
+```
+
+- `admit_budget_tokens` (policy) is the **per-replica** KV token capacity certified by the benchmark (`router_limits.yaml kv_occupancy.admit_budget_tokens`).
+- `admit_fraction` (router config, default **0.90**) leaves headroom for token-estimate error. It shipped at 0.85 and was raised to 0.90 once the learned estimator + true-up replaced the `len/4` heuristic (which under-counted coding inputs by ~20%).
+- `healthy_replicas` scales the budget to the live pool, recomputed per request and floored at 1 — so the budget tracks replicas joining and leaving, and zero healthy replicas cannot zero the budget (which would read as "gate off"). Routing spreads the admitted load; a single hot replica is handled by the per-agent `exclude_if` gates and B3, not by this counter.
+- `max_inflight` (policy) is a plain per-replica concurrency backstop from `max(concurrency.soak_running_p95_per_sku)`, scaled by the same replica count.
+
+An over-budget request whose own footprint could ever fit **parks** for up to `HIVENET_ROUTER_ADMIT_PARK_TIMEOUT` (default 250ms) waiting for a release, then rejects with 429 + `Retry-After`. A request whose footprint alone exceeds the budget rejects immediately — parking cannot save it.
+
+## B3 — front-door KV-pressure shed
+
+B2 works from estimates; B3 reads the **live engine signal**. When the mean KV-cache utilization or waiting-request count across the model's healthy replicas breaches the policy's `shed_if` thresholds, new requests are rejected at the door with 429 rather than queued into an already-saturated pool.
+
+```yaml
+shed_if:
+  kv_cache_utilization: { gt: 0.90 }   # aligned with admit_fraction
+  waiting_requests:     { gt: 20 }
+```
+
+- The signal is the **mean** across healthy replicas (a single hot replica is routing's job, shedding is warranted only when the pool as a whole is under pressure).
+- A missing signal **fails open**: engines that do not report KV utilization simply skip that dimension, and B2's static budget carries the safety.
+- Only `kv_cache_utilization` and `waiting_requests` are accepted in `shed_if`; an unknown field is a load-time error (a typo must not silently disable the shed).
+- 0.90 is more permissive than the industry de-facto 0.80; it leans on the learned estimator's accuracy. Lower it if preemption metrics show the estimate is optimistic.
+
+## B4 — serverless per-key caps
+
+Applied only when the governing policy declares `mode: serverless` (many keys sharing replicas). On `mode: reserved` (default — one client rents the whole replica) these are inert; B1/B2/B3 still protect the box.
+
+| Cap | Field | Mechanism |
+| --- | --- | --- |
+| Requests/min | `quota.requests_per_minute` | token bucket; burst = certified window via `HIVENET_ROUTER_RPM_BURST_SECONDS`, not the library's full-minute default |
+| Input tokens/min | `quota.input_tokens_per_minute` | bucket charged with the admission estimate **before** the daily budget, so a rate rejection never spends daily tokens |
+| Output tokens/min | `quota.output_tokens_per_minute` | metered **post-hoc** from real usage (never reserved); a key that over-produces is held off on its *next* request |
+| Occupancy share | `max_occupancy_share` (key-level) | the key's in-flight `Σw` must fit `share × pool_budget` — the same replica-scaled pool B2 admits against |
+
+B4 is **fairness and anti-abuse, not box protection** — the caps are deliberately oversubscribed (three keys with share 0.40 = 1.2×; do not make them "add up"), because B2/B3 are the safety. Two invariants are validated at load, on reload, and on every admin-API key mutation:
+
+- `max_occupancy_share` ∈ (0, 1], 0 meaning unset — above 1 one key could out-reserve the pool.
+- `input_tokens_per_minute ≥ max_input_tokens` on every serverless model the key can reach — a smaller bucket can *never* admit a full-context prompt and silently becomes a context cap. The router refuses to start, refuses the reload, and returns 400 from the admin API rather than accept it.
+
+Per-model default derivation rules (recompute per campaign; never copy another model's constants): share = `max(max_model_len/admit_budget, 0.40)`; ITPM = `clamp(share × itpm_ceiling, 2 × max_input_tokens, itpm_ceiling)`; OTPM = `share × otpm_ceiling`; RPM ≈ `2 × max(sellable_rpm)`. The reference implementation is `auth.DeriveKeyDefaults` (`internal/auth/derive.go`).
+
+## The token estimator
+
+Admission is only as good as its input estimate. The router uses a **per-model learned ratio** instead of a fixed heuristic (`internal/tokenizer/estimator.go`):
+
+- **Estimate** = `ceil(text_bytes × ratio)`, floored at 4 tokens per message so a textless (image/tool-only) request is still counted. `text_bytes` covers message text, the Anthropic top-level `system` prompt, and the raw `tools` JSON (tool schemas are rendered into the prompt and tokenized by the backend).
+- **Cold start** assumes 3.2 chars/token (code density), not 4 — `len/4` under-counts coding inputs by ~20%.
+- **Learning**: each exact `usage.prompt_tokens` from a backend response folds `prompt_tokens ÷ text_bytes` into the model's ratio via EWMA (α = 0.2). Samples are clamped to 0.05–1.0 tokens/byte so one unmodeled request cannot swing the ratio.
+- **Learning guards** — the estimator only learns from samples that describe *this model's text tokenizer*: fallback estimates are never fed back (it would relearn its own heuristic), image-carrying requests are skipped (image tokens would inflate the text ratio), and provider-fallback responses are skipped (a different tokenizer).
+- **True-up**: on completion the in-flight reservation is corrected by `exact − estimate`, capped so it can never free more than the reservation holds.
+- Both usage dialects are parsed: OpenAI (`prompt_tokens`/`completion_tokens`, streaming via `stream_options.include_usage`) and Anthropic (`input_tokens`/`output_tokens`, streaming via `message_start`/`message_delta` events).
+
+The exact per-model tokenizer embedded in the router (phase 2) is deliberately deferred; no synchronous backend `/tokenize` call sits on the admission path.
+
+## What is exempt
+
+- **`/v1/messages/count_tokens`** skips B1–B4 entirely: it is a stateless tokenizer lookup that holds no KV cache and generates nothing, and clients that count before sending (Claude Code's pattern) would otherwise be billed twice per request. The per-key RPM flood guard still covers it.
+- **Provider-fallback traffic** (OpenAI/Anthropic cloud): the occupancy reservation is released the moment the request leaves the local pool, and provider-served responses charge no OTPM and never teach the estimator. RPM, ITPM, and the daily input charge still apply — they are taken before routing and are the key's commercial plan limits regardless of who serves.
+- **Embeddings and reranking** (`/v1/embeddings`, `/v1/rerank`) bypass admission control and token metering entirely — the gates model KV-cache-bound *generation*, which prefill-only workloads do not do. They are protected by RPM, the body-size cap, and the concurrency/queue gates only. This is a stated scope decision, not an oversight.
+
+## Housekeeping
+
+Per-key limiter state (RPM/ITPM/OTPM buckets, occupancy counters, daily counters) is garbage-collected by the router's 5-minute GC tick, losslessly: rate buckets are evicted only when full (a full bucket is identical to the fresh one the next request creates), daily counters only after their UTC day passes, occupancy states only when empty and idle for 15 minutes. Cumulative usage history is unaffected — it lives in the [Prometheus tenant counters](/observability/prometheus-metrics) and the [audit log](/observability/audit-logging), never in these maps.
+
+## Configuration
+
+| Environment variable | Default | Meaning |
+| --- | --- | --- |
+| `HIVENET_ROUTER_ADMIT_FRACTION` | `0.90` | Scales `admit_budget_tokens` into the effective budget; range (0,1] |
+| `HIVENET_ROUTER_ADMIT_PARK_TIMEOUT` | `250ms` | How long an over-budget request waits for occupancy to free before 429 (0 = reject immediately) |
+| `HIVENET_ROUTER_RPM_BURST_SECONDS` | `0` | RPM bucket burst window in seconds; 0 or ≥60 keeps the legacy full-minute burst |
+
+Per-model limits live in the [policy YAML](/routing/policy-yaml-reference) (`mode`, `max_input_tokens`, `images_max`, `admit_budget_tokens`, `max_inflight`, `shed_if`); per-key caps live in the [auth YAML](/security/auth-yaml-reference) (`quota.*_tokens_per_minute`, `max_occupancy_share`). Every benchmark-derived number loads from the model's `router_limits.yaml` — never hardcode one.
 
 ## Admission errors
 
-Two admission-specific error codes are important to clients:
-
-| Error | Meaning | Recommended client behavior |
-| --- | --- | --- |
-| `input_too_long` | The request exceeds a configured token or image limit. | Reduce the prompt or image payload. Retrying unchanged will not help. |
-| `concurrency_limit_exceeded` | Current occupancy or a per-key concurrency budget prevents admission. | Retry with backoff and jitter, or reduce concurrent work. |
-
-Treat these errors differently. `input_too_long` requires a smaller request. `concurrency_limit_exceeded` describes temporary or policy-limited capacity.
+| Error | HTTP | Meaning | Client behavior |
+| --- | --- | --- | --- |
+| `input_too_long` | 400 | Prompt over `max_input_tokens`, or images over `images_max`. | Reduce the payload. Retrying unchanged will not help. |
+| `concurrency_limit_exceeded` | 429 | Occupancy budget, `max_inflight`, or the front-door shed. | Retry with backoff + jitter; honor `Retry-After`. |
+| `rate_limit_exceeded` | 429 | A per-key cap (RPM, ITPM, OTPM, occupancy share). | Retry with backoff, or spread work across keys/time. |
+| `token_limit_exceeded` | 429 | Daily token budget exhausted. | Do not retry until UTC midnight. |
 
 ## Client guidance
 
-- Apply exponential backoff with jitter to temporary admission failures.
-- Bound retries so a saturated fleet does not receive a retry storm.
-- Track admission errors separately from backend failures.
-- Use separate API keys for workloads that require distinct occupancy or rate budgets.
+- Apply exponential backoff with jitter to 429s; bound retries so a saturated fleet does not receive a retry storm.
+- Declare `max_tokens` when you know your output size — a declared request admits or rejects instantly instead of growing into a mid-stream squeeze on the pool.
+- Track `input_too_long` separately from the 429 family: it needs a smaller request, not a retry.
+- Use separate API keys for workloads that need distinct occupancy or rate budgets.
 - Keep client timeouts longer than the configured parking window.
 
 ## Related pages
 
 <CardGroup cols={2}>
-  <Card title="Policy gates" href="/routing/policy-gates">
-    Control which routes and models are eligible before admission.
+  <Card title="Policy YAML reference" href="/routing/policy-yaml-reference">
+    The per-model admission fields: mode, caps, budget, shed thresholds.
   </Card>
 
-  <Card title="API keys" href="/security/api-keys">
-    Configure request, token, and occupancy limits for credentials.
+  <Card title="Auth YAML reference" href="/security/auth-yaml-reference">
+    Per-key quotas: RPM, ITPM, OTPM, occupancy share, daily tokens.
+  </Card>
+
+  <Card title="Admission control metrics" href="/observability/admission-control-metrics">
+    Occupancy vs budget, in-flight concurrency, and 429s by reason.
   </Card>
 
   <Card title="Error codes" href="/reference/error-codes">
     Handle router, agent, backend, and admission failures consistently.
-  </Card>
-
-  <Card title="Prometheus metrics" href="/observability/prometheus-metrics">
-    Monitor capacity, occupancy, latency, and rejected work.
   </Card>
 </CardGroup>

--- a/docs/routing/admission-control.mdx
+++ b/docs/routing/admission-control.mdx
@@ -118,7 +118,7 @@ The exact per-model tokenizer embedded in the router (phase 2) is deliberately d
 
 ## What is exempt
 
-- **`/v1/messages/count_tokens`** skips B1–B4 entirely: it is a stateless tokenizer lookup that holds no KV cache and generates nothing, and clients that count before sending (Claude Code's pattern) would otherwise be billed twice per request. The per-key RPM flood guard still covers it.
+- **`/v1/messages/count_tokens`** skips B1–B4 entirely: it is a stateless tokenizer lookup that holds no KV cache and generates nothing, and clients that count before sending (Claude Code's pattern) would otherwise be billed twice per request. It charges no token quota — including the daily budget — and is guarded by the per-key RPM flood limit alone.
 - **Provider-fallback traffic** (OpenAI/Anthropic cloud): the occupancy reservation is released the moment the request leaves the local pool, and provider-served responses charge no OTPM and never teach the estimator. RPM, ITPM, and the daily input charge still apply — they are taken before routing and are the key's commercial plan limits regardless of who serves.
 - **Embeddings and reranking** (`/v1/embeddings`, `/v1/rerank`) bypass admission control and token metering entirely — the gates model KV-cache-bound *generation*, which prefill-only workloads do not do. They are protected by RPM, the body-size cap, and the concurrency/queue gates only. This is a stated scope decision, not an oversight.
 

--- a/docs/routing/admission-control.mdx
+++ b/docs/routing/admission-control.mdx
@@ -12,6 +12,8 @@ A GPU inference box under overload does not crash or return errors — the engin
 
 The router therefore admits on **tokens in flight**, not request counts. Requests-per-minute and tokens-per-day are kept for the jobs they are good at (tiny-request flood guard, commercial budget); the occupancy budget is the gate that protects the latency SLO.
 
+The gates are **engine-agnostic**: B1, B2, and B4 are pure router-side counters whose only engine-supplied number is the KV capacity in tokens — measured by benchmarking whatever engine is deployed, not read from an engine API — so they work unchanged in front of vLLM, SGLang, or any other KV-cache-bound engine. B3 is the one telemetry-coupled gate, and it fails open when an engine does not report the signals.
+
 ## The gate pipeline
 
 Every `/v1/chat/completions` and `/v1/messages` request passes the gates in this order (`internal/api/handlers.go` `Passthrough`). Ordering is deliberate: cheap, deterministic rejections come first, and nothing charges the tenant's daily budget until every cheaper gate has passed.
@@ -69,6 +71,19 @@ pool_budget = admit_fraction × admit_budget_tokens × healthy_replicas
 - `max_inflight` (policy) is a plain per-replica concurrency backstop from `max(concurrency.soak_running_p95_per_sku)`, scaled by the same replica count.
 
 An over-budget request whose own footprint could ever fit **parks** for up to `HIVENET_ROUTER_ADMIT_PARK_TIMEOUT` (default 250ms) waiting for a release, then rejects with 429 + `Retry-After`. A request whose footprint alone exceeds the budget rejects immediately — parking cannot save it.
+
+### How many requests fit
+
+Concurrent capacity is **arithmetic, not a curve**: when all requests are roughly the same size `s`, the pool holds `min(floor(pool_budget / s), max_inflight × replicas)` of them. With a single replica and a ~409K-token effective budget:
+
+| Request size (input + output) | Fits concurrently |
+| --- | --- |
+| 250K (full-context coding) | 1 |
+| 64K | ~6 |
+| 16K | ~24 |
+| ~3K (chat turn) | ~130 → capped by `max_inflight` |
+
+Mixed traffic shares the same weighted sum — one 250K request displaces ~80 chat turns. This is why three full-context requests arriving together can 429 while hundreds of chat turns flow freely, and why declaring an accurate `max_tokens` matters: the reservation is the footprint.
 
 ## B3 — front-door KV-pressure shed
 

--- a/docs/routing/policy-yaml-reference.mdx
+++ b/docs/routing/policy-yaml-reference.mdx
@@ -14,6 +14,18 @@ Policies use YAML and can apply globally or to specific models.
 models:
   - meta-llama/Llama-3.1-8B-Instruct
 
+# Admission control (all fields optional; zero = gate disabled)
+mode: serverless                 # reserved (default) | serverless
+max_input_tokens: 262144         # B1: reject larger prompts with 400 input_too_long
+images_max: 10                   # B1: reject requests carrying more images
+admit_budget_tokens: 408987      # B2: per-replica KV-occupancy budget (tokens)
+max_inflight: 37                 # B2: per-replica concurrent-request backstop
+shed_if:                         # B3: front-door 429 on live engine pressure
+  kv_cache_utilization:
+    gt: 0.90
+  waiting_requests:
+    gt: 20
+
 routing_policy:
   match:
     region: EU-France
@@ -23,7 +35,7 @@ routing_policy:
 
   exclude_if:
     kv_cache_utilization:
-      gt: 0.85
+      gt: 0.90
     success_rate:
       lt: 0.95
 
@@ -53,6 +65,12 @@ fallback_provider:
 | Field | Type | Required | Purpose |
 | --- | --- | --- | --- |
 | `models` | Array of strings | For per-model policy documents | Models that use this policy |
+| `mode` | String | No (default `reserved`) | Admission profile: `serverless` activates per-key caps |
+| `max_input_tokens` | Integer | No (0 = disabled) | Per-request prompt cap (admission gate B1) |
+| `images_max` | Integer | No (0 = disabled) | Per-request image-count cap (admission gate B1) |
+| `admit_budget_tokens` | Integer | No (0 = disabled) | Per-replica KV-occupancy budget (admission gate B2) |
+| `max_inflight` | Integer | No (0 = disabled) | Per-replica in-flight request backstop (admission gate B2) |
+| `shed_if` | Object | No | Front-door shed thresholds (admission gate B3) |
 | `routing_policy` | Object | Yes | Primary local routing step |
 | `fallback_chain` | Array | No | Ordered local fallback steps |
 | `fallback_provider` | Object | No | Final external provider fallback |
@@ -64,6 +82,52 @@ The `models` field is ignored for a global policy loaded through:
 - `PUT /admin/policy`
 
 It is required for named per-model policy documents.
+
+## Admission control fields
+
+These fields configure the [admission gates](/routing/admission-control) for every model the policy governs. All are optional — a zero/absent value disables that gate, so a routing-only policy passes unchanged.
+
+```yaml
+mode: serverless
+max_input_tokens: 262144
+images_max: 10
+admit_budget_tokens: 408987
+max_inflight: 37
+shed_if:
+  kv_cache_utilization: { gt: 0.90 }
+  waiting_requests:     { gt: 20 }
+```
+
+### `mode`
+
+| Value | Meaning |
+| --- | --- |
+| `reserved` (default) | One client rents the whole replica: circuit-breaker gates only (B1/B2/B3), no per-key caps. |
+| `serverless` | Many keys share the replicas: the same circuit breaker **plus** the per-key caps (B4) declared on each key in `auth.yaml`. |
+
+An empty `mode` is normalised to `reserved` at load; any other value is a load-time error.
+
+### `max_input_tokens` and `images_max`
+
+Per-request hard caps (B1); a breach is a 400 `input_too_long`. The token check uses the router's learned admission estimate (message text + Anthropic `system` prompt + tool-definition JSON); images are counted (`image_url` parts and Anthropic `image` blocks). There is deliberately no output-token field — the router never clamps `max_tokens`.
+
+### `admit_budget_tokens` and `max_inflight`
+
+Both are **per-replica** numbers from the model's benchmark artifact (`router_limits.yaml`: `kv_occupancy.admit_budget_tokens` and `max(concurrency.soak_running_p95_per_sku)`). At enforcement the router scales each by the count of healthy replicas serving the model and applies the admit fraction:
+
+```text
+effective budget = HIVENET_ROUTER_ADMIT_FRACTION × admit_budget_tokens × healthy_replicas
+```
+
+A request is admitted while the model's weighted in-flight token sum plus its own footprint fits the effective budget and the in-flight count fits the scaled `max_inflight`; otherwise it parks briefly, then 429 `concurrency_limit_exceeded`.
+
+### `shed_if`
+
+Front-door shed thresholds (B3), evaluated against the **mean** live engine pressure across the model's healthy replicas. Exactly two fields are accepted — `kv_cache_utilization` and `waiting_requests` — each with exactly one comparison operator (`gt`, `lt`, `gte`, `lte`); an unknown field or operator count is a load-time error, so a typo cannot silently disable the shed. A replica pool that reports neither signal passes (the gate fails open and B2's static budget carries the safety). This is additive to the per-agent `exclude_if` routing gates: `exclude_if` drops one hot agent from the candidate pool, `shed_if` rejects new work at the door when the whole pool is saturated.
+
+### Validation
+
+Negative values for any cap are a load-time error. Cross-config invariants that span this file and `auth.yaml` (a serverless key's `input_tokens_per_minute` must cover `max_input_tokens`) are checked at startup, on every SIGHUP reload of either file, and on admin-API key mutations — the offending config is rejected rather than silently capping context. See [Auth YAML reference](/security/auth-yaml-reference).
 
 ## Primary routing policy
 

--- a/docs/routing/provider-fallback.mdx
+++ b/docs/routing/provider-fallback.mdx
@@ -304,7 +304,14 @@ meta-llama/Llama-3.1-8B-Instruct
 
 It does not need a Hivenet Router allowlist entry for the external provider model.
 
-Request and token accounting also remains associated with the original requested model and tenant. When the provider returns usage data, Hivenet Router charges the resulting input and output tokens to the same quota bucket used during request admission.
+Request and token accounting remains associated with the original requested model and tenant, but a provider-served request is deliberately **not** charged as local load:
+
+- Charges taken **before routing** stand: the per-key request-rate deduction, the input-tokens-per-minute charge, and the daily input-token reservation. They are the key's plan limits and apply regardless of which backend answers.
+- The **KV-occupancy reservation is released** the moment the request is handed to the provider — provider traffic consumes the provider's account, not local GPU memory.
+- Provider output is **not** charged against the per-key output-tokens-per-minute cap, and provider usage never feeds the router's learned token estimator (the provider's tokenizer differs from the local model's).
+- The provider-reported usage is still recorded in the per-tenant Prometheus token counters and the audit log, attributed to the original model, so billing and observability see the real consumption.
+
+See [Admission control](/routing/admission-control) for the full accounting model.
 
 ## OpenAI fallback
 

--- a/docs/security/api-keys.mdx
+++ b/docs/security/api-keys.mdx
@@ -309,13 +309,19 @@ The flat quota shape applies one request and token budget to every model the own
 quota:
   requests_per_minute: 1000
   tokens_per_day: 1000000
+  input_tokens_per_minute: 524288    # serverless deployments only
+  output_tokens_per_minute: 47424    # serverless deployments only
 ```
 
 | Field | Meaning |
 | --- | --- |
 | `requests_per_minute` | Shared request-rate ceiling |
 | `tokens_per_day` | Shared daily chat-token budget |
+| `input_tokens_per_minute` | Per-key input-token rate; applies only on `mode: serverless` policies |
+| `output_tokens_per_minute` | Per-key output-token rate, metered from real usage; applies only on `mode: serverless` policies |
 | `0` | Unlimited |
+
+Serverless keys can additionally declare a key-level `max_occupancy_share` — the fraction of a model pool's KV-occupancy budget the key may hold in flight at once. See [Admission control](/routing/admission-control) and the [auth YAML reference](/security/auth-yaml-reference) for the full semantics, derivation rules, and the validation invariants (`input_tokens_per_minute` must cover one maximum-size prompt on every serverless model the key can reach).
 
 The flat quota bucket is keyed by:
 
@@ -331,7 +337,7 @@ This has an important consequence:
   Use different owner values when keys require independent quota buckets.
 </Warning>
 
-The request-rate limiter uses a token bucket. It begins with up to one minute’s configured capacity and refills continuously rather than resetting at fixed clock-minute boundaries.
+The request-rate limiter uses a token bucket. It begins with up to one minute’s configured capacity and refills continuously rather than resetting at fixed clock-minute boundaries. Operators can shrink the burst window below a full minute with `HIVENET_ROUTER_RPM_BURST_SECONDS`, so a key cannot spend its entire minute’s quota in one instant.
 
 The daily token counter resets at midnight UTC.
 

--- a/docs/security/auth-yaml-reference.mdx
+++ b/docs/security/auth-yaml-reference.mdx
@@ -462,7 +462,7 @@ api:
       tokens_per_day: 5000000
 ```
 
-- **ITPM** is a continuously refilling token bucket (rate = limit/60 per second, capacity = one minute). It is charged with the request's estimated input tokens *before* the daily budget, so a rate rejection never spends daily tokens.
+- **ITPM** is a continuously refilling token bucket (rate = limit/60 per second, capacity = one minute). It is charged with the request's estimated input tokens *before* the daily budget, so a rate rejection never spends daily tokens. Note that **cached prompt prefixes currently count in full toward ITPM** — a discount for engine-cached tokens is a planned refinement — so agentic clients that resend a long, stable prefix every turn spend their ITPM faster than the GPU-side cost would suggest. Size such keys' ITPM (or a per-key override) with that in mind.
 - **OTPM** is metered after each response from the real completion tokens — output is never reserved up front, so a long response spread over minutes is not penalised; a key that over-produces is held off on its next request instead.
 - **`max_occupancy_share`** bounds the key's token-weighted in-flight sum to `share × (admit_fraction × admit_budget_tokens × healthy replicas)` — the same pool the global occupancy gate admits against.
 - The caps are **fairness/anti-abuse, deliberately oversubscribed** — box safety is the occupancy budget and the shed gate, so do not size shares to "add up" to 1.0.

--- a/docs/security/auth-yaml-reference.mdx
+++ b/docs/security/auth-yaml-reference.mdx
@@ -184,6 +184,7 @@ api:
 | `metadata` | Yes | Identity and lifecycle information |
 | `models` | No | Exact model allowlist |
 | `quota` | No | Flat or per-model quota configuration |
+| `max_occupancy_share` | No | Serverless occupancy share: the fraction of a model pool's admit budget this key may hold in flight at once. Range (0, 1]; 0/absent = unset. Sits at the key level (not inside `quota`) because it is a fraction of the replica pool's KV budget, not a per-minute rate. Ignored on `mode: reserved` policies. |
 
 ### `key_hash`
 
@@ -385,13 +386,19 @@ The flat quota shape applies one shared budget to every model the owner may call
 quota:
   requests_per_minute: 1000
   tokens_per_day: 5000000
+  input_tokens_per_minute: 519540    # serverless per-key ITPM (admission gate B4)
+  output_tokens_per_minute: 47424    # serverless per-key OTPM (admission gate B4)
 ```
 
 | Field | Required | Description |
 | --- | --- | --- |
 | `requests_per_minute` | No | Shared request-rate limit |
 | `tokens_per_day` | No | Shared daily language-model token budget |
+| `input_tokens_per_minute` | No | Per-key input-token rate; charged with the admission estimate before forwarding. Applies only on `mode: serverless` policies |
+| `output_tokens_per_minute` | No | Per-key output-token rate; metered from real usage after each response (never reserved). Applies only on `mode: serverless` policies |
 | `0` | Not applicable | Unlimited |
+
+The two per-minute token fields are flat-shape only — they cannot be combined with `per_model`, like the other flat fields. Negative values are rejected at load.
 
 Flat quota buckets are associated with the owner rather than the individual key.
 
@@ -437,6 +444,38 @@ The daily budget:
 A value of `0` disables the token budget.
 
 Embedding and reranking requests currently participate in request-rate limits but do not charge input against `tokens_per_day`.
+
+### Serverless per-key caps (B4)
+
+On a policy with `mode: serverless`, four per-key caps apply on top of the shared circuit breaker — see [Admission control](/routing/admission-control) for the full model:
+
+```yaml
+api:
+  - key_hash: "..."
+    metadata: { name: some-customer, owner: acme }
+    models: [gemma-4-31b]
+    max_occupancy_share: 0.64
+    quota:
+      requests_per_minute: 96
+      input_tokens_per_minute: 519540
+      output_tokens_per_minute: 47424
+      tokens_per_day: 5000000
+```
+
+- **ITPM** is a continuously refilling token bucket (rate = limit/60 per second, capacity = one minute). It is charged with the request's estimated input tokens *before* the daily budget, so a rate rejection never spends daily tokens.
+- **OTPM** is metered after each response from the real completion tokens — output is never reserved up front, so a long response spread over minutes is not penalised; a key that over-produces is held off on its next request instead.
+- **`max_occupancy_share`** bounds the key's token-weighted in-flight sum to `share × (admit_fraction × admit_budget_tokens × healthy replicas)` — the same pool the global occupancy gate admits against.
+- The caps are **fairness/anti-abuse, deliberately oversubscribed** — box safety is the occupancy budget and the shed gate, so do not size shares to "add up" to 1.0.
+- Rejections are 429 `rate_limit_exceeded` with `Retry-After`.
+
+Derive the four values per model from its benchmark artifact (`auth.DeriveKeyDefaults` implements the rules); never copy another model's constants.
+
+### Cross-config validation
+
+Two invariants are enforced wherever keys enter the system — at startup, on SIGHUP reload of `auth.yaml` or the policies, and on every dynamic admin-API key mutation (`PUT /admin/api-keys/:id`, `POST /admin/api-keys/replace`):
+
+1. `max_occupancy_share` must be in (0, 1] (0 means unset). Above 1 one key could out-reserve the whole pool.
+2. On every serverless model a key can reach, `input_tokens_per_minute` must be at least the policy's `max_input_tokens`. A smaller bucket can never admit a full-context prompt — even from a completely idle bucket — so it silently becomes a context cap for that key. The router refuses to start, rejects the reload, or returns 400 from the admin API instead.
 
 ## Per-model quotas
 

--- a/docs/security/auth-yaml-reference.mdx
+++ b/docs/security/auth-yaml-reference.mdx
@@ -447,7 +447,7 @@ Embedding and reranking requests currently participate in request-rate limits bu
 
 ### Serverless per-key caps (B4)
 
-On a policy with `mode: serverless`, four per-key caps apply on top of the shared circuit breaker — see [Admission control](/routing/admission-control) for the full model:
+On a policy with `mode: serverless`, the per-key occupancy share and input/output tokens-per-minute caps apply **in addition to** the always-on per-key request-rate limit (`requests_per_minute`, enforced at the front door in every mode) — see [Admission control](/routing/admission-control) for the full model:
 
 ```yaml
 api:
@@ -466,7 +466,7 @@ api:
 - **OTPM** is metered after each response from the real completion tokens — output is never reserved up front, so a long response spread over minutes is not penalised; a key that over-produces is held off on its next request instead.
 - **`max_occupancy_share`** bounds the key's token-weighted in-flight sum to `share × (admit_fraction × admit_budget_tokens × healthy replicas)` — the same pool the global occupancy gate admits against.
 - The caps are **fairness/anti-abuse, deliberately oversubscribed** — box safety is the occupancy budget and the shed gate, so do not size shares to "add up" to 1.0.
-- Rejections are 429 `rate_limit_exceeded` with `Retry-After`.
+- ITPM, OTPM, and occupancy-share rejections are 429 `rate_limit_exceeded` **with** `Retry-After`. The front-door `requests_per_minute` limiter also returns 429 `rate_limit_exceeded`, but **without** `Retry-After` (it sets `X-RateLimit-Remaining-Requests` instead) — so clients keyed on this error code should honor `Retry-After` when present and fall back to `60 / rpm` otherwise.
 
 Derive the four values per model from its benchmark artifact (`auth.DeriveKeyDefaults` implements the rules); never copy another model's constants.
 

--- a/docs/use-the-api/admin-endpoints.mdx
+++ b/docs/use-the-api/admin-endpoints.mdx
@@ -776,9 +776,12 @@ curl -X PUT \
     \"allowed_models\": [
       \"meta-llama/Llama-3.1-8B-Instruct\"
     ],
+    \"max_occupancy_share\": 0.4,
     \"quota\": {
       \"requests_per_minute\": 1000,
-      \"tokens_per_day\": 1000000
+      \"tokens_per_day\": 1000000,
+      \"input_tokens_per_minute\": 524288,
+      \"output_tokens_per_minute\": 47424
     }
   }" \
   http://localhost:8080/admin/api-keys/acme-prod
@@ -802,7 +805,8 @@ Response:
 | `enabled` | Yes | Whether the key may authenticate |
 | `expires_at` | No | RFC 3339 timestamp; empty means no expiry |
 | `allowed_models` | No | Model allowlist; empty means unrestricted |
-| `quota` | No | Flat or per-model quota configuration |
+| `quota` | No | Flat or per-model quota configuration; the flat shape also accepts the serverless `input_tokens_per_minute` / `output_tokens_per_minute` caps |
+| `max_occupancy_share` | No | Serverless occupancy share, fraction of a model pool's admit budget in (0, 1]; 0 means unset. Key-level, mirroring the `auth.yaml` field |
 
 A stale version returns HTTP `409`:
 
@@ -814,6 +818,16 @@ A stale version returns HTTP `409`:
 ```
 
 A key hash cannot belong to two different IDs. Delete the existing entry before assigning its hash to another ID.
+
+### Admission validation on key writes
+
+`PUT /admin/api-keys/{id}` and `POST /admin/api-keys/replace` enforce the same admission invariants the static `auth.yaml` loader enforces at startup, returning HTTP `400` instead of accepting a key that would misbehave silently:
+
+- `max_occupancy_share` outside (0, 1] is rejected (a share above 1 would let one key out-reserve the whole pool).
+- Negative `input_tokens_per_minute` / `output_tokens_per_minute` are rejected.
+- On every `mode: serverless` model the key can reach, `input_tokens_per_minute` must be at least the policy's `max_input_tokens` — a smaller bucket can never admit a full-context prompt, so it would silently cap the usable context for that key.
+
+The reverse direction holds too: a policy reload that would break these invariants against the keys currently registered (static or dynamic) is rejected, keeping the previous policies active. See [Admission control](/routing/admission-control).
 
 ### Use per-model quotas
 

--- a/docs/use-the-api/chat-completions.mdx
+++ b/docs/use-the-api/chat-completions.mdx
@@ -27,9 +27,10 @@ For each request, Hivenet Router:
 2. applies request and token quotas when configured
 3. reads and validates the top-level `model` field
 4. checks that the API key may use that model
-5. selects a healthy `llm` agent through the routing policy
-6. forwards the original body to the same path on the selected backend
-7. returns the backend response to the client
+5. applies the [admission gates](/routing/admission-control) — per-request caps, pressure shed, occupancy budget, and (on serverless) per-key caps
+6. selects a healthy `llm` agent through the routing policy
+7. forwards the original body to the same path on the selected backend
+8. returns the backend response to the client
 
 Apart from the fields needed for routing and quota estimation, Hivenet Router does not impose its own generation schema or defaults. Parameters such as sampling controls, tools, structured output, multimodal input, and backend-specific extensions work only when the selected backend supports them.
 
@@ -145,8 +146,10 @@ Hivenet Router forwards the complete request, but it reads a small number of fie
 | Field | How Hivenet Router uses it |
 | --- | --- |
 | `model` | Selects matching agents and applies model restrictions |
-| `messages` | Estimates input-token use when token quotas are enabled |
-| `max_completion_tokens` | Checks the worst-case requested output against the daily token budget |
+| `messages` | Estimates input-token use for quotas and admission; image parts count against the per-request image cap |
+| `system` | Anthropic top-level system prompt — included in the input-token estimate |
+| `tools` | Tool/function definitions — their JSON bytes are included in the input-token estimate (the backend tokenizes them) |
+| `max_completion_tokens` | Reserved as the request's output footprint for occupancy admission and checked against the daily token budget |
 | `max_tokens` | Used as a fallback when `max_completion_tokens` is absent |
 | `stream` | Enables progressive streaming through the router and agent |
 
@@ -389,10 +392,13 @@ API keys can enforce:
 - requests per minute
 - daily token budgets
 - separate quotas for individual models
+- on serverless deployments: per-key input/output tokens-per-minute and an occupancy share (see [Admission control](/routing/admission-control))
 
 Before routing, Hivenet Router checks the request-rate quota.
 
-When a daily token budget is configured, it also estimates the prompt and checks whether the remaining budget can cover:
+Independently of per-key quotas, every request also passes the [admission gates](/routing/admission-control) for its model: the per-request input and image caps, the front-door pressure shed, and the KV-occupancy budget. These protect the serving pool as a whole and apply even to keys with unlimited quotas.
+
+When a daily token budget is configured, the router estimates the prompt and checks whether the remaining budget can cover:
 
 ```text
 estimated input tokens + requested maximum output tokens
@@ -402,9 +408,9 @@ estimated input tokens + requested maximum output tokens
 
 The estimated input tokens are charged at admission. Actual completion tokens are charged after the backend responds.
 
-<Warning>
-  Token estimation for Anthropic-format requests is best-effort. The estimator does not fully account for every Anthropic content structure, including some top-level system instructions and non-text blocks.
-</Warning>
+<Note>
+  The input estimate uses a per-model learned tokens-per-byte ratio that self-calibrates from each backend's reported usage, and it covers message text, the Anthropic top-level `system` prompt, and tool-definition JSON. The estimate is reconciled against the backend's exact `prompt_tokens` when the response completes. Image content is not byte-estimable and is bounded by the per-request image cap instead.
+</Note>
 
 ## Rate-limit headers
 
@@ -457,12 +463,14 @@ Common responses include:
 | HTTP status | Example code | Meaning |
 | --- | --- | --- |
 | `400` | `request_invalid` | Malformed request or missing model |
+| `400` | `input_too_long` | Prompt over the model's `max_input_tokens`, or more images than `images_max` |
 | `400` | `context_length_exceeded` | Backend rejected the context length |
 | `413` | Not guaranteed | Request body exceeds `HIVENET_ROUTER_MAX_REQUEST_BYTES` |
 | `401` | `unauthorized` | Missing or invalid credentials |
 | `403` | `model_forbidden` | API key cannot use the requested model |
 | `404` | `model_not_found` | No registered model matches the request |
-| `429` | `rate_limit_exceeded` | Request-rate quota exhausted |
+| `429` | `rate_limit_exceeded` | A per-key cap: request rate, input/output tokens per minute, or occupancy share |
+| `429` | `concurrency_limit_exceeded` | Occupancy budget or `max_inflight` full, or the front-door pressure shed fired; carries `Retry-After` |
 | `429` | `token_limit_exceeded` | Daily token budget exhausted |
 | `503` | `no_agents_available` | No healthy matching agent |
 | `503` | `no_capacity` | Matching agents are at capacity |

--- a/docs/use-the-api/embeddings.mdx
+++ b/docs/use-the-api/embeddings.mdx
@@ -271,6 +271,8 @@ When the request-rate quota is exhausted, Hivenet Router returns HTTP `429`.
 
 <Note>
   The current embedding path does not charge input or output tokens against the daily token quota. It records successful embedding requests with zero input and output tokens for quota accounting.
+
+  Embedding requests are also exempt from the [admission gates](/routing/admission-control) (per-request token caps, KV-occupancy budget, per-key token rates) by design: those gates model KV-cache-bound generation, which prefill-only embedding work does not do. The request-rate quota, body-size cap, and agent concurrency limits are the protections on this path.
 </Note>
 
 ## Routing policies

--- a/docs/use-the-api/reranking.mdx
+++ b/docs/use-the-api/reranking.mdx
@@ -328,6 +328,8 @@ When the request-rate quota is exhausted, Hivenet Router returns HTTP `429`.
 
 <Note>
   The current reranking path does not charge query or document tokens against the daily token quota. Successful reranking requests are recorded with zero input and output tokens for quota accounting.
+
+  Reranking requests are also exempt from the [admission gates](/routing/admission-control) (per-request token caps, KV-occupancy budget, per-key token rates) by design: those gates model KV-cache-bound generation. The request-rate quota, body-size cap, and agent concurrency limits are the protections on this path.
 </Note>
 
 ## Routing policies

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -404,10 +404,11 @@ func (h *Handlers) Passthrough(c *gin.Context) {
 	// shared estimator can shift between calls as other requests complete.
 	inputEstimate := h.estimatePromptTokens(&req)
 	// /v1/messages/count_tokens is a stateless tokenizer lookup: it holds no KV
-	// cache and generates nothing, so charging it against the occupancy budget or
-	// the per-key token buckets would double-bill every client that counts before
-	// it sends (Claude Code does exactly that). It skips the admission gates and
-	// is guarded by the per-key RPM flood limit alone.
+	// cache and generates nothing, so charging it against the occupancy budget,
+	// the per-key token buckets, or the daily token budget would double-bill
+	// every client that counts before it sends (Claude Code does exactly that).
+	// It skips the admission gates and the token quotas and is guarded by the
+	// per-key RPM flood limit alone.
 	countOnly := path == "/v1/messages/count_tokens"
 	var reservation admission.Reservations
 	if !countOnly {
@@ -443,7 +444,10 @@ func (h *Handlers) Passthrough(c *gin.Context) {
 	if !countOnly && !h.enforcePerKeyRates(c, &req, m, inputEstimate) {
 		return
 	}
-	if !h.reserveInputBudget(c, &req, m) {
+	// count_tokens is also exempt from the daily token budget: it generates
+	// nothing, and a count-then-send client would otherwise pay for every
+	// prompt twice (once counted, once sent).
+	if !countOnly && !h.reserveInputBudget(c, &req, m) {
 		return
 	}
 	if !captureRawBody(c, &req, m.requestID) {

--- a/test/api/count_tokens_test.go
+++ b/test/api/count_tokens_test.go
@@ -16,6 +16,7 @@ import (
 
 	"hivenet_router/internal/admission"
 	"hivenet_router/internal/api"
+	"hivenet_router/internal/auth"
 	"hivenet_router/internal/domain"
 	"hivenet_router/internal/policy"
 	"hivenet_router/internal/tokenizer"
@@ -88,5 +89,46 @@ func TestCountTokens_SkipsAdmissionGates(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (body %s)", w.Code, w.Body.String())
+	}
+}
+
+// TestCountTokens_SkipsDailyBudget verifies /v1/messages/count_tokens neither
+// checks nor charges the daily token budget: counting a prompt bigger than the
+// remaining budget must still succeed, and the budget must be untouched after —
+// a count-then-send client would otherwise pay for every prompt twice.
+func TestCountTokens_SkipsDailyBudget(t *testing.T) {
+	q := make(chan *domain.PendingRequest, 1)
+	lim := auth.NewInMemoryLimiter()
+	exec := policy.NewExecutor(nil, nil, &policy.Policy{}, 0, 0)
+	h := api.NewHandlers(
+		nil, nil, q, time.Second,
+		exec, nil, nil, lim,
+		nil, nil, nil, nil, nil, nil, nil, nil,
+		admission.NewController(1.0, 0), nil, nil, nil,
+		nil, tokenizer.NewEstimator(),
+	)
+	// The 400-byte prompt estimates to ~125 tokens — far over a 10-token daily
+	// budget, so the same body on /v1/messages would be a 429 token_limit_exceeded.
+	const tpd = 10
+	body := []byte(`{"model":"m","messages":[{"role":"user","content":"` + strings.Repeat("a", 400) + `"}]}`)
+	c, w := newCtx("/v1/messages/count_tokens", body)
+	c.Set("tenant_id", "t1")
+	c.Set("quota_limits", auth.QuotaLimits{TokensPerDay: tpd})
+
+	done := make(chan struct{})
+	go func() { h.Passthrough(c); close(done) }()
+	select {
+	case pending := <-q:
+		pending.Response <- &domain.ChatResponse{RawBytes: []byte(`{"input_tokens":123}`)}
+	case <-time.After(time.Second):
+		t.Fatal("count_tokens request was not enqueued — the daily budget rejected it")
+	}
+	<-done
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body %s)", w.Code, w.Body.String())
+	}
+	if remaining, err := lim.RemainingTokens("t1", "", tpd); err != nil || remaining != tpd {
+		t.Errorf("count_tokens must not charge the daily budget; remaining=%d (want %d), err=%v", remaining, tpd, err)
 	}
 }


### PR DESCRIPTION
Closes the rate-limiting series: RL-1…RL-7 shipped (PRs #5–#8, #14–#16) plus the post-merge review fixes (#17); this is the RL-8 documentation pass. **Docs only — no behavior changes.**

## What's in the PR (public docs site)

- **`routing/admission-control.mdx` — full technical rewrite.** The old page was a high-level sketch and documented `HR_*` environment variables that never existed. It now covers: why token-weighted admission (the KV-cache argument with the worked example), the exact gate pipeline and its ordering rationale, the footprint formula (declared reserve vs. live-growth for undeclared `max_tokens`, true-up, early release on provider fallback), B1 semantics (shared estimate, both image dialects, no output clamp), B2 (replica-scaled effective budget formula, parking, `max_inflight`), B3 (mean-pressure shed, fail-open, strict `shed_if` validation), B4 (all four per-key caps, oversubscription principle, derivation rules, the two validated invariants), the learned token estimator (what counts as estimable bytes, EWMA, clamps, learning guards), the three exemptions (`count_tokens`, provider fallback, embeddings/rerank — stated as scope decisions), the idle-state GC, correct `HIVENET_ROUTER_*` configuration, and the client error contract.
- **`routing/policy-yaml-reference.mdx`** — new "Admission control fields" section (`mode`, `max_input_tokens`, `images_max`, `admit_budget_tokens`, `max_inflight`, `shed_if`) with per-field semantics, validation rules, and the replica-scaling formula; the complete-structure example and top-level field table updated.
- **`security/auth-yaml-reference.mdx`** — per-key `input_tokens_per_minute` / `output_tokens_per_minute` in the flat-quota shape, the key-level `max_occupancy_share`, a "Serverless per-key caps (B4)" section, and the cross-config invariants (share range; ITPM ≥ `max_input_tokens`, enforced at startup, reload, and admin-API writes).
- **`reference/error-codes.mdx`** — `input_too_long` (400) and `concurrency_limit_exceeded` (429 + `Retry-After`) rows and retry guidance; `rate_limit_exceeded` trigger updated to cover the B4 caps.
- **`reference/configuration-reference.mdx`** — `HIVENET_ROUTER_ADMIT_FRACTION` (with the 0.85→0.90 history), `HIVENET_ROUTER_ADMIT_PARK_TIMEOUT`, `HIVENET_ROUTER_RPM_BURST_SECONDS`.
- **`use-the-api/admin-endpoints.mdx`** — `max_occupancy_share` and the per-minute quota fields on the key-write endpoints, plus the "Admission validation on key writes" contract (400 on invariant breach, both directions: key writes validated against policies, policy reloads validated against keys).

## Also updated (local-only, gitignored — not in this diff)

`docs/Exploration/` is gitignored, so the internal spec and ticket docs can't ship here, but they were updated on disk in the same pass per the RL-8 ticket: spec status flipped to **IMPLEMENTED** with a per-gate PR/merge-date table; every "Where:" line and the §4 hook table rewritten to as-merged `file:line` (re-verified 2026-08-12; spot-checked hooks all resolve); §1 dated as the pre-build survey with an as-built capability table; the 0.85→0.90 admit-fraction story recorded; new **§4a** records the as-built deviations (per-model enforcement with replica scaling, the three exemptions, estimator scope, dynamic-key validation, GC) instead of papering over them; §5 carries the follow-up for the benchmark-side `enforced: true` flip; RL-1…RL-7 stamped DONE, RL-9/RL-10 explicitly deferred.

## Verification

- No stale "not yet built" / `HR_*` language remains (grepped).
- All cited `file:line` hooks resolve against `main` at 2026-08-12 (spot-checked 10).
- Full preflight green (docs-only; confirms nothing else moved).

## Second commit: full-site alignment audit

Audited every remaining docs page for claims the admission work made stale; seven more pages corrected:

- **`use-the-api/chat-completions.mdx`** — pipeline gains the admission step; fields table gains `system`/`tools`; the outdated "Anthropic estimation is best-effort" warning replaced (system + tools **are** counted now); error table gains `input_too_long` + `concurrency_limit_exceeded`.
- **`routing/provider-fallback.mdx`** — the claim that provider usage is "charged to the same quota bucket used during admission" was wrong as built; replaced with the real accounting (pre-routing charges stand; occupancy released; no OTPM charge; no estimator learning; metrics/audit still record usage).
- **`security/api-keys.mdx`** — flat-quota shape gains the serverless per-minute fields + `max_occupancy_share` pointer; burst-window note.
- **`reference/detailed-architecture.mdx`** — request lifecycle step 4 now includes the admission gates, reservation lifetime, and the `count_tokens` exemption.
- **`observability/prometheus-metrics.mdx`** — the metrics catalog gains the admission family (previously only on the dedicated page).
- **`use-the-api/embeddings.mdx` + `reranking.mdx`** — the "no token charge" notes now also state the deliberate admission-gate exemption.

Pages already aligned and left untouched: `observability/admission-control-metrics.mdx` (current from RL-6), `routing/policy-gates.mdx`, `routing/fallback-chains.mdx`, getting-started/architecture pages (generic claims, still true), integrations pages.
