### PR TITLE
docs: polish Mintlify presentation across all pages

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -60,6 +60,24 @@ Use `hivenet-router`, `hivenet-agent`, `HIVENET_ROUTER_*`, and `sk-hivenet-*` wh
 
 Avoid unsupported claims, promotional language, and invented examples that appear to be guaranteed behavior.
 
+## Presentation system
+
+Use Mintlify components to clarify structure, meaning, or choice. Do not add components only for decoration.
+
+- Use `<Note>` for neutral supporting information that does not fit naturally in the main flow.
+- Use `<Info>` for behavior, prerequisites, or caveats the reader must understand.
+- Use `<Tip>` for optional shortcuts and improvements.
+- Use `<Warning>` when ignoring the content can break a deployment, expose access, or produce an unsafe configuration.
+- Use `<Danger>` only for destructive, irreversible, or security-critical actions.
+- Use `<Check>` to confirm that a procedure or verification succeeded.
+- Use `<Steps>` only for actions or events with a meaningful sequence.
+- Use `<Tabs>` for mutually exclusive choices or parallel variants, not to hide prerequisite or safety information.
+- Use `<CodeGroup>` for equivalent code or command alternatives.
+- Use `<AccordionGroup>` for troubleshooting, edge cases, and secondary detail. Keep core instructions and limitations visible.
+- Use `<Columns>` and `<Card>` for overview and navigation choices. Do not turn reference tables or ordinary paragraphs into cards.
+
+Keep callout meaning consistent across pages. Core requirements must remain understandable when a reader scans only the headings and visible text.
+
 ## Page structure
 
 Every MDX page must have valid frontmatter containing a clear title and description.

--- a/docs/deploy/agents/custom-engine.mdx
+++ b/docs/deploy/agents/custom-engine.mdx
@@ -465,179 +465,181 @@ curl http://192.168.1.100:2112/metrics \
 
 ## Troubleshooting
 
-### The agent reports that `--model` is required
+<AccordionGroup>
+  <Accordion title="The agent reports that `--model` is required">
+    The custom engine cannot discover models.
 
-The custom engine cannot discover models.
+    Start the agent with:
 
-Start the agent with:
-
-```bash
---model <model-name>
-```
-
-### The agent reports that `--health-url` is required
-
-Provide the complete health endpoint:
-
-```bash
---health-url http://localhost:8000/health
-```
-
-This is separate from `--backend-url`.
-
-### The backend never becomes ready
-
-Test the exact URL passed to `--health-url`:
-
-```bash
-curl -i http://localhost:8000/health
-```
-
-The endpoint must return HTTP `200`. Redirects, authentication challenges, and other status codes are treated as unhealthy.
-
-### Direct requests work, but routed requests fail
-
-Test the exact OpenAI-compatible path:
-
-```bash
-curl -X POST \
-  http://localhost:8000/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "meta-llama/Llama-3.1-8B-Instruct",
-    "messages": [
-      {
-        "role": "user",
-        "content": "Hello"
-      }
-    ]
-  }'
-```
-
-Common causes include:
-
-- the backend uses another path
-- the backend expects a proprietary request schema
-- the model name differs
-- the backend requires credentials that are not present in the client request
-- the backend does not support the requested field or streaming mode
-
-### The model is visible but requests do not route
-
-Check the model value in all three places:
-
-```text
-Agent --model
-Client request body
-Backend model identifier
-```
-
-The agent’s registered model must match the client request.
-
-Inspect the routing table:
-
-```bash
-curl http://192.168.1.100:8080/admin/routing-table \
-  | jq '.agents[]
-      | select(.metadata.engine == "custom")
-      | {
-          model: .metadata.model,
-          capability: .metadata.capability,
-          healthy: .status.healthy,
-          active_requests: .status.active_requests,
-          capacity: .metadata.capacity
-        }'
-```
-
-### The agent does not register
-
-Check the logs:
-
-<Tabs>
-  <Tab title="Docker">
     ```bash
-    docker logs hivenet-agent
+    --model <model-name>
     ```
-  </Tab>
-  <Tab title="systemd">
+  </Accordion>
+
+  <Accordion title="The agent reports that `--health-url` is required">
+    Provide the complete health endpoint:
+
     ```bash
-    sudo journalctl \
-      -u hivenet-agent \
-      -n 100 \
-      --no-pager
+    --health-url http://localhost:8000/health
     ```
-  </Tab>
-</Tabs>
 
-Test connectivity from the agent to the router:
+    This is separate from `--backend-url`.
+  </Accordion>
 
-```bash
-nc -zv 192.168.1.100 50051
-nc -zv 192.168.1.100 9000
-```
+  <Accordion title="The backend never becomes ready">
+    Test the exact URL passed to `--health-url`:
 
-Check that:
+    ```bash
+    curl -i http://localhost:8000/health
+    ```
 
-- the router and agent use the same JWT secret
-- the backend health endpoint returns HTTP `200`
-- the router’s libp2p interface is reachable
-- the router advertises a libp2p address the agent can reach
+    The endpoint must return HTTP `200`. Redirects, authentication challenges, and other status codes are treated as unhealthy.
+  </Accordion>
 
-### Streaming is buffered or incomplete
+  <Accordion title="Direct requests work, but routed requests fail">
+    Test the exact OpenAI-compatible path:
 
-Test the backend directly with `curl -N`.
+    ```bash
+    curl -X POST \
+      http://localhost:8000/v1/chat/completions \
+      -H "Content-Type: application/json" \
+      -d '{
+        "model": "meta-llama/Llama-3.1-8B-Instruct",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Hello"
+          }
+        ]
+      }'
+    ```
 
-Confirm that it returns a streaming content type and flushes chunks as they are generated.
+    Common causes include:
 
-Hivenet Router can relay an SSE stream, but it cannot correct buffering introduced by the backend or an intermediate proxy.
+    - the backend uses another path
+    - the backend expects a proprietary request schema
+    - the model name differs
+    - the backend requires credentials that are not present in the client request
+    - the backend does not support the requested field or streaming mode
+  </Accordion>
 
-### Requests time out
+  <Accordion title="The model is visible but requests do not route">
+    Check the model value in all three places:
 
-The backend HTTP timeout defaults to two minutes.
+    ```text
+    Agent --model
+    Client request body
+    Backend model identifier
+    ```
 
-Increase it for longer requests:
+    The agent’s registered model must match the client request.
 
-```bash
---http-timeout 10m
-```
+    Inspect the routing table:
 
-For streaming responses, the rolling stream-write timeout is configured separately:
+    ```bash
+    curl http://192.168.1.100:8080/admin/routing-table \
+      | jq '.agents[]
+          | select(.metadata.engine == "custom")
+          | {
+              model: .metadata.model,
+              capability: .metadata.capability,
+              healthy: .status.healthy,
+              active_requests: .status.active_requests,
+              capacity: .metadata.capacity
+            }'
+    ```
+  </Accordion>
 
-```bash
---stream-write-timeout 2m
-```
+  <Accordion title="The agent does not register">
+    Check the logs:
 
-Also check the backend’s own timeout, queue, and concurrency settings.
+    <Tabs>
+      <Tab title="Docker">
+        ```bash
+        docker logs hivenet-agent
+        ```
+      </Tab>
+      <Tab title="systemd">
+        ```bash
+        sudo journalctl \
+          -u hivenet-agent \
+          -n 100 \
+          --no-pager
+        ```
+      </Tab>
+    </Tabs>
 
-### The peer ID changes after restart
+    Test connectivity from the agent to the router:
 
-Make sure `--identity-path` points to persistent storage.
+    ```bash
+    nc -zv 192.168.1.100 50051
+    nc -zv 192.168.1.100 9000
+    ```
 
-For Docker:
+    Check that:
 
-```bash
-docker inspect hivenet-agent \
-  | jq '.[0].Mounts'
-```
+    - the router and agent use the same JWT secret
+    - the backend health endpoint returns HTTP `200`
+    - the router’s libp2p interface is reachable
+    - the router advertises a libp2p address the agent can reach
+  </Accordion>
 
-For bare metal:
+  <Accordion title="Streaming is buffered or incomplete">
+    Test the backend directly with `curl -N`.
 
-```bash
-ls -l /var/lib/hivenet-router/agent/identity.key
-```
+    Confirm that it returns a streaming content type and flushes chunks as they are generated.
+
+    Hivenet Router can relay an SSE stream, but it cannot correct buffering introduced by the backend or an intermediate proxy.
+  </Accordion>
+
+  <Accordion title="Requests time out">
+    The backend HTTP timeout defaults to two minutes.
+
+    Increase it for longer requests:
+
+    ```bash
+    --http-timeout 10m
+    ```
+
+    For streaming responses, the rolling stream-write timeout is configured separately:
+
+    ```bash
+    --stream-write-timeout 2m
+    ```
+
+    Also check the backend’s own timeout, queue, and concurrency settings.
+  </Accordion>
+
+  <Accordion title="The peer ID changes after restart">
+    Make sure `--identity-path` points to persistent storage.
+
+    For Docker:
+
+    ```bash
+    docker inspect hivenet-agent \
+      | jq '.[0].Mounts'
+    ```
+
+    For bare metal:
+
+    ```bash
+    ls -l /var/lib/hivenet-router/agent/identity.key
+    ```
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Chat completions" href="/use-the-api/chat-completions">
+<Columns cols={3}>
+  <Card title="Chat completions" icon="comments" href="/use-the-api/chat-completions">
     Review the supported request, response, and streaming behavior.
   </Card>
 
-  <Card title="Routing concepts" href="/routing/routing-concepts">
+  <Card title="Routing concepts" icon="route" href="/routing/routing-concepts">
     Learn how custom agents participate in routing and fallback.
   </Card>
 
-  <Card title="Hardware metrics" href="/observability/hardware-metrics">
+  <Card title="Hardware metrics" icon="gauge-high" href="/observability/hardware-metrics">
     Understand the system and GPU signals collected from agent hosts.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/deploy/agents/infinity.mdx
+++ b/docs/deploy/agents/infinity.mdx
@@ -595,190 +595,192 @@ curl http://192.168.1.100:2112/metrics \
 
 ## Troubleshooting
 
-### `/v1/models` returns `404`
+<AccordionGroup>
+  <Accordion title="`/v1/models` returns `404`">
+    Confirm that Infinity was started with:
 
-Confirm that Infinity was started with:
-
-```bash
-INFINITY_URL_PREFIX=/v1
-```
-
-For Docker, inspect the container environment:
-
-```bash
-docker inspect infinity \
-  | jq '.[0].Config.Env'
-```
-
-Without the prefix, Infinity serves its API at different paths from those expected by Hivenet Router.
-
-Restart Infinity after changing the setting.
-
-### An agent cannot discover its model
-
-Check Infinity:
-
-```bash
-curl http://localhost:7997/health
-```
-
-List model IDs:
-
-```bash
-curl http://localhost:7997/v1/models \
-  | jq '.data[].id'
-```
-
-The returned ID must match the agent’s `--model` value exactly.
-
-### The wrong model name is exposed
-
-Check the order of:
-
-```text
---model-id
---served-model-name
-```
-
-Each served name corresponds to the model ID in the same position.
-
-Restart Infinity after changing the mapping.
-
-### Embedding requests are routed incorrectly
-
-Confirm that the agent uses:
-
-```bash
---capability embedding
-```
-
-Inspect the routing table:
-
-```bash
-curl http://192.168.1.100:8080/admin/routing-table \
-  | jq '.agents[]
-      | select(.metadata.model == "bge-m3")
-      | {
-          model: .metadata.model,
-          capability: .metadata.capability,
-          engine: .metadata.engine
-        }'
-```
-
-### Reranking requests are routed incorrectly
-
-Confirm that the agent uses:
-
-```bash
---capability reranker
-```
-
-The accepted capability value is `reranker`, while the HTTP endpoint is:
-
-```text
-/v1/rerank
-```
-
-### An agent does not register
-
-Check its logs:
-
-<Tabs>
-  <Tab title="Docker">
     ```bash
-    docker logs hivenet-router-embedding-agent
-    docker logs hivenet-router-reranking-agent
+    INFINITY_URL_PREFIX=/v1
     ```
-  </Tab>
-  <Tab title="systemd">
+
+    For Docker, inspect the container environment:
+
     ```bash
-    sudo journalctl \
-      -u hivenet-agent \
-      -n 100 \
-      --no-pager
+    docker inspect infinity \
+      | jq '.[0].Config.Env'
     ```
-  </Tab>
-</Tabs>
 
-Test connectivity from the agent host:
+    Without the prefix, Infinity serves its API at different paths from those expected by Hivenet Router.
 
-```bash
-nc -zv 192.168.1.100 50051
-nc -zv 192.168.1.100 9000
-```
+    Restart Infinity after changing the setting.
+  </Accordion>
 
-Check that:
+  <Accordion title="An agent cannot discover its model">
+    Check Infinity:
 
-- the router and agents use the same JWT secret
-- the agent host can reach the router’s gRPC and libp2p ports
-- each agent has a unique identity path
-- Infinity is healthy
-- the selected model is listed by `/v1/models`
+    ```bash
+    curl http://localhost:7997/health
+    ```
 
-### A peer ID changes after restart
+    List model IDs:
 
-Make sure each `--identity-path` points to persistent storage.
+    ```bash
+    curl http://localhost:7997/v1/models \
+      | jq '.data[].id'
+    ```
 
-For Docker:
+    The returned ID must match the agent’s `--model` value exactly.
+  </Accordion>
 
-```bash
-docker inspect hivenet-router-embedding-agent \
-  | jq '.[0].Mounts'
-```
+  <Accordion title="The wrong model name is exposed">
+    Check the order of:
 
-For bare metal:
+    ```text
+    --model-id
+    --served-model-name
+    ```
 
-```bash
-ls -l /var/lib/hivenet-router/agents/
-```
+    Each served name corresponds to the model ID in the same position.
 
-### Requests time out
+    Restart Infinity after changing the mapping.
+  </Accordion>
 
-The agent’s backend HTTP timeout defaults to two minutes.
+  <Accordion title="Embedding requests are routed incorrectly">
+    Confirm that the agent uses:
 
-Increase it when large batches need more time:
+    ```bash
+    --capability embedding
+    ```
 
-```bash
---http-timeout 10m
-```
+    Inspect the routing table:
 
-Also review:
+    ```bash
+    curl http://192.168.1.100:8080/admin/routing-table \
+      | jq '.agents[]
+          | select(.metadata.model == "bge-m3")
+          | {
+              model: .metadata.model,
+              capability: .metadata.capability,
+              engine: .metadata.engine
+            }'
+    ```
+  </Accordion>
 
-- embedding or document batch size
-- input length
-- declared agent capacity
-- Infinity batch size
-- whether both models compete for the same GPU memory
+  <Accordion title="Reranking requests are routed incorrectly">
+    Confirm that the agent uses:
 
-### GPU metrics are missing
+    ```bash
+    --capability reranker
+    ```
 
-Check the host:
+    The accepted capability value is `reranker`, while the HTTP endpoint is:
 
-```bash
-nvidia-smi
-```
+    ```text
+    /v1/rerank
+    ```
+  </Accordion>
 
-For Docker, confirm that each agent received GPU access:
+  <Accordion title="An agent does not register">
+    Check its logs:
 
-```bash
-docker inspect hivenet-router-embedding-agent \
-  | jq '.[0].HostConfig.DeviceRequests'
-```
+    <Tabs>
+      <Tab title="Docker">
+        ```bash
+        docker logs hivenet-router-embedding-agent
+        docker logs hivenet-router-reranking-agent
+        ```
+      </Tab>
+      <Tab title="systemd">
+        ```bash
+        sudo journalctl \
+          -u hivenet-agent \
+          -n 100 \
+          --no-pager
+        ```
+      </Tab>
+    </Tabs>
 
-The agents continue to operate without NVML. They report CPU and memory metrics but omit GPU measurements.
+    Test connectivity from the agent host:
+
+    ```bash
+    nc -zv 192.168.1.100 50051
+    nc -zv 192.168.1.100 9000
+    ```
+
+    Check that:
+
+    - the router and agents use the same JWT secret
+    - the agent host can reach the router’s gRPC and libp2p ports
+    - each agent has a unique identity path
+    - Infinity is healthy
+    - the selected model is listed by `/v1/models`
+  </Accordion>
+
+  <Accordion title="A peer ID changes after restart">
+    Make sure each `--identity-path` points to persistent storage.
+
+    For Docker:
+
+    ```bash
+    docker inspect hivenet-router-embedding-agent \
+      | jq '.[0].Mounts'
+    ```
+
+    For bare metal:
+
+    ```bash
+    ls -l /var/lib/hivenet-router/agents/
+    ```
+  </Accordion>
+
+  <Accordion title="Requests time out">
+    The agent’s backend HTTP timeout defaults to two minutes.
+
+    Increase it when large batches need more time:
+
+    ```bash
+    --http-timeout 10m
+    ```
+
+    Also review:
+
+    - embedding or document batch size
+    - input length
+    - declared agent capacity
+    - Infinity batch size
+    - whether both models compete for the same GPU memory
+  </Accordion>
+
+  <Accordion title="GPU metrics are missing">
+    Check the host:
+
+    ```bash
+    nvidia-smi
+    ```
+
+    For Docker, confirm that each agent received GPU access:
+
+    ```bash
+    docker inspect hivenet-router-embedding-agent \
+      | jq '.[0].HostConfig.DeviceRequests'
+    ```
+
+    The agents continue to operate without NVML. They report CPU and memory metrics but omit GPU measurements.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Custom engine agent" href="/deploy/agents/custom-engine">
+<Columns cols={3}>
+  <Card title="Custom engine agent" icon="gears" href="/deploy/agents/custom-engine">
     Connect another OpenAI-compatible backend to Hivenet Router.
   </Card>
 
-  <Card title="Embeddings" href="/use-the-api/embeddings">
+  <Card title="Embeddings" icon="vector-square" href="/use-the-api/embeddings">
     Review the embedding request and response format.
   </Card>
 
-  <Card title="Reranking" href="/use-the-api/reranking">
+  <Card title="Reranking" icon="arrow-down-wide-short" href="/use-the-api/reranking">
     Review reranking fields, examples, and response ordering.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/deploy/agents/llama-cpp.mdx
+++ b/docs/deploy/agents/llama-cpp.mdx
@@ -486,176 +486,178 @@ Support depends on the build and hardware. Remove it if the server fails to star
 
 ## Troubleshooting
 
-### llama.cpp is not ready
+<AccordionGroup>
+  <Accordion title="llama.cpp is not ready">
+    Check the health endpoint:
 
-Check the health endpoint:
-
-```bash
-curl -i http://localhost:8888/health
-```
-
-List the exposed model:
-
-```bash
-curl http://localhost:8888/v1/models \
-  | jq .
-```
-
-Inspect the logs:
-
-<Tabs>
-  <Tab title="Docker">
     ```bash
-    docker logs llama-cpp
+    curl -i http://localhost:8888/health
     ```
-  </Tab>
-  <Tab title="Bare metal">
-    Review the terminal or service logs for `llama-server`.
-  </Tab>
-</Tabs>
 
-The agent waits and retries while the backend is unavailable or still loading.
+    List the exposed model:
 
-### Metrics are missing
-
-Confirm that llama.cpp was started with:
-
-```bash
---metrics
-```
-
-Check the endpoint directly:
-
-```bash
-curl http://localhost:8888/metrics \
-  | head
-```
-
-Without `--metrics`, the endpoint returns HTTP `404` and Hivenet Router cannot collect engine-specific metrics.
-
-A metrics scrape failure does not stop the agent from forwarding requests.
-
-### The model name does not match
-
-Check the name returned by llama.cpp:
-
-```bash
-curl http://localhost:8888/v1/models \
-  | jq '.data[].id'
-```
-
-Use `-a` to set a stable alias:
-
-```bash
--a "llama-3.1-8b"
-```
-
-Clients must send the same name to Hivenet Router.
-
-### Responses are slow
-
-Possible adjustments include:
-
-- reduce `--capacity` on the Hivenet Router agent
-- reduce llama.cpp’s context size
-- use a smaller model or quantization
-- increase GPU offloading
-- reduce parallel request pressure
-
-Measure with representative prompts before changing several settings at once.
-
-### The agent does not register
-
-Check the agent logs:
-
-<Tabs>
-  <Tab title="Docker">
     ```bash
-    docker logs hivenet-agent
+    curl http://localhost:8888/v1/models \
+      | jq .
     ```
-  </Tab>
-  <Tab title="systemd">
+
+    Inspect the logs:
+
+    <Tabs>
+      <Tab title="Docker">
+        ```bash
+        docker logs llama-cpp
+        ```
+      </Tab>
+      <Tab title="Bare metal">
+        Review the terminal or service logs for `llama-server`.
+      </Tab>
+    </Tabs>
+
+    The agent waits and retries while the backend is unavailable or still loading.
+  </Accordion>
+
+  <Accordion title="Metrics are missing">
+    Confirm that llama.cpp was started with:
+
     ```bash
-    sudo journalctl \
-      -u hivenet-agent \
-      -n 100 \
-      --no-pager
+    --metrics
     ```
-  </Tab>
-</Tabs>
 
-Test connectivity from the agent to the router:
+    Check the endpoint directly:
 
-```bash
-nc -zv 192.168.1.100 50051
-nc -zv 192.168.1.100 9000
-```
+    ```bash
+    curl http://localhost:8888/metrics \
+      | head
+    ```
 
-Check that:
+    Without `--metrics`, the endpoint returns HTTP `404` and Hivenet Router cannot collect engine-specific metrics.
 
-- the router and agent use the same JWT secret
-- the router’s libp2p interface is reachable
-- the router advertises a libp2p address the agent can reach
-- llama.cpp is healthy and exposes a model
+    A metrics scrape failure does not stop the agent from forwarding requests.
+  </Accordion>
 
-### The peer ID changes after restart
+  <Accordion title="The model name does not match">
+    Check the name returned by llama.cpp:
 
-Make sure `--identity-path` points to persistent storage.
+    ```bash
+    curl http://localhost:8888/v1/models \
+      | jq '.data[].id'
+    ```
 
-For Docker:
+    Use `-a` to set a stable alias:
 
-```bash
-docker inspect hivenet-agent \
-  | jq '.[0].Mounts'
-```
+    ```bash
+    -a "llama-3.1-8b"
+    ```
 
-For bare metal:
+    Clients must send the same name to Hivenet Router.
+  </Accordion>
 
-```bash
-ls -l /var/lib/hivenet-router/agent/identity.key
-```
+  <Accordion title="Responses are slow">
+    Possible adjustments include:
 
-### Requests time out
+    - reduce `--capacity` on the Hivenet Router agent
+    - reduce llama.cpp’s context size
+    - use a smaller model or quantization
+    - increase GPU offloading
+    - reduce parallel request pressure
 
-The agent’s backend HTTP timeout defaults to two minutes.
+    Measure with representative prompts before changing several settings at once.
+  </Accordion>
 
-Increase it for long-running requests:
+  <Accordion title="The agent does not register">
+    Check the agent logs:
 
-```bash
---http-timeout 10m
-```
+    <Tabs>
+      <Tab title="Docker">
+        ```bash
+        docker logs hivenet-agent
+        ```
+      </Tab>
+      <Tab title="systemd">
+        ```bash
+        sudo journalctl \
+          -u hivenet-agent \
+          -n 100 \
+          --no-pager
+        ```
+      </Tab>
+    </Tabs>
 
-Also check the declared agent capacity and llama.cpp queue state.
+    Test connectivity from the agent to the router:
 
-### GPU metrics are missing
+    ```bash
+    nc -zv 192.168.1.100 50051
+    nc -zv 192.168.1.100 9000
+    ```
 
-Check the host:
+    Check that:
 
-```bash
-nvidia-smi
-```
+    - the router and agent use the same JWT secret
+    - the router’s libp2p interface is reachable
+    - the router advertises a libp2p address the agent can reach
+    - llama.cpp is healthy and exposes a model
+  </Accordion>
 
-For Docker, confirm the agent received GPU access:
+  <Accordion title="The peer ID changes after restart">
+    Make sure `--identity-path` points to persistent storage.
 
-```bash
-docker inspect hivenet-agent \
-  | jq '.[0].HostConfig.DeviceRequests'
-```
+    For Docker:
 
-The agent continues to operate without NVML. It reports CPU and memory metrics but omits GPU measurements.
+    ```bash
+    docker inspect hivenet-agent \
+      | jq '.[0].Mounts'
+    ```
+
+    For bare metal:
+
+    ```bash
+    ls -l /var/lib/hivenet-router/agent/identity.key
+    ```
+  </Accordion>
+
+  <Accordion title="Requests time out">
+    The agent’s backend HTTP timeout defaults to two minutes.
+
+    Increase it for long-running requests:
+
+    ```bash
+    --http-timeout 10m
+    ```
+
+    Also check the declared agent capacity and llama.cpp queue state.
+  </Accordion>
+
+  <Accordion title="GPU metrics are missing">
+    Check the host:
+
+    ```bash
+    nvidia-smi
+    ```
+
+    For Docker, confirm the agent received GPU access:
+
+    ```bash
+    docker inspect hivenet-agent \
+      | jq '.[0].HostConfig.DeviceRequests'
+    ```
+
+    The agent continues to operate without NVML. It reports CPU and memory metrics but omits GPU measurements.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Infinity agent" href="/deploy/agents/infinity">
+<Columns cols={3}>
+  <Card title="Infinity agent" icon="microchip" href="/deploy/agents/infinity">
     Connect embedding and reranking models through Infinity.
   </Card>
 
-  <Card title="Routing concepts" href="/routing/routing-concepts">
+  <Card title="Routing concepts" icon="route" href="/routing/routing-concepts">
     Learn how Hivenet Router filters and ranks matching agents.
   </Card>
 
-  <Card title="Engine metrics" href="/observability/engine-metrics">
+  <Card title="Engine metrics" icon="gauge-high" href="/observability/engine-metrics">
     Understand the metrics collected from llama.cpp and other engines.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/deploy/agents/ollama.mdx
+++ b/docs/deploy/agents/ollama.mdx
@@ -428,207 +428,209 @@ Engine-specific values such as KV cache utilization, waiting requests, time to f
 
 ## Troubleshooting
 
-### No model is found
+<AccordionGroup>
+  <Accordion title="No model is found">
+    List the pulled models:
 
-List the pulled models:
+    <Tabs>
+      <Tab title="Linux">
+        ```bash
+        ollama list
+        ```
+      </Tab>
+      <Tab title="Docker">
+        ```bash
+        docker exec ollama \
+          ollama list
+        ```
+      </Tab>
+    </Tabs>
 
-<Tabs>
-  <Tab title="Linux">
+    Pull the missing model:
+
     ```bash
-    ollama list
+    ollama pull llama3.1:8b
     ```
-  </Tab>
-  <Tab title="Docker">
+
+    Check the endpoint used by the agent:
+
     ```bash
-    docker exec ollama \
-      ollama list
+    curl http://localhost:11434/api/tags \
+      | jq .
     ```
-  </Tab>
-</Tabs>
+  </Accordion>
 
-Pull the missing model:
+  <Accordion title="The wrong model is registered">
+    When `--model` is omitted, the agent registers the first model returned by `/api/tags`.
 
-```bash
-ollama pull llama3.1:8b
-```
+    Restart the agent with an explicit model:
 
-Check the endpoint used by the agent:
-
-```bash
-curl http://localhost:11434/api/tags \
-  | jq .
-```
-
-### The wrong model is registered
-
-When `--model` is omitted, the agent registers the first model returned by `/api/tags`.
-
-Restart the agent with an explicit model:
-
-```bash
---model llama3.1:8b
-```
-
-### A model appears without `:latest`
-
-This is expected.
-
-Hivenet Router converts:
-
-```text
-llama3.1:latest
-```
-
-to:
-
-```text
-llama3.1
-```
-
-Explicit tags such as `:8b` or `:7b` are preserved.
-
-### Ollama is unreachable
-
-Check the server:
-
-```bash
-curl http://localhost:11434/api/tags
-```
-
-For a Linux process, inspect its log:
-
-```bash
-tail -f ~/ollama.log
-```
-
-For Docker:
-
-```bash
-docker logs ollama
-```
-
-Confirm that the agent’s `--backend-url` matches the address where Ollama is listening.
-
-### The first response is slow
-
-Ollama may need to load the model into memory before serving the first request.
-
-Check loaded models:
-
-<Tabs>
-  <Tab title="Linux">
     ```bash
-    ollama ps
+    --model llama3.1:8b
     ```
-  </Tab>
-  <Tab title="Docker">
+  </Accordion>
+
+  <Accordion title="A model appears without `:latest`">
+    This is expected.
+
+    Hivenet Router converts:
+
+    ```text
+    llama3.1:latest
+    ```
+
+    to:
+
+    ```text
+    llama3.1
+    ```
+
+    Explicit tags such as `:8b` or `:7b` are preserved.
+  </Accordion>
+
+  <Accordion title="Ollama is unreachable">
+    Check the server:
+
     ```bash
-    docker exec ollama \
-      ollama ps
+    curl http://localhost:11434/api/tags
     ```
-  </Tab>
-</Tabs>
 
-Using:
+    For a Linux process, inspect its log:
 
-```bash
-OLLAMA_KEEP_ALIVE=-1
-```
-
-keeps the model loaded after it has been used.
-
-### The agent does not register
-
-Check the agent logs:
-
-<Tabs>
-  <Tab title="Docker">
     ```bash
-    docker logs hivenet-agent
+    tail -f ~/ollama.log
     ```
-  </Tab>
-  <Tab title="systemd">
+
+    For Docker:
+
     ```bash
-    sudo journalctl \
-      -u hivenet-agent \
-      -n 100 \
-      --no-pager
+    docker logs ollama
     ```
-  </Tab>
-</Tabs>
 
-Test connectivity from the agent to the router:
+    Confirm that the agent’s `--backend-url` matches the address where Ollama is listening.
+  </Accordion>
 
-```bash
-nc -zv 192.168.1.100 50051
-nc -zv 192.168.1.100 9000
-```
+  <Accordion title="The first response is slow">
+    Ollama may need to load the model into memory before serving the first request.
 
-Check that:
+    Check loaded models:
 
-- the router and agent use the same JWT secret
-- the router’s libp2p interface is reachable
-- the router advertises a libp2p address the agent can reach
-- Ollama contains the selected model
+    <Tabs>
+      <Tab title="Linux">
+        ```bash
+        ollama ps
+        ```
+      </Tab>
+      <Tab title="Docker">
+        ```bash
+        docker exec ollama \
+          ollama ps
+        ```
+      </Tab>
+    </Tabs>
 
-### The agent gets a new peer ID after restart
+    Using:
 
-Make sure `--identity-path` points to persistent storage.
+    ```bash
+    OLLAMA_KEEP_ALIVE=-1
+    ```
 
-For Docker:
+    keeps the model loaded after it has been used.
+  </Accordion>
 
-```bash
-docker inspect hivenet-agent \
-  | jq '.[0].Mounts'
-```
+  <Accordion title="The agent does not register">
+    Check the agent logs:
 
-For bare metal:
+    <Tabs>
+      <Tab title="Docker">
+        ```bash
+        docker logs hivenet-agent
+        ```
+      </Tab>
+      <Tab title="systemd">
+        ```bash
+        sudo journalctl \
+          -u hivenet-agent \
+          -n 100 \
+          --no-pager
+        ```
+      </Tab>
+    </Tabs>
 
-```bash
-ls -l /var/lib/hivenet-router/agent/identity.key
-```
+    Test connectivity from the agent to the router:
 
-### GPU metrics are missing
+    ```bash
+    nc -zv 192.168.1.100 50051
+    nc -zv 192.168.1.100 9000
+    ```
 
-Check that NVIDIA tools work on the host:
+    Check that:
 
-```bash
-nvidia-smi
-```
+    - the router and agent use the same JWT secret
+    - the router’s libp2p interface is reachable
+    - the router advertises a libp2p address the agent can reach
+    - Ollama contains the selected model
+  </Accordion>
 
-For Docker, confirm the agent received GPU access:
+  <Accordion title="The agent gets a new peer ID after restart">
+    Make sure `--identity-path` points to persistent storage.
 
-```bash
-docker inspect hivenet-agent \
-  | jq '.[0].HostConfig.DeviceRequests'
-```
+    For Docker:
 
-The agent continues to operate without NVML. It reports CPU and memory metrics but omits GPU measurements.
+    ```bash
+    docker inspect hivenet-agent \
+      | jq '.[0].Mounts'
+    ```
 
-### Requests time out
+    For bare metal:
 
-The agent’s backend HTTP timeout defaults to two minutes.
+    ```bash
+    ls -l /var/lib/hivenet-router/agent/identity.key
+    ```
+  </Accordion>
 
-Increase it for long-running requests:
+  <Accordion title="GPU metrics are missing">
+    Check that NVIDIA tools work on the host:
 
-```bash
---http-timeout 10m
-```
+    ```bash
+    nvidia-smi
+    ```
 
-Also check whether the agent capacity is too high for the model and hardware.
+    For Docker, confirm the agent received GPU access:
+
+    ```bash
+    docker inspect hivenet-agent \
+      | jq '.[0].HostConfig.DeviceRequests'
+    ```
+
+    The agent continues to operate without NVML. It reports CPU and memory metrics but omits GPU measurements.
+  </Accordion>
+
+  <Accordion title="Requests time out">
+    The agent’s backend HTTP timeout defaults to two minutes.
+
+    Increase it for long-running requests:
+
+    ```bash
+    --http-timeout 10m
+    ```
+
+    Also check whether the agent capacity is too high for the model and hardware.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="SGLang agent" href="/deploy/agents/sglang">
+<Columns cols={3}>
+  <Card title="SGLang agent" icon="microchip" href="/deploy/agents/sglang">
     Connect an SGLang backend and collect engine metrics.
   </Card>
 
-  <Card title="Routing concepts" href="/routing/routing-concepts">
+  <Card title="Routing concepts" icon="route" href="/routing/routing-concepts">
     Learn how metadata, capacity, and policies affect agent selection.
   </Card>
 
-  <Card title="Hardware metrics" href="/observability/hardware-metrics">
+  <Card title="Hardware metrics" icon="gauge-high" href="/observability/hardware-metrics">
     Understand the CPU, memory, and GPU signals reported by agents.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/deploy/agents/sglang.mdx
+++ b/docs/deploy/agents/sglang.mdx
@@ -461,159 +461,161 @@ This allocates a larger fraction of GPU memory to SGLang’s static memory pool.
 
 ## Troubleshooting
 
-### SGLang is not ready
+<AccordionGroup>
+  <Accordion title="SGLang is not ready">
+    Check the health endpoint:
 
-Check the health endpoint:
-
-```bash
-curl -i http://localhost:3000/health
-```
-
-Check model discovery:
-
-```bash
-curl http://localhost:3000/v1/models \
-  | jq .
-```
-
-Inspect the server logs:
-
-<Tabs>
-  <Tab title="Docker">
     ```bash
-    docker logs sglang
+    curl -i http://localhost:3000/health
     ```
-  </Tab>
-  <Tab title="Bare metal">
-    Review the terminal or service logs for the SGLang process.
-  </Tab>
-</Tabs>
 
-The agent waits and retries while SGLang is unavailable or still loading.
+    Check model discovery:
 
-### Metrics are missing
-
-Confirm that SGLang was started with:
-
-```bash
---enable-metrics
-```
-
-Check the metrics endpoint directly:
-
-```bash
-curl http://localhost:3000/metrics \
-  | head
-```
-
-Without metrics enabled, the endpoint may return HTTP `404`.
-
-A metrics scrape failure does not stop the agent from forwarding requests.
-
-### The wrong model is registered
-
-Automatic discovery selects the first model returned by `/v1/models`.
-
-Pin the correct model:
-
-```bash
---model meta-llama/Llama-3.1-8B-Instruct
-```
-
-Restart the agent after changing the value.
-
-### The agent does not register
-
-Check the agent logs:
-
-<Tabs>
-  <Tab title="Docker">
     ```bash
-    docker logs hivenet-agent
+    curl http://localhost:3000/v1/models \
+      | jq .
     ```
-  </Tab>
-  <Tab title="systemd">
+
+    Inspect the server logs:
+
+    <Tabs>
+      <Tab title="Docker">
+        ```bash
+        docker logs sglang
+        ```
+      </Tab>
+      <Tab title="Bare metal">
+        Review the terminal or service logs for the SGLang process.
+      </Tab>
+    </Tabs>
+
+    The agent waits and retries while SGLang is unavailable or still loading.
+  </Accordion>
+
+  <Accordion title="Metrics are missing">
+    Confirm that SGLang was started with:
+
     ```bash
-    sudo journalctl \
-      -u hivenet-agent \
-      -n 100 \
-      --no-pager
+    --enable-metrics
     ```
-  </Tab>
-</Tabs>
 
-Test connectivity from the agent to the router:
+    Check the metrics endpoint directly:
 
-```bash
-nc -zv 192.168.1.100 50051
-nc -zv 192.168.1.100 9000
-```
+    ```bash
+    curl http://localhost:3000/metrics \
+      | head
+    ```
 
-Check that:
+    Without metrics enabled, the endpoint may return HTTP `404`.
 
-- the router and agent use the same JWT secret
-- the router’s libp2p interface is reachable
-- the router advertises a libp2p address the agent can reach
-- SGLang is healthy and exposes a model
+    A metrics scrape failure does not stop the agent from forwarding requests.
+  </Accordion>
 
-### The peer ID changes after restart
+  <Accordion title="The wrong model is registered">
+    Automatic discovery selects the first model returned by `/v1/models`.
 
-Make sure `--identity-path` points to persistent storage.
+    Pin the correct model:
 
-For Docker:
+    ```bash
+    --model meta-llama/Llama-3.1-8B-Instruct
+    ```
 
-```bash
-docker inspect hivenet-agent \
-  | jq '.[0].Mounts'
-```
+    Restart the agent after changing the value.
+  </Accordion>
 
-For bare metal:
+  <Accordion title="The agent does not register">
+    Check the agent logs:
 
-```bash
-ls -l /var/lib/hivenet-router/agent/identity.key
-```
+    <Tabs>
+      <Tab title="Docker">
+        ```bash
+        docker logs hivenet-agent
+        ```
+      </Tab>
+      <Tab title="systemd">
+        ```bash
+        sudo journalctl \
+          -u hivenet-agent \
+          -n 100 \
+          --no-pager
+        ```
+      </Tab>
+    </Tabs>
 
-### Requests time out
+    Test connectivity from the agent to the router:
 
-The agent’s backend HTTP timeout defaults to two minutes.
+    ```bash
+    nc -zv 192.168.1.100 50051
+    nc -zv 192.168.1.100 9000
+    ```
 
-Increase it for long-running requests:
+    Check that:
 
-```bash
---http-timeout 10m
-```
+    - the router and agent use the same JWT secret
+    - the router’s libp2p interface is reachable
+    - the router advertises a libp2p address the agent can reach
+    - SGLang is healthy and exposes a model
+  </Accordion>
 
-Also check SGLang’s queue length, cache pressure, and the capacity declared by the agent.
+  <Accordion title="The peer ID changes after restart">
+    Make sure `--identity-path` points to persistent storage.
 
-### GPU metrics are missing
+    For Docker:
 
-Check that NVIDIA tools work on the host:
+    ```bash
+    docker inspect hivenet-agent \
+      | jq '.[0].Mounts'
+    ```
 
-```bash
-nvidia-smi
-```
+    For bare metal:
 
-For Docker, confirm the agent received GPU access:
+    ```bash
+    ls -l /var/lib/hivenet-router/agent/identity.key
+    ```
+  </Accordion>
 
-```bash
-docker inspect hivenet-agent \
-  | jq '.[0].HostConfig.DeviceRequests'
-```
+  <Accordion title="Requests time out">
+    The agent’s backend HTTP timeout defaults to two minutes.
 
-The agent continues to operate without NVML. It reports CPU and memory metrics but omits GPU measurements.
+    Increase it for long-running requests:
+
+    ```bash
+    --http-timeout 10m
+    ```
+
+    Also check SGLang’s queue length, cache pressure, and the capacity declared by the agent.
+  </Accordion>
+
+  <Accordion title="GPU metrics are missing">
+    Check that NVIDIA tools work on the host:
+
+    ```bash
+    nvidia-smi
+    ```
+
+    For Docker, confirm the agent received GPU access:
+
+    ```bash
+    docker inspect hivenet-agent \
+      | jq '.[0].HostConfig.DeviceRequests'
+    ```
+
+    The agent continues to operate without NVML. It reports CPU and memory metrics but omits GPU measurements.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="llama.cpp agent" href="/deploy/agents/llama-cpp">
+<Columns cols={3}>
+  <Card title="llama.cpp agent" icon="microchip" href="/deploy/agents/llama-cpp">
     Connect a llama.cpp server and enable its Prometheus metrics.
   </Card>
 
-  <Card title="Routing concepts" href="/routing/routing-concepts">
+  <Card title="Routing concepts" icon="route" href="/routing/routing-concepts">
     Learn how Hivenet Router filters and ranks matching agents.
   </Card>
 
-  <Card title="Engine metrics" href="/observability/engine-metrics">
+  <Card title="Engine metrics" icon="gauge-high" href="/observability/engine-metrics">
     Understand the metrics collected from SGLang and other engines.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/deploy/agents/vllm.mdx
+++ b/docs/deploy/agents/vllm.mdx
@@ -435,139 +435,141 @@ See [Policy YAML reference](/routing/policy-yaml-reference) for the full policy 
 
 ## Troubleshooting
 
-### The agent cannot discover a model
+<AccordionGroup>
+  <Accordion title="The agent cannot discover a model">
+    Check vLLM health:
 
-Check vLLM health:
-
-```bash
-curl -i http://localhost:8888/health
-```
-
-Check model discovery:
-
-```bash
-curl http://localhost:8888/v1/models \
-  | jq '.data[].id'
-```
-
-The agent waits and retries if vLLM is healthy but no model is available yet.
-
-### The wrong model is registered
-
-Automatic discovery selects the first model returned by `/v1/models`.
-
-Pin the correct one:
-
-```bash
---model meta-llama/Llama-3.1-8B-Instruct
-```
-
-Restart the agent after changing the setting.
-
-### The agent does not register
-
-Check the agent logs:
-
-<Tabs>
-  <Tab title="Docker">
     ```bash
-    docker logs hivenet-agent
+    curl -i http://localhost:8888/health
     ```
-  </Tab>
-  <Tab title="systemd">
+
+    Check model discovery:
+
     ```bash
-    sudo journalctl -u hivenet-agent -n 100 --no-pager
+    curl http://localhost:8888/v1/models \
+      | jq '.data[].id'
     ```
-  </Tab>
-</Tabs>
 
-Confirm connectivity:
+    The agent waits and retries if vLLM is healthy but no model is available yet.
+  </Accordion>
 
-```bash
-nc -zv 192.168.1.100 50051
-nc -zv 192.168.1.100 9000
-```
+  <Accordion title="The wrong model is registered">
+    Automatic discovery selects the first model returned by `/v1/models`.
 
-Check that the router and agent use the same JWT secret.
+    Pin the correct one:
 
-### KV cache utilization remains high
+    ```bash
+    --model meta-llama/Llama-3.1-8B-Instruct
+    ```
 
-Reduce the amount of work Hivenet Router assigns to the agent:
+    Restart the agent after changing the setting.
+  </Accordion>
 
-```bash
---capacity 128
-```
+  <Accordion title="The agent does not register">
+    Check the agent logs:
 
-Or reduce vLLM’s scheduler limit:
+    <Tabs>
+      <Tab title="Docker">
+        ```bash
+        docker logs hivenet-agent
+        ```
+      </Tab>
+      <Tab title="systemd">
+        ```bash
+        sudo journalctl -u hivenet-agent -n 100 --no-pager
+        ```
+      </Tab>
+    </Tabs>
 
-```bash
---max-num-seqs 128
-```
+    Confirm connectivity:
 
-You can also use a routing gate to stop selecting the agent above a chosen threshold.
+    ```bash
+    nc -zv 192.168.1.100 50051
+    nc -zv 192.168.1.100 9000
+    ```
 
-### Preemptions keep increasing
+    Check that the router and agent use the same JWT secret.
+  </Accordion>
 
-Rising preemptions indicate that vLLM is evicting in-flight KV-cache data under memory pressure.
+  <Accordion title="KV cache utilization remains high">
+    Reduce the amount of work Hivenet Router assigns to the agent:
 
-Reduce:
+    ```bash
+    --capacity 128
+    ```
 
-- `--capacity` on the Hivenet Router agent
-- `--max-num-seqs` on vLLM
-- model context or batch pressure, where appropriate for your workload
+    Or reduce vLLM’s scheduler limit:
 
-### Backend requests time out
+    ```bash
+    --max-num-seqs 128
+    ```
 
-The agent’s backend HTTP timeout defaults to two minutes.
+    You can also use a routing gate to stop selecting the agent above a chosen threshold.
+  </Accordion>
 
-Increase it for longer requests:
+  <Accordion title="Preemptions keep increasing">
+    Rising preemptions indicate that vLLM is evicting in-flight KV-cache data under memory pressure.
 
-```bash
---http-timeout 10m
-```
+    Reduce:
 
-### The peer ID changes after restart
+    - `--capacity` on the Hivenet Router agent
+    - `--max-num-seqs` on vLLM
+    - model context or batch pressure, where appropriate for your workload
+  </Accordion>
 
-Make sure `--identity-path` points to persistent storage.
+  <Accordion title="Backend requests time out">
+    The agent’s backend HTTP timeout defaults to two minutes.
 
-For Docker, confirm the volume is mounted:
+    Increase it for longer requests:
 
-```bash
-docker inspect hivenet-agent \
-  | jq '.[0].Mounts'
-```
+    ```bash
+    --http-timeout 10m
+    ```
+  </Accordion>
 
-For bare metal:
+  <Accordion title="The peer ID changes after restart">
+    Make sure `--identity-path` points to persistent storage.
 
-```bash
-ls -l /var/lib/hivenet-router/agent/identity.key
-```
+    For Docker, confirm the volume is mounted:
 
-### Metrics are missing
+    ```bash
+    docker inspect hivenet-agent \
+      | jq '.[0].Mounts'
+    ```
 
-Check vLLM’s metrics endpoint:
+    For bare metal:
 
-```bash
-curl http://localhost:8888/metrics \
-  | head
-```
+    ```bash
+    ls -l /var/lib/hivenet-router/agent/identity.key
+    ```
+  </Accordion>
 
-Check the agent logs for scrape errors.
+  <Accordion title="Metrics are missing">
+    Check vLLM’s metrics endpoint:
 
-Metrics are scraped in the background. A scrape failure does not stop the agent from forwarding requests.
+    ```bash
+    curl http://localhost:8888/metrics \
+      | head
+    ```
+
+    Check the agent logs for scrape errors.
+
+    Metrics are scraped in the background. A scrape failure does not stop the agent from forwarding requests.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Ollama agent" href="/deploy/agents/ollama">
+<Columns cols={3}>
+  <Card title="Ollama agent" icon="server" href="/deploy/agents/ollama">
     Connect an Ollama backend for local or edge inference.
   </Card>
 
-  <Card title="Routing concepts" href="/routing/routing-concepts">
+  <Card title="Routing concepts" icon="route" href="/routing/routing-concepts">
     Learn how Hivenet Router filters and ranks matching agents.
   </Card>
 
-  <Card title="Engine metrics" href="/observability/engine-metrics">
+  <Card title="Engine metrics" icon="chart-line" href="/observability/engine-metrics">
     Understand the metrics collected from vLLM and other engines.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/deploy/bare-metal.mdx
+++ b/docs/deploy/bare-metal.mdx
@@ -561,13 +561,29 @@ You do not need to restart the router when adding capacity.
 
 On the new host:
 
-1. Create the `hivenet-router` account and directories.
-2. Install the agent binary.
-3. Install the shared JWT secret.
-4. Create `/etc/hivenet-router/agent.env` with the router address and agent region.
-5. Install the agent systemd unit.
-6. Start the inference backend.
-7. Enable and start `hivenet-agent`.
+<Steps>
+  <Step title="Create the account and directories">
+    Create the `hivenet-router` account and directories.
+  </Step>
+  <Step title="Install the agent binary">
+    Install the agent binary.
+  </Step>
+  <Step title="Install the shared JWT secret">
+    Install the shared JWT secret.
+  </Step>
+  <Step title="Create the agent environment file">
+    Create `/etc/hivenet-router/agent.env` with the router address and agent region.
+  </Step>
+  <Step title="Install the agent systemd unit">
+    Install the agent systemd unit.
+  </Step>
+  <Step title="Start the inference backend">
+    Start the inference backend.
+  </Step>
+  <Step title="Enable and start the agent">
+    Enable and start `hivenet-agent`.
+  </Step>
+</Steps>
 
 The new agent registers automatically once it can reach the router and its backend is ready.
 
@@ -683,142 +699,144 @@ When the router itself is behind NAT or another translated network, configure th
 
 ## Troubleshooting
 
-### A service does not start
+<AccordionGroup>
+  <Accordion title="A service does not start">
+    Inspect its status and recent logs:
 
-Inspect its status and recent logs:
+    ```bash
+    sudo systemctl status hivenet-router
+    sudo journalctl -u hivenet-router -n 100 --no-pager
+    ```
 
-```bash
-sudo systemctl status hivenet-router
-sudo journalctl -u hivenet-router -n 100 --no-pager
-```
+    For an agent:
 
-For an agent:
+    ```bash
+    sudo systemctl status hivenet-agent
+    sudo journalctl -u hivenet-agent -n 100 --no-pager
+    ```
+  </Accordion>
 
-```bash
-sudo systemctl status hivenet-agent
-sudo journalctl -u hivenet-agent -n 100 --no-pager
-```
+  <Accordion title="The router cannot read the JWT secret">
+    Check the file ownership and mode:
 
-### The router cannot read the JWT secret
+    ```bash
+    sudo ls -l /etc/hivenet-router/jwt.secret
+    ```
 
-Check the file ownership and mode:
+    Expected ownership and permissions:
 
-```bash
-sudo ls -l /etc/hivenet-router/jwt.secret
-```
+    ```text
+    -rw-r----- root hivenet-router
+    ```
 
-Expected ownership and permissions:
+    Test access as the service account:
 
-```text
--rw-r----- root hivenet-router
-```
+    ```bash
+    sudo -u hivenet-router cat /etc/hivenet-router/jwt.secret >/dev/null
+    ```
+  </Accordion>
 
-Test access as the service account:
+  <Accordion title="An agent does not register">
+    From the agent host, check the router:
 
-```bash
-sudo -u hivenet-router cat /etc/hivenet-router/jwt.secret >/dev/null
-```
+    ```bash
+    nc -zv 192.168.1.100 50051
+    nc -zv 192.168.1.100 9000
+    ```
 
-### An agent does not register
+    Common causes include:
 
-From the agent host, check the router:
+    - the router is not listening on `0.0.0.0`
+    - `ROUTER_IP` is incorrect
+    - the router advertises a libp2p address the agent cannot reach
+    - the router needs a correct `--p2p-announce-addr` behind NAT or port translation
+    - the router or agent firewall blocks outbound agent connectivity
+    - the JWT secret differs between hosts
+    - the backend has not become healthy
+    - the agent environment file contains an invalid value
+  </Accordion>
 
-```bash
-nc -zv 192.168.1.100 50051
-nc -zv 192.168.1.100 9000
-```
+  <Accordion title="The agent gets a new peer ID after restart">
+    Confirm that the persistent identity file exists:
 
-Common causes include:
+    ```bash
+    sudo ls -l /var/lib/hivenet-router/agent/identity.key
+    ```
 
-- the router is not listening on `0.0.0.0`
-- `ROUTER_IP` is incorrect
-- the router advertises a libp2p address the agent cannot reach
-- the router needs a correct `--p2p-announce-addr` behind NAT or port translation
-- the router or agent firewall blocks outbound agent connectivity
-- the JWT secret differs between hosts
-- the backend has not become healthy
-- the agent environment file contains an invalid value
+    The service account must be able to read and write this file.
+  </Accordion>
 
-### The agent gets a new peer ID after restart
+  <Accordion title="GPU metrics are missing">
+    Check NVIDIA access:
 
-Confirm that the persistent identity file exists:
+    ```bash
+    nvidia-smi
+    ```
 
-```bash
-sudo ls -l /var/lib/hivenet-router/agent/identity.key
-```
+    Test access as the service account:
 
-The service account must be able to read and write this file.
+    ```bash
+    sudo -u hivenet-router nvidia-smi
+    ```
 
-### GPU metrics are missing
+    Check the account’s groups:
 
-Check NVIDIA access:
+    ```bash
+    id hivenet-router
+    ```
 
-```bash
-nvidia-smi
-```
+    If necessary:
 
-Test access as the service account:
+    ```bash
+    sudo usermod -aG video hivenet-router
+    sudo systemctl restart hivenet-agent
+    ```
 
-```bash
-sudo -u hivenet-router nvidia-smi
-```
+    If NVML remains unavailable, the agent continues to report CPU and memory metrics but omits GPU metrics.
+  </Accordion>
 
-Check the account’s groups:
+  <Accordion title="Ports are already in use">
+    ```bash
+    sudo ss -tlnp \
+      | grep -E '8080|50051|9000|2112'
+    ```
+  </Accordion>
 
-```bash
-id hivenet-router
-```
+  <Accordion title="Check live routing data">
+    ```bash
+    curl http://192.168.1.100:8080/admin/routing-table \
+      | jq '.agents[] | {
+          peer_id,
+          model: .metadata.model,
+          engine: .metadata.engine,
+          region: .metadata.region,
+          healthy: .status.healthy,
+          active_requests: .status.active_requests,
+          srtt_ms: .universal.srtt_ms
+        }'
+    ```
 
-If necessary:
+    Check the routing counter:
 
-```bash
-sudo usermod -aG video hivenet-router
-sudo systemctl restart hivenet-agent
-```
-
-If NVML remains unavailable, the agent continues to report CPU and memory metrics but omits GPU metrics.
-
-### Ports are already in use
-
-```bash
-sudo ss -tlnp \
-  | grep -E '8080|50051|9000|2112'
-```
-
-### Check live routing data
-
-```bash
-curl http://192.168.1.100:8080/admin/routing-table \
-  | jq '.agents[] | {
-      peer_id,
-      model: .metadata.model,
-      engine: .metadata.engine,
-      region: .metadata.region,
-      healthy: .status.healthy,
-      active_requests: .status.active_requests,
-      srtt_ms: .universal.srtt_ms
-    }'
-```
-
-Check the routing counter:
-
-```bash
-curl http://192.168.1.100:2112/metrics \
-  | grep hivenet_router_routing_requests_routed_total
-```
+    ```bash
+    curl http://192.168.1.100:2112/metrics \
+      | grep hivenet_router_routing_requests_routed_total
+    ```
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="vLLM agent" href="/deploy/agents/vllm">
+<Columns cols={3}>
+  <Card title="vLLM agent" icon="microchip" href="/deploy/agents/vllm">
     Configure vLLM discovery, capacity, metrics, and multi-model deployments.
   </Card>
 
-  <Card title="Configuration reference" href="/reference/configuration-reference">
+  <Card title="Configuration reference" icon="book" href="/reference/configuration-reference">
     Review every router and agent flag and environment variable.
   </Card>
 
-  <Card title="Authentication overview" href="/security/authentication-overview">
+  <Card title="Authentication overview" icon="shield-halved" href="/security/authentication-overview">
     Protect the client and administration APIs before production use.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/deploy/docker-compose.mdx
+++ b/docs/deploy/docker-compose.mdx
@@ -663,119 +663,121 @@ docker compose --env-file .env up -d
 
 ## Troubleshooting
 
-### An agent does not appear
+<AccordionGroup>
+  <Accordion title="An agent does not appear">
+    Check the agent logs:
 
-Check the agent logs:
+    ```bash
+    docker compose \
+      -f docker-compose.agent.yml \
+      logs agent
+    ```
 
-```bash
-docker compose \
-  -f docker-compose.agent.yml \
-  logs agent
-```
+    Test the agent’s connection to the router:
 
-Test the agent’s connection to the router:
+    ```bash
+    nc -zv <router-ip> 8902
+    nc -zv <router-ip> 8903
+    ```
 
-```bash
-nc -zv <router-ip> 8902
-nc -zv <router-ip> 8903
-```
+    Check the router logs:
 
-Check the router logs:
+    ```bash
+    docker compose logs router \
+      | grep -i "registered\|agent\|error"
+    ```
 
-```bash
-docker compose logs router \
-  | grep -i "registered\|agent\|error"
-```
+    Common causes include:
 
-Common causes include:
+    - a different JWT secret on the router and agent
+    - an incorrect or unreachable `ROUTER_GRPC` address
+    - the router advertising a libp2p address the agent cannot reach
+    - a missing or incorrect router `--p2p-announce-addr` behind NAT or port translation
+    - an unhealthy inference backend
+  </Accordion>
 
-- a different JWT secret on the router and agent
-- an incorrect or unreachable `ROUTER_GRPC` address
-- the router advertising a libp2p address the agent cannot reach
-- a missing or incorrect router `--p2p-announce-addr` behind NAT or port translation
-- an unhealthy inference backend
+  <Accordion title="Prometheus cannot scrape the router">
+    Inspect Prometheus targets:
 
-### Prometheus cannot scrape the router
+    ```bash
+    docker compose exec prometheus \
+      wget -qO- http://localhost:9090/api/v1/targets \
+      | jq '.data.activeTargets[] | {
+          job: .labels.job,
+          health: .health,
+          lastError: .lastError
+        }'
+    ```
 
-Inspect Prometheus targets:
+    Check the router endpoint from the Prometheus container:
 
-```bash
-docker compose exec prometheus \
-  wget -qO- http://localhost:9090/api/v1/targets \
-  | jq '.data.activeTargets[] | {
-      job: .labels.job,
-      health: .health,
-      lastError: .lastError
-    }'
-```
+    ```bash
+    docker compose exec prometheus \
+      wget -qO- http://router:2112/metrics \
+      | head
+    ```
+  </Accordion>
 
-Check the router endpoint from the Prometheus container:
+  <Accordion title="Grafana has no metrics">
+    Confirm that Prometheus contains Hivenet Router data:
 
-```bash
-docker compose exec prometheus \
-  wget -qO- http://router:2112/metrics \
-  | head
-```
+    ```bash
+    docker compose exec prometheus \
+      wget -qO- \
+      'http://localhost:9090/api/v1/query?query=hivenet_router_routing_agent_info' \
+      | jq .
+    ```
 
-### Grafana has no metrics
+    Check the service logs:
 
-Confirm that Prometheus contains Hivenet Router data:
+    ```bash
+    docker compose logs prometheus | tail -50
+    docker compose logs grafana | tail -50
+    ```
+  </Accordion>
 
-```bash
-docker compose exec prometheus \
-  wget -qO- \
-  'http://localhost:9090/api/v1/query?query=hivenet_router_routing_agent_info' \
-  | jq .
-```
+  <Accordion title="Grafana has no audit logs">
+    Check Loki and Promtail:
 
-Check the service logs:
+    ```bash
+    docker compose logs loki | tail -50
+    docker compose logs promtail | tail -50
+    ```
 
-```bash
-docker compose logs prometheus | tail -50
-docker compose logs grafana | tail -50
-```
+    Confirm that the router writes audit records to the shared volume:
 
-### Grafana has no audit logs
+    ```bash
+    docker compose exec router \
+      ls -la /var/log/hivenet-router
+    ```
+  </Accordion>
 
-Check Loki and Promtail:
+  <Accordion title="Agent metrics are missing">
+    Agents do not expose a separate Prometheus endpoint for this deployment. They push metrics to the router.
 
-```bash
-docker compose logs loki | tail -50
-docker compose logs promtail | tail -50
-```
+    Inspect the routing table:
 
-Confirm that the router writes audit records to the shared volume:
+    ```bash
+    curl http://localhost:8888/admin/routing-table \
+      | jq '.agents[]'
+    ```
 
-```bash
-docker compose exec router \
-  ls -la /var/log/hivenet-router
-```
-
-### Agent metrics are missing
-
-Agents do not expose a separate Prometheus endpoint for this deployment. They push metrics to the router.
-
-Inspect the routing table:
-
-```bash
-curl http://localhost:8888/admin/routing-table \
-  | jq '.agents[]'
-```
-
-If the agent is missing or unhealthy, check its backend, network connection, logs, and JWT secret.
+    If the agent is missing or unhealthy, check its backend, network connection, logs, and JWT secret.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Bare metal" href="/deploy/bare-metal">
+<Columns cols={3}>
+  <Card title="Bare metal" icon="server" href="/deploy/bare-metal">
     Run the router and agents directly without Docker.
   </Card>
 
-  <Card title="vLLM agent" href="/deploy/agents/vllm">
+  <Card title="vLLM agent" icon="microchip" href="/deploy/agents/vllm">
     Configure a vLLM backend, model discovery, metrics, and capacity.
   </Card>
 
-  <Card title="Grafana dashboards" href="/observability/grafana-dashboards">
+  <Card title="Grafana dashboards" icon="chart-line" href="/observability/grafana-dashboards">
     Understand the provisioned dashboards and data sources.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/deploy/docker-quickstart.mdx
+++ b/docs/deploy/docker-quickstart.mdx
@@ -430,6 +430,10 @@ This guide uses Docker host networking and is intended for Linux hosts.
   </Step>
 </Steps>
 
+<Check>
+  The deployment is ready when the router reports two healthy vLLM agents and the routing counter increases after you send requests.
+</Check>
+
 ## Port reference
 
 | Service | Host | Port | Restrict access to |
@@ -444,91 +448,93 @@ Because the agent container uses host networking, it reaches vLLM at `localhost:
 
 ## Troubleshooting
 
-### An agent does not register
+<AccordionGroup>
+  <Accordion title="An agent does not register" icon="link-slash">
+    Check the agent logs:
 
-Check the agent logs:
+    ```bash
+    docker logs hivenet-agent
+    ```
 
-```bash
-docker logs hivenet-agent
-```
+    Test the agent’s connection to the router:
 
-Test the agent’s connection to the router:
+    ```bash
+    nc -zv 192.168.1.100 50051
+    nc -zv 192.168.1.100 9000
+    ```
 
-```bash
-nc -zv 192.168.1.100 50051
-nc -zv 192.168.1.100 9000
-```
+    Common causes include:
 
-Common causes include:
+    - `--router-grpc` points to the wrong address
+    - the router advertises a libp2p address the agent cannot reach
+    - the router is not listening on `0.0.0.0`
+    - the backend is not healthy
+    - the router and agent use different JWT secrets
+  </Accordion>
 
-- `--router-grpc` points to the wrong address
-- the router advertises a libp2p address the agent cannot reach
-- the router is not listening on `0.0.0.0`
-- the backend is not healthy
-- the router and agent use different JWT secrets
+  <Accordion title="vLLM is not ready" icon="server">
+    Inspect the logs:
 
-### vLLM is not ready
+    ```bash
+    docker logs vllm
+    ```
 
-Inspect the logs:
+    Check the health endpoint:
 
-```bash
-docker logs vllm
-```
+    ```bash
+    curl http://localhost:8888/health
+    ```
 
-Check the health endpoint:
+    Wait for vLLM to finish loading the model before starting the agent.
+  </Accordion>
 
-```bash
-curl http://localhost:8888/health
-```
+  <Accordion title="The JWT secret does not match" icon="key">
+    On the router and each agent host:
 
-Wait for vLLM to finish loading the model before starting the agent.
+    ```bash
+    sha256sum /path/to/jwt.secret
+    ```
 
-### The JWT secret does not match
+    The hash must be identical on every host.
+  </Accordion>
 
-On the router and each agent host:
+  <Accordion title="GPU metrics are missing" icon="microchip">
+    Check that Docker can access the GPU:
 
-```bash
-sha256sum /path/to/jwt.secret
-```
+    ```bash
+    docker run --rm \
+      --gpus all \
+      nvidia/cuda:12.6.0-base-ubuntu24.04 \
+      nvidia-smi
+    ```
 
-The hash must be identical on every host.
+    Confirm that the agent container received a GPU device request:
 
-### GPU metrics are missing
+    ```bash
+    docker inspect hivenet-agent \
+      | grep -A5 DeviceRequests
+    ```
+  </Accordion>
 
-Check that Docker can access the GPU:
+  <Accordion title="A firewall blocks traffic" icon="shield-halved">
+    On the router, allow only the traffic your deployment requires.
 
-```bash
-docker run --rm \
-  --gpus all \
-  nvidia/cuda:12.6.0-base-ubuntu24.04 \
-  nvidia-smi
-```
+    With UFW:
 
-Confirm that the agent container received a GPU device request:
+    ```bash
+    sudo ufw allow 8080/tcp
+    sudo ufw allow from 192.168.1.101 to any port 50051 proto tcp
+    sudo ufw allow from 192.168.1.102 to any port 50051 proto tcp
+    sudo ufw allow from 192.168.1.101 to any port 9000 proto tcp
+    sudo ufw allow from 192.168.1.102 to any port 9000 proto tcp
+    sudo ufw allow from <monitoring-ip> to any port 2112 proto tcp
+    ```
 
-```bash
-docker inspect hivenet-agent \
-  | grep -A5 DeviceRequests
-```
-
-### A firewall blocks traffic
-
-On the router, allow only the traffic your deployment requires.
-
-With UFW:
-
-```bash
-sudo ufw allow 8080/tcp
-sudo ufw allow from 192.168.1.101 to any port 50051 proto tcp
-sudo ufw allow from 192.168.1.102 to any port 50051 proto tcp
-sudo ufw allow from 192.168.1.101 to any port 9000 proto tcp
-sudo ufw allow from 192.168.1.102 to any port 9000 proto tcp
-sudo ufw allow from <monitoring-ip> to any port 2112 proto tcp
-```
-
-<Warning>
-  These commands are examples, not a complete network-security policy. Apply equivalent restrictions in your cloud firewall or security group.
-</Warning>
+    <Warning>
+      These commands are examples, not a complete network-security policy. Apply equivalent restrictions in your cloud firewall or security group.
+    </Warning>
+  </Accordion>
+</AccordionGroup>
 
 ## Clean up
 
@@ -550,16 +556,16 @@ The BadgerDB data in the mounted `badger` directory and agent identity files in 
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Docker Compose" href="/deploy/docker-compose">
+<Columns cols={3}>
+  <Card title="Docker Compose" icon="boxes-stacked" href="/deploy/docker-compose">
     Add Prometheus, Grafana, Loki, and Tempo using the repository’s Compose stack.
   </Card>
 
-  <Card title="vLLM agent" href="/deploy/agents/vllm">
+  <Card title="vLLM agent" icon="microchip" href="/deploy/agents/vllm">
     Configure model discovery, metrics, capacity, and multi-model deployments.
   </Card>
 
-  <Card title="Routing concepts" href="/routing/routing-concepts">
+  <Card title="Routing concepts" icon="route" href="/routing/routing-concepts">
     Control how Hivenet Router filters, ranks, and falls back across agents.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -7,6 +7,9 @@
     "light": "#FFB366",
     "dark": "#D46E35"
   },
+  "styling": {
+    "eyebrows": "breadcrumbs"
+  },
   "favicon": {
     "light": "/images/favicon.png",
     "dark": "/images/favicon.png"
@@ -16,6 +19,7 @@
       "index",
       {
         "group": "Getting started",
+        "icon": "rocket",
         "pages": [
           "getting-started/introduction",
           "getting-started/why-hivenet-router",
@@ -26,12 +30,14 @@
       },
       {
         "group": "Deploy Hivenet Router",
+        "icon": "server",
         "pages": [
           "deploy/docker-quickstart",
           "deploy/docker-compose",
           "deploy/bare-metal",
           {
             "group": "Agents",
+            "icon": "microchip",
             "pages": [
               "deploy/agents/vllm",
               "deploy/agents/ollama",
@@ -45,6 +51,7 @@
       },
       {
         "group": "Use the API",
+        "icon": "code",
         "pages": [
           "use-the-api/chat-completions",
           "use-the-api/embeddings",
@@ -55,6 +62,7 @@
       },
       {
         "group": "Routing and policies",
+        "icon": "route",
         "pages": [
           "routing/routing-concepts",
           "routing/policy-yaml-reference",
@@ -66,6 +74,7 @@
       },
       {
         "group": "Security and auth",
+        "icon": "lock",
         "pages": [
           "security/authentication-overview",
           "security/api-keys",
@@ -76,6 +85,7 @@
       },
       {
         "group": "Observability",
+        "icon": "chart-line",
         "pages": [
           "observability/observability-overview",
           "observability/prometheus-metrics",
@@ -90,6 +100,7 @@
       },
       {
         "group": "Integrations",
+        "icon": "plug",
         "pages": [
           "integrations/integrations-overview",
           "integrations/claude-code",
@@ -101,6 +112,7 @@
       },
       {
         "group": "Reference",
+        "icon": "book",
         "pages": [
           "reference/detailed-architecture",
           "reference/configuration-reference",
@@ -110,6 +122,7 @@
       },
       {
         "group": "Project",
+        "icon": "users",
         "pages": [
           "project/project-overview",
           "project/contributing",

--- a/docs/getting-started/architecture-overview.mdx
+++ b/docs/getting-started/architecture-overview.mdx
@@ -83,17 +83,41 @@ A deployment can mix different backend types. Applications continue to use the r
 
 A typical inference request moves through Hivenet Router like this:
 
-1. A client sends a request to the router.
-2. The router authenticates the client if API authentication is enabled.
-3. The router identifies the requested model and capability.
-4. Static policy filters remove agents that do not match the request.
-5. Dynamic policy gates remove agents that fail configured health or metric thresholds.
-6. The routing strategy ranks the remaining agents.
-7. The router acquires capacity on the selected agent.
-8. The request is forwarded to the agent over the encrypted libp2p data plane.
-9. The agent sends the request to its local inference backend.
-10. The response returns through the agent and router to the client.
-11. Hivenet Router records the outcome and updates routing and latency metrics.
+<Steps>
+  <Step title="Client sends a request">
+    A client sends a request to the router.
+  </Step>
+  <Step title="Client authentication">
+    The router authenticates the client if API authentication is enabled.
+  </Step>
+  <Step title="Model and capability">
+    The router identifies the requested model and capability.
+  </Step>
+  <Step title="Static matching">
+    Static policy filters remove agents that do not match the request.
+  </Step>
+  <Step title="Dynamic gates">
+    Dynamic policy gates remove agents that fail configured health or metric thresholds.
+  </Step>
+  <Step title="Ranking">
+    The routing strategy ranks the remaining agents.
+  </Step>
+  <Step title="Capacity acquisition">
+    The router acquires capacity on the selected agent.
+  </Step>
+  <Step title="Forward to agent">
+    The request is forwarded to the agent over the encrypted libp2p data plane.
+  </Step>
+  <Step title="Backend execution">
+    The agent sends the request to its local inference backend.
+  </Step>
+  <Step title="Response">
+    The response returns through the agent and router to the client.
+  </Step>
+  <Step title="Record outcome">
+    Hivenet Router records the outcome and updates routing and latency metrics.
+  </Step>
+</Steps>
 
 If the initial routing step cannot serve the request, Hivenet Router can continue through a configured fallback chain. An optional provider fallback can send the request to OpenAI or Anthropic after local options are exhausted.
 
@@ -117,11 +141,23 @@ Hivenet Router separates authentication from inference traffic.
 
 ### Agent authentication
 
-1. The agent signs a JWT with the shared secret.
-2. It connects to the router’s gRPC authentication endpoint.
-3. The router validates the token and agent metadata.
-4. The router returns a session token and its libp2p address.
-5. The agent registers over libp2p using the session token.
+<Steps>
+  <Step title="Sign JWT">
+    The agent signs a JWT with the shared secret.
+  </Step>
+  <Step title="Connect to gRPC">
+    It connects to the router’s gRPC authentication endpoint.
+  </Step>
+  <Step title="Validate token">
+    The router validates the token and agent metadata.
+  </Step>
+  <Step title="Return session">
+    The router returns a session token and its libp2p address.
+  </Step>
+  <Step title="Register over libp2p">
+    The agent registers over libp2p using the session token.
+  </Step>
+</Steps>
 
 The gRPC connection uses TLS 1.3. The certificate and client trust material are derived from the shared JWT secret, so the deployment does not require a separate public-key infrastructure for router-agent authentication.
 
@@ -137,7 +173,9 @@ The same connection carries registration, heartbeats, routing signals, and forwa
 
 The router’s built-in API server listens over HTTP.
 
-For production deployments, place the API behind a reverse proxy or load balancer that provides TLS and any network controls your environment requires.
+<Info>
+  For production deployments, place the API behind a reverse proxy or load balancer that provides TLS and any network controls your environment requires.
+</Info>
 
 ## Health and metrics
 
@@ -219,12 +257,12 @@ Hivenet Router does not require Kubernetes. The current repository does not incl
 
 ## What to read next
 
-<CardGroup cols={2}>
-  <Card title="Quickstart" href="/quickstart">
+<Columns cols={2}>
+  <Card title="Quickstart" icon="rocket" href="/quickstart">
     Deploy a router and several agents, then send your first routed request.
   </Card>
 
-  <Card title="Hivenet Router and Hivenet services" href="/getting-started/hivenet-services">
+  <Card title="Hivenet Router and Hivenet services" icon="layer-group" href="/getting-started/hivenet-services">
     Understand how Hivenet Router differs from Hivenet Inference API and Compute with Hivenet.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/getting-started/hivenet-services.mdx
+++ b/docs/getting-started/hivenet-services.mdx
@@ -12,6 +12,20 @@ The main difference is who operates each layer.
 - With **Hivenet Inference API**, Hivenet operates the inference service behind a managed API.
 - With **Compute with Hivenet**, you rent infrastructure and decide what software to run on it.
 
+<Columns cols={3}>
+  <Card title="Hivenet Router" icon="route">
+    Self-hosted routing for your own inference backends.
+  </Card>
+
+  <Card title="Hivenet Inference API" icon="cloud">
+    Managed inference endpoint operated by Hivenet.
+  </Card>
+
+  <Card title="Compute with Hivenet" icon="server">
+    Rented GPU and CPU infrastructure you operate.
+  </Card>
+</Columns>
+
 <Note>
   These docs cover Hivenet Router. Information about Hivenet Inference API and Compute with Hivenet is included here only to explain where Hivenet Router fits.
 </Note>
@@ -112,12 +126,12 @@ You can also combine them where appropriate. For example, you might run Hivenet 
 
 ## Continue with Hivenet Router
 
-<CardGroup cols={2}>
-  <Card title="Quickstart" href="/quickstart">
+<Columns cols={2}>
+  <Card title="Quickstart" icon="rocket" href="/quickstart">
     Deploy a router and agents, then send your first routed request.
   </Card>
 
-  <Card title="Architecture overview" href="/getting-started/architecture-overview">
+  <Card title="Architecture overview" icon="sitemap" href="/getting-started/architecture-overview">
     See how the router, agents, control plane, and data plane work together.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -105,20 +105,20 @@ Hivenet Router exports Prometheus metrics and includes Grafana dashboards for ro
 
 ## Start exploring
 
-<CardGroup cols={2}>
-  <Card title="Quickstart" href="/quickstart">
+<Columns cols={2}>
+  <Card title="Quickstart" icon="rocket" href="/quickstart">
     Build Hivenet Router, start a router and agent, and send your first request.
   </Card>
 
-  <Card title="Architecture overview" href="/getting-started/architecture-overview">
+  <Card title="Architecture overview" icon="sitemap" href="/getting-started/architecture-overview">
     Understand the control plane, data plane, storage, authentication, and request flow.
   </Card>
 
-  <Card title="Hivenet Router and Hivenet services" href="/getting-started/hivenet-services">
+  <Card title="Hivenet Router and Hivenet services" icon="layer-group" href="/getting-started/hivenet-services">
     See how Hivenet Router differs from Hivenet Inference API and Compute with Hivenet.
   </Card>
 
-  <Card title="GitHub repository" href="https://github.com/HivenetOSS/hivenet_router">
+  <Card title="GitHub repository" icon="github" href="https://github.com/HivenetOSS/hivenet_router">
     View the source code, project status, license, and contribution guidance.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/getting-started/why-hivenet-router.mdx
+++ b/docs/getting-started/why-hivenet-router.mdx
@@ -29,20 +29,20 @@ A direct connection may be simpler for a single static backend with one trusted 
 
 The router coordinates requests; it does not replace the inference engines that execute them. Agents report model and hardware capacity, while routing policies decide which healthy targets are eligible. Admission control decides whether eligible capacity can accept more work.
 
-<CardGroup cols={2}>
-  <Card title="Architecture overview" href="/getting-started/architecture-overview">
+<Columns cols={2}>
+  <Card title="Architecture overview" icon="sitemap" href="/getting-started/architecture-overview">
     See how routers, agents, and inference engines work together.
   </Card>
 
-  <Card title="Hivenet services" href="/getting-started/hivenet-services">
+  <Card title="Hivenet services" icon="layer-group" href="/getting-started/hivenet-services">
     Compare Hivenet Router with hosted Hivenet inference and compute services.
   </Card>
 
-  <Card title="Routing concepts" href="/routing/routing-concepts">
+  <Card title="Routing concepts" icon="route" href="/routing/routing-concepts">
     Learn how policies, candidates, and fallback behavior shape a request.
   </Card>
 
-  <Card title="Admission control" href="/routing/admission-control">
+  <Card title="Admission control" icon="shield-check" href="/routing/admission-control">
     Understand request limits and occupancy protection.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -30,93 +30,72 @@ description: "Open-source routing for self-hosted and distributed AI inference."
   </div>
 </div>
 
-<div className="max-w-5xl mx-auto px-6 pb-20">
-  <div className="mb-8">
-    <h2 className="text-2xl font-medium tracking-tight text-gray-900 dark:text-zinc-50">
-      Explore the docs
-    </h2>
-
-    <p className="mt-2 text-gray-600 dark:text-zinc-400">
-      Start with the system overview or go directly to deployment, routing,
-      and API guidance.
-    </p>
-  </div>
-
-  <Columns cols={2}>
-    <Card title="Introduction" icon="book-open" color="#FF9A33" href="/getting-started/introduction">
-      Learn what Hivenet Router does, when it is useful, and what it does not
-      provide.
-    </Card>
-
-    <Card title="Quickstart" icon="rocket" color="#FF9A33" href="/quickstart">
-      Deploy a router and agents, then send your first routed inference
-      request.
-    </Card>
-
-    <Card title="Architecture overview" icon="network-wired" color="#FF9A33" href="/getting-started/architecture-overview">
-      Understand the router, agents, control plane, data plane, storage,
-      and request flow.
-    </Card>
-
-    <Card title="Hivenet Router and Hivenet services" icon="arrows-split-up-and-left" color="#FF9A33" href="/getting-started/hivenet-services">
-      See how Hivenet Router differs from Hivenet Inference API and Compute
-      with Hivenet.
-    </Card>
-  </Columns>
-</div>
-
-Hivenet Router is an open-source router for self-hosted AI inference, maintained by Hivenet.
-
-It puts one client-facing API in front of multiple inference servers. A central router tracks the health, load, latency, models, and capabilities of connected agents, then forwards each request according to your routing policies.
+Hivenet Router is an open-source project maintained by Hivenet. It puts one client-facing API in front of multiple inference servers and routes each request using current agent health, load, latency, model, and capability data.
 
 <Warning>
   Hivenet Router is currently in alpha. Interfaces, configuration, and deployment workflows may change as the project develops.
 </Warning>
 
-## Start here
+## How it works
 
-<CardGroup cols={2}>
-  <Card title="Introduction" href="/getting-started/introduction">
-    Understand what Hivenet Router does and when to use it.
+<Columns cols={3}>
+  <Card title="Connect" icon="link" color="#FF9A33">
+    Agents connect inference backends to the router and report their models, capabilities, capacity, health, and live signals.
   </Card>
 
-  <Card title="Quickstart" href="/quickstart">
-    Deploy a router and an agent and send your first request.
+  <Card title="Route" icon="route" color="#FF9A33">
+    The router applies model and capability constraints, policy gates, ranking, queues, retries, and fallback.
   </Card>
 
-  <Card title="Architecture overview" href="/getting-started/architecture-overview">
-    See the control plane, data plane, and request flow.
+  <Card title="Observe" icon="chart-line" color="#FF9A33">
+    Prometheus metrics, Grafana dashboards, traces, and audit records show how requests move through the fleet.
+  </Card>
+</Columns>
+
+## Start building
+
+<Columns cols={2}>
+  <Card title="Quickstart" icon="rocket" color="#FF9A33" href="/quickstart">
+    Deploy a router and three agents, then send and observe your first routed inference request.
   </Card>
 
-  <Card title="Docker quickstart" href="/deploy/docker-quickstart">
-    Deploy a router and two vLLM agents with Docker.
-  </Card>
-</CardGroup>
-
-## Explore by topic
-
-<CardGroup cols={2}>
-  <Card title="Deploy" icon="server" href="/deploy/docker-quickstart">
-    Install the router and agents on Docker, Docker Compose, or bare metal.
+  <Card title="Architecture overview" icon="network-wired" color="#FF9A33" href="/getting-started/architecture-overview">
+    Understand the control plane, data plane, storage, authentication, and request flow.
   </Card>
 
-  <Card title="Routing and policies" icon="route" href="/routing/routing-concepts">
-    Filter and rank agents with YAML policies and fallback chains.
+  <Card title="Docker quickstart" icon="server" color="#FF9A33" href="/deploy/docker-quickstart">
+    Run a router and two vLLM agents across Linux hosts with Docker.
   </Card>
 
-  <Card title="Security and auth" icon="lock" href="/security/authentication-overview">
-    Authenticate agents and clients, enforce quotas, and rotate keys.
+  <Card title="Use the API" icon="code" color="#FF9A33" href="/use-the-api/chat-completions">
+    Send chat, embedding, reranking, model-list, and administration requests.
+  </Card>
+</Columns>
+
+## Explore by task
+
+<Columns cols={3}>
+  <Card title="Routing and policies" icon="route" href="/routing/routing-concepts" horizontal>
+    Filter, rank, queue, and fall back across agents.
   </Card>
 
-  <Card title="Observability" icon="chart-line" href="/observability/prometheus-metrics">
-    Monitor routing, agents, engines, and hardware with Prometheus and Grafana.
+  <Card title="Security and auth" icon="lock" href="/security/authentication-overview" horizontal>
+    Authenticate agents and clients and enforce access controls.
   </Card>
 
-  <Card title="Integrations" icon="plug" href="/integrations/integrations-overview">
-    Connect Hivenet Router to Claude Code, OpenCode, Open WebUI, and more.
+  <Card title="Observability" icon="chart-line" href="/observability/observability-overview" horizontal>
+    Monitor router, agent, engine, and hardware behavior.
   </Card>
 
-  <Card title="Reference" icon="book" href="/reference/detailed-architecture">
-    Configuration schema, error codes, and performance characteristics.
+  <Card title="Integrations" icon="plug" href="/integrations/integrations-overview" horizontal>
+    Connect Claude Code, OpenCode, Pi, Open WebUI, and applications.
   </Card>
-</CardGroup>
+
+  <Card title="Reference" icon="book" href="/reference/configuration-reference" horizontal>
+    Look up configuration, architecture, errors, and performance.
+  </Card>
+
+  <Card title="Project" icon="users" href="/project/project-overview" horizontal>
+    Contribute, report security issues, and review project policies.
+  </Card>
+</Columns>

--- a/docs/integrations/claude-code.mdx
+++ b/docs/integrations/claude-code.mdx
@@ -775,255 +775,257 @@ Give Claude Code its own client key when you need its traffic separated from oth
 
 ## Troubleshooting
 
-### Claude Code opens the login screen
+<AccordionGroup>
+  <Accordion title="Claude Code opens the login screen">
+    The gateway credential did not reach the process.
 
-The gateway credential did not reach the process.
+    Check:
 
-Check:
-
-```bash
-echo "$ANTHROPIC_BASE_URL"
-echo "${ANTHROPIC_AUTH_TOKEN:+set}"
-```
-
-Then start Claude Code from the same shell.
-
-Run `/status` after it opens.
-
-### `/status` shows no Anthropic base URL
-
-Claude Code is not using the Hivenet Router endpoint.
-
-Check for:
-
-- a missing environment variable
-- a settings-file override
-- an editor or launcher with another environment
-- a misspelled variable name
-
-### Requests return `401`
-
-Use:
-
-```text
-ANTHROPIC_AUTH_TOKEN
-```
-
-rather than only:
-
-```text
-ANTHROPIC_API_KEY
-```
-
-Confirm that the raw Hivenet Router client key is being sent, not its SHA-256 hash.
-
-Test it directly:
-
-```bash
-curl \
-  -H "Authorization: Bearer <hivenet-router-api-key>" \
-  https://router.example.com/v1/models
-```
-
-### Requests return a plain `404`
-
-Check the base URL.
-
-It should not end in:
-
-```text
-/v1
-```
-
-Also confirm that the request reaches:
-
-```text
-/v1/messages
-```
-
-rather than an unsupported path.
-
-### The router returns `model_not_found`
-
-Compare the configured alias with:
-
-```bash
-curl \
-  -H "Authorization: Bearer <hivenet-router-api-key>" \
-  https://router.example.com/v1/models \
-  | jq -r '.data[].id'
-```
-
-Check:
-
-- capitalization
-- punctuation
-- served-model alias
-- agent `--model`
-- API-key model access
-- agent health
-
-### The backend returns `404` for `/v1/messages`
-
-The backend does not implement the Anthropic Messages endpoint.
-
-A backend that supports only:
-
-```text
-/v1/chat/completions
-```
-
-cannot serve Claude Code through the current Hivenet Router passthrough.
-
-Use an Anthropic-compatible backend or another coding client that speaks OpenAI Chat Completions.
-
-### Text works but tools fail
-
-Check that:
-
-- the model supports structured tool calls
-- vLLM uses `--enable-auto-tool-choice`
-- the selected `--tool-call-parser` matches the model
-- the backend returns Anthropic-format tool-use blocks
-- the model follows tool schemas reliably
-
-Test the backend directly to isolate it from Hivenet Router.
-
-### The backend rejects `system` messages
-
-Upgrade the backend and test the current Claude Code request against it directly.
-
-Do not begin by pinning an old Claude Code release. First confirm whether the backend’s current Anthropic Messages implementation accepts the system-content shape the client sends.
-
-### The backend rejects `thinking` or `adaptive`
-
-Update the backend first.
-
-As a compatibility test:
-
-```bash
-export CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1
-```
-
-Restart Claude Code after changing the variable.
-
-### The backend rejects beta fields
-
-As a temporary diagnostic:
-
-```bash
-export CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1
-```
-
-This may disable context management and newer tool features.
-
-### Claude Code retries and Hivenet Router later reports no eligible agent
-
-Inspect the backend’s first error.
-
-A backend rejection that Hivenet Router treats as retryable can cause the request session to try other agents and exclude agents that already failed.
-
-Check:
-
-<Tabs>
-  <Tab title="Router">
     ```bash
-    docker compose logs router \
-      | grep -iE "messages|policy|failed|exhaust"
+    echo "$ANTHROPIC_BASE_URL"
+    echo "${ANTHROPIC_AUTH_TOKEN:+set}"
     ```
-  </Tab>
-  <Tab title="Agent">
+
+    Then start Claude Code from the same shell.
+
+    Run `/status` after it opens.
+  </Accordion>
+
+  <Accordion title="`/status` shows no Anthropic base URL">
+    Claude Code is not using the Hivenet Router endpoint.
+
+    Check for:
+
+    - a missing environment variable
+    - a settings-file override
+    - an editor or launcher with another environment
+    - a misspelled variable name
+  </Accordion>
+
+  <Accordion title="Requests return `401`">
+    Use:
+
+    ```text
+    ANTHROPIC_AUTH_TOKEN
+    ```
+
+    rather than only:
+
+    ```text
+    ANTHROPIC_API_KEY
+    ```
+
+    Confirm that the raw Hivenet Router client key is being sent, not its SHA-256 hash.
+
+    Test it directly:
+
     ```bash
-    docker compose logs <agent-service> \
-      | tail -100
+    curl \
+      -H "Authorization: Bearer <hivenet-router-api-key>" \
+      https://router.example.com/v1/models
     ```
-  </Tab>
-  <Tab title="vLLM">
+  </Accordion>
+
+  <Accordion title="Requests return a plain `404`">
+    Check the base URL.
+
+    It should not end in:
+
+    ```text
+    /v1
+    ```
+
+    Also confirm that the request reaches:
+
+    ```text
+    /v1/messages
+    ```
+
+    rather than an unsupported path.
+  </Accordion>
+
+  <Accordion title="The router returns `model_not_found`">
+    Compare the configured alias with:
+
     ```bash
-    docker compose logs <vllm-service> \
-      | tail -100
+    curl \
+      -H "Authorization: Bearer <hivenet-router-api-key>" \
+      https://router.example.com/v1/models \
+      | jq -r '.data[].id'
     ```
-  </Tab>
-</Tabs>
 
-The most useful validation message often appears in the backend log.
+    Check:
 
-### Streaming arrives only after completion
+    - capitalization
+    - punctuation
+    - served-model alias
+    - agent `--model`
+    - API-key model access
+    - agent health
+  </Accordion>
 
-Check:
+  <Accordion title="The backend returns `404` for `/v1/messages`">
+    The backend does not implement the Anthropic Messages endpoint.
 
-- backend SSE behavior
-- Hivenet Router agent version
-- reverse-proxy buffering
-- proxy read and idle timeouts
-- response `Content-Type`
+    A backend that supports only:
 
-Test the backend and router separately with streaming curl requests.
+    ```text
+    /v1/chat/completions
+    ```
 
-### Token counting fails
+    cannot serve Claude Code through the current Hivenet Router passthrough.
 
-Test the backend directly:
+    Use an Anthropic-compatible backend or another coding client that speaks OpenAI Chat Completions.
+  </Accordion>
 
-```bash
-curl -i -X POST \
-  http://localhost:8888/v1/messages/count_tokens \
-  -H "Content-Type: application/json" \
-  -H "anthropic-version: 2023-06-01" \
-  -d '{
-    "model": "hivenet-router-code-model",
-    "messages": [
-      {
-        "role": "user",
-        "content": "Hello"
-      }
-    ]
-  }'
-```
+  <Accordion title="Text works but tools fail">
+    Check that:
 
-Claude Code can estimate context locally when token counting is unavailable, but backend support gives more accurate results.
+    - the model supports structured tool calls
+    - vLLM uses `--enable-auto-tool-choice`
+    - the selected `--tool-call-parser` matches the model
+    - the backend returns Anthropic-format tool-use blocks
+    - the model follows tool schemas reliably
 
-### The model picker does not show Hivenet Router models
+    Test the backend directly to isolate it from Hivenet Router.
+  </Accordion>
 
-Use the mapped aliases:
+  <Accordion title="The backend rejects `system` messages">
+    Upgrade the backend and test the current Claude Code request against it directly.
 
-```text
-/model sonnet
-/model opus
-/model haiku
-```
+    Do not begin by pinning an old Claude Code release. First confirm whether the backend’s current Anthropic Messages implementation accepts the system-content shape the client sends.
+  </Accordion>
 
-Or configure:
+  <Accordion title="The backend rejects `thinking` or `adaptive`">
+    Update the backend first.
 
-```text
-ANTHROPIC_CUSTOM_MODEL_OPTION
-```
+    As a compatibility test:
 
-Gateway discovery ignores typical open-model IDs that do not begin with `claude` or `anthropic`.
+    ```bash
+    export CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1
+    ```
+
+    Restart Claude Code after changing the variable.
+  </Accordion>
+
+  <Accordion title="The backend rejects beta fields">
+    As a temporary diagnostic:
+
+    ```bash
+    export CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1
+    ```
+
+    This may disable context management and newer tool features.
+  </Accordion>
+
+  <Accordion title="Claude Code retries and Hivenet Router later reports no eligible agent">
+    Inspect the backend’s first error.
+
+    A backend rejection that Hivenet Router treats as retryable can cause the request session to try other agents and exclude agents that already failed.
+
+    Check:
+
+    <Tabs>
+      <Tab title="Router">
+        ```bash
+        docker compose logs router \
+          | grep -iE "messages|policy|failed|exhaust"
+        ```
+      </Tab>
+      <Tab title="Agent">
+        ```bash
+        docker compose logs <agent-service> \
+          | tail -100
+        ```
+      </Tab>
+      <Tab title="vLLM">
+        ```bash
+        docker compose logs <vllm-service> \
+          | tail -100
+        ```
+      </Tab>
+    </Tabs>
+
+    The most useful validation message often appears in the backend log.
+  </Accordion>
+
+  <Accordion title="Streaming arrives only after completion">
+    Check:
+
+    - backend SSE behavior
+    - Hivenet Router agent version
+    - reverse-proxy buffering
+    - proxy read and idle timeouts
+    - response `Content-Type`
+
+    Test the backend and router separately with streaming curl requests.
+  </Accordion>
+
+  <Accordion title="Token counting fails">
+    Test the backend directly:
+
+    ```bash
+    curl -i -X POST \
+      http://localhost:8888/v1/messages/count_tokens \
+      -H "Content-Type: application/json" \
+      -H "anthropic-version: 2023-06-01" \
+      -d '{
+        "model": "hivenet-router-code-model",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Hello"
+          }
+        ]
+      }'
+    ```
+
+    Claude Code can estimate context locally when token counting is unavailable, but backend support gives more accurate results.
+  </Accordion>
+
+  <Accordion title="The model picker does not show Hivenet Router models">
+    Use the mapped aliases:
+
+    ```text
+    /model sonnet
+    /model opus
+    /model haiku
+    ```
+
+    Or configure:
+
+    ```text
+    ANTHROPIC_CUSTOM_MODEL_OPTION
+    ```
+
+    Gateway discovery ignores typical open-model IDs that do not begin with `claude` or `anthropic`.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="OpenCode" href="/integrations/open-code">
+<Columns cols={3}>
+  <Card title="OpenCode" icon="code" href="/integrations/open-code">
     Connect a coding agent through OpenAI Chat Completions.
   </Card>
 
-  <Card title="Use from code" href="/integrations/use-from-code">
+  <Card title="Use from code" icon="code-branch" href="/integrations/use-from-code">
     Call Hivenet Router from SDKs, scripts, and custom applications.
   </Card>
 
-  <Card title="Chat completions and messages" href="/use-the-api/chat-completions">
+  <Card title="Chat completions and messages" icon="messages" href="/use-the-api/chat-completions">
     Review the Anthropic and OpenAI inference paths.
   </Card>
 
-  <Card title="API keys" href="/security/api-keys">
+  <Card title="API keys" icon="key" href="/security/api-keys">
     Configure model access, quotas, expiration, and credential rotation.
   </Card>
 
-  <Card title="vLLM agent" href="/deploy/agents/vllm">
+  <Card title="vLLM agent" icon="server" href="/deploy/agents/vllm">
     Deploy and register the backend serving Claude Code requests.
   </Card>
 
-  <Card title="Audit logging" href="/observability/audit-logging">
+  <Card title="Audit logging" icon="clipboard-list" href="/observability/audit-logging">
     Investigate Claude Code requests by tenant, model, status, and agent.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/integrations/integrations-overview.mdx
+++ b/docs/integrations/integrations-overview.mdx
@@ -11,27 +11,27 @@ The right setup depends on two things:
 - the client you are connecting
 - the API format supported by the inference backend behind Hivenet Router
 
-<CardGroup cols={2}>
-  <Card title="Claude Code" href="/integrations/claude-code">
+<Columns cols={2}>
+  <Card title="Claude Code" icon="terminal" href="/integrations/claude-code">
     Connect Claude Code through the Anthropic Messages API.
   </Card>
 
-  <Card title="OpenCode" href="/integrations/open-code">
+  <Card title="OpenCode" icon="code" href="/integrations/open-code">
     Configure Hivenet Router as an OpenAI-compatible provider in OpenCode.
   </Card>
 
-  <Card title="Pi" href="/integrations/pi">
+  <Card title="Pi" icon="robot" href="/integrations/pi">
     Add Hivenet Router and its available models to the Pi coding agent.
   </Card>
 
-  <Card title="Open WebUI" href="/integrations/open-web-ui">
+  <Card title="Open WebUI" icon="browser" href="/integrations/open-web-ui">
     Use Hivenet Router as the inference endpoint for a browser-based chat interface.
   </Card>
 
-  <Card title="Use from code" href="/integrations/use-from-code">
+  <Card title="Use from code" icon="code-branch" href="/integrations/use-from-code">
     Call Hivenet Router from curl, Python, JavaScript, SDKs, and custom services.
   </Card>
-</CardGroup>
+</Columns>
 
 ## Choose an integration
 
@@ -270,28 +270,28 @@ Use the direct curl test to determine whether a problem belongs to Hivenet Route
 
 ## Integration guides
 
-<CardGroup cols={2}>
-  <Card title="Claude Code" href="/integrations/claude-code">
+<Columns cols={2}>
+  <Card title="Claude Code" icon="terminal" href="/integrations/claude-code">
     Configure the Anthropic Messages endpoint, authentication, model, and tool-use checks.
   </Card>
 
-  <Card title="OpenCode" href="/integrations/open-code">
+  <Card title="OpenCode" icon="code" href="/integrations/open-code">
     Configure a custom OpenAI-compatible provider and model.
   </Card>
 
-  <Card title="Pi" href="/integrations/pi">
+  <Card title="Pi" icon="robot" href="/integrations/pi">
     Register a custom provider and expose Hivenet Router models in Pi.
   </Card>
 
-  <Card title="Open WebUI" href="/integrations/open-web-ui">
+  <Card title="Open WebUI" icon="browser" href="/integrations/open-web-ui">
     Connect a browser interface and understand shared-key behavior.
   </Card>
 
-  <Card title="Use from code" href="/integrations/use-from-code">
+  <Card title="Use from code" icon="code-branch" href="/integrations/use-from-code">
     Call chat, embeddings, and reranking endpoints from your own software.
   </Card>
 
-  <Card title="Chat completions and messages" href="/use-the-api/chat-completions">
+  <Card title="Chat completions and messages" icon="messages" href="/use-the-api/chat-completions">
     Review Hivenet Router’s supported LLM paths and forwarding behavior.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/integrations/open-code.mdx
+++ b/docs/integrations/open-code.mdx
@@ -1027,282 +1027,284 @@ sum by (tenant_id, model) (
 
 ## Troubleshooting
 
-### The Hivenet Router provider does not appear
+<AccordionGroup>
+  <Accordion title="The Hivenet Router provider does not appear">
+    Check the merged configuration:
 
-Check the merged configuration:
+    ```bash
+    opencode debug config \
+      | jq '.provider.hivenet-router'
+    ```
 
-```bash
-opencode debug config \
-  | jq '.provider.hivenet-router'
-```
+    Check that:
 
-Check that:
+    - the file is in a supported configuration location
+    - the JSON is valid
+    - `hivenet-router` is included in `enabled_providers`
+    - it is not also present in `disabled_providers`
+    - the current project does not override the provider
 
-- the file is in a supported configuration location
-- the JSON is valid
-- `hivenet-router` is included in `enabled_providers`
-- it is not also present in `disabled_providers`
-- the current project does not override the provider
+    OpenCode configurations are merged, so a project file can override a global setting.
+  </Accordion>
 
-OpenCode configurations are merged, so a project file can override a global setting.
+  <Accordion title="OpenCode reports `ProviderModelNotFoundError`">
+    Model references must use:
 
-### OpenCode reports `ProviderModelNotFoundError`
+    ```text
+    provider/model
+    ```
 
-Model references must use:
+    For example:
 
-```text
-provider/model
-```
+    ```text
+    hivenet-router/hivenet-router-code-model
+    ```
 
-For example:
+    The provider prefix must match:
 
-```text
-hivenet-router/hivenet-router-code-model
-```
+    ```json
+    "provider": {
+      "hivenet-router": {}
+    }
+    ```
 
-The provider prefix must match:
+    The model suffix must match a key under:
 
-```json
-"provider": {
-  "hivenet-router": {}
-}
-```
+    ```json
+    "provider": {
+      "hivenet-router": {
+        "models": {}
+      }
+    }
+    ```
 
-The model suffix must match a key under:
+    List the loaded models:
 
-```json
-"provider": {
-  "hivenet-router": {
-    "models": {}
-  }
-}
-```
+    ```bash
+    opencode models hivenet-router
+    ```
+  </Accordion>
 
-List the loaded models:
+  <Accordion title="Hivenet Router returns `401 Unauthorized`">
+    Check that:
 
-```bash
-opencode models hivenet-router
-```
+    - `HIVENET_ROUTER_API_KEY` contains the raw client key
+    - the variable reached the OpenCode process
+    - the key has not expired
+    - the configured `apiKey` uses the correct environment-variable name
 
-### Hivenet Router returns `401 Unauthorized`
+    Test the same value directly:
 
-Check that:
+    ```bash
+    curl \
+      -H "Authorization: Bearer $HIVENET_ROUTER_API_KEY" \
+      https://router.example.com/v1/models
+    ```
+  </Accordion>
 
-- `HIVENET_ROUTER_API_KEY` contains the raw client key
-- the variable reached the OpenCode process
-- the key has not expired
-- the configured `apiKey` uses the correct environment-variable name
+  <Accordion title="Requests reach `/v1/responses`">
+    The wrong provider adapter is configured.
 
-Test the same value directly:
+    Use:
 
-```bash
-curl \
-  -H "Authorization: Bearer $HIVENET_ROUTER_API_KEY" \
-  https://router.example.com/v1/models
-```
+    ```json
+    "npm": "@ai-sdk/openai-compatible"
+    ```
 
-### Requests reach `/v1/responses`
+    Hivenet Router supports:
 
-The wrong provider adapter is configured.
+    ```text
+    POST /v1/chat/completions
+    ```
 
-Use:
+    but not:
 
-```json
-"npm": "@ai-sdk/openai-compatible"
-```
+    ```text
+    POST /v1/responses
+    ```
+  </Accordion>
 
-Hivenet Router supports:
+  <Accordion title="Requests return a plain `404`">
+    Check the base URL.
 
-```text
-POST /v1/chat/completions
-```
+    It must end in:
 
-but not:
+    ```text
+    /v1
+    ```
 
-```text
-POST /v1/responses
-```
+    but not:
 
-### Requests return a plain `404`
+    ```text
+    /v1/chat/completions
+    ```
 
-Check the base URL.
+    Inspect the reverse-proxy access log to confirm the final path.
+  </Accordion>
 
-It must end in:
+  <Accordion title="Hivenet Router returns `model_not_found`">
+    Compare:
 
-```text
-/v1
-```
+    ```bash
+    opencode models hivenet-router
+    ```
 
-but not:
+    with:
 
-```text
-/v1/chat/completions
-```
+    ```bash
+    curl \
+      -H "Authorization: Bearer $HIVENET_ROUTER_API_KEY" \
+      https://router.example.com/v1/models \
+      | jq -r '.data[].id'
+    ```
 
-Inspect the reverse-proxy access log to confirm the final path.
+    Check:
 
-### Hivenet Router returns `model_not_found`
+    - capitalization
+    - slashes and punctuation
+    - backend served-model alias
+    - agent registration
+    - client-key model access
+    - agent health
+  </Accordion>
 
-Compare:
+  <Accordion title="Text works but file or shell tools do not">
+    The likely issue is model or backend tool-call support.
 
-```bash
-opencode models hivenet-router
-```
+    Check that:
 
-with:
+    - the model supports tools
+    - vLLM uses `--enable-auto-tool-choice`
+    - the configured parser matches the model
+    - the backend returns OpenAI-format `tool_calls`
+    - OpenCode permissions allow or ask for the operation
+    - the model follows tool schemas reliably
 
-```bash
-curl \
-  -H "Authorization: Bearer $HIVENET_ROUTER_API_KEY" \
-  https://router.example.com/v1/models \
-  | jq -r '.data[].id'
-```
+    Test the backend directly with a Chat Completions request containing a `tools` array.
+  </Accordion>
 
-Check:
+  <Accordion title="A tool call appears as plain text">
+    The backend did not convert the model output into a structured OpenAI tool call.
 
-- capitalization
-- slashes and punctuation
-- backend served-model alias
-- agent registration
-- client-key model access
-- agent health
+    Review:
 
-### Text works but file or shell tools do not
+    - tool-call parser
+    - chat template
+    - model family
+    - backend version
+    - streaming tool-call support
 
-The likely issue is model or backend tool-call support.
+    The router forwards the response it receives. It does not parse plain model text into tool calls.
+  </Accordion>
 
-Check that:
+  <Accordion title="OpenCode uses an unexpected model">
+    Inspect:
 
-- the model supports tools
-- vLLM uses `--enable-auto-tool-choice`
-- the configured parser matches the model
-- the backend returns OpenAI-format `tool_calls`
-- OpenCode permissions allow or ask for the operation
-- the model follows tool schemas reliably
+    ```bash
+    opencode debug config \
+      | jq '{
+          model,
+          small_model,
+          enabled_providers
+        }'
+    ```
 
-Test the backend directly with a Chat Completions request containing a `tools` array.
+    Also check:
 
-### A tool call appears as plain text
+    - the `-m` CLI flag
+    - the model selected through `/models`
+    - project-level overrides
+    - agent-specific model settings
+    - command-specific model settings
 
-The backend did not convert the model output into a structured OpenAI tool call.
+    OpenCode gives a command-line model selection precedence over the configured default.
+  </Accordion>
 
-Review:
+  <Accordion title="Background requests fail">
+    Check the configured:
 
-- tool-call parser
-- chat template
-- model family
-- backend version
-- streaming tool-call support
+    ```json
+    "small_model"
+    ```
 
-The router forwards the response it receives. It does not parse plain model text into tool calls.
+    The small model must:
 
-### OpenCode uses an unexpected model
+    - be defined under the provider
+    - appear in Hivenet Router’s client catalog
+    - be permitted by the API key
+    - have an available `llm` agent
 
-Inspect:
+    Using the main model for `small_model` is valid when no separate lightweight model is available.
+  </Accordion>
 
-```bash
-opencode debug config \
-  | jq '{
-      model,
-      small_model,
-      enabled_providers
-    }'
-```
+  <Accordion title="OpenCode cannot modify files">
+    Check the permission prompt and configuration:
 
-Also check:
+    ```json
+    "permission": {
+      "edit": "ask",
+      "bash": "ask"
+    }
+    ```
 
-- the `-m` CLI flag
-- the model selected through `/models`
-- project-level overrides
-- agent-specific model settings
-- command-specific model settings
+    The `edit` permission also covers file creation and patch operations. The operation may be waiting for approval rather than failing.
+  </Accordion>
 
-OpenCode gives a command-line model selection precedence over the configured default.
+  <Accordion title="Output stops or hangs during streaming">
+    Test the same model directly with streaming curl.
 
-### Background requests fail
+    Check:
 
-Check the configured:
+    - backend SSE output
+    - reverse-proxy buffering
+    - proxy timeout
+    - router request timeout
+    - agent logs
+    - OpenCode logs
 
-```json
-"small_model"
-```
+    OpenCode logs are stored under:
 
-The small model must:
+    ```text
+    ~/.local/share/opencode/log/
+    ```
 
-- be defined under the provider
-- appear in Hivenet Router’s client catalog
-- be permitted by the API key
-- have an available `llm` agent
+    Run with debug output:
 
-Using the main model for `small_model` is valid when no separate lightweight model is available.
+    ```bash
+    opencode \
+      --print-logs \
+      --log-level DEBUG
+    ```
+  </Accordion>
 
-### OpenCode cannot modify files
+  <Accordion title="A backend request is rejected with `invalid_parameter`">
+    Hivenet Router now treats structured backend validation failures such as invalid parameters or context-length errors as non-retryable request failures.
 
-Check the permission prompt and configuration:
+    It returns the error without trying every other agent serving the same model.
 
-```json
-"permission": {
-  "edit": "ask",
-  "bash": "ask"
-}
-```
+    Inspect the backend message and correct:
 
-The `edit` permission also covers file creation and patch operations. The operation may be waiting for approval rather than failing.
+    - context length
+    - output limit
+    - unsupported tool fields
+    - unsupported roles
+    - model-specific parameters
+  </Accordion>
 
-### Output stops or hangs during streaming
+  <Accordion title="Requests return `504 request_timeout`">
+    The request exceeded Hivenet Router’s deadline.
 
-Test the same model directly with streaming curl.
+    Check:
 
-Check:
+    - model startup state
+    - prompt and requested output size
+    - backend queue depth
+    - router-side capacity queueing
+    - current `--request-timeout`
 
-- backend SSE output
-- reverse-proxy buffering
-- proxy timeout
-- router request timeout
-- agent logs
-- OpenCode logs
-
-OpenCode logs are stored under:
-
-```text
-~/.local/share/opencode/log/
-```
-
-Run with debug output:
-
-```bash
-opencode \
-  --print-logs \
-  --log-level DEBUG
-```
-
-### A backend request is rejected with `invalid_parameter`
-
-Hivenet Router now treats structured backend validation failures such as invalid parameters or context-length errors as non-retryable request failures.
-
-It returns the error without trying every other agent serving the same model.
-
-Inspect the backend message and correct:
-
-- context length
-- output limit
-- unsupported tool fields
-- unsupported roles
-- model-specific parameters
-
-### Requests return `504 request_timeout`
-
-The request exceeded Hivenet Router’s deadline.
-
-Check:
-
-- model startup state
-- prompt and requested output size
-- backend queue depth
-- router-side capacity queueing
-- current `--request-timeout`
-
-Increase the timeout only after confirming that the backend is progressing normally.
+    Increase the timeout only after confirming that the backend is progressing normally.
+  </Accordion>
+</AccordionGroup>
 
 ## Read the relevant logs
 
@@ -1345,28 +1347,28 @@ Request-schema and tool-parser failures usually appear most clearly in the backe
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Pi" href="/integrations/pi">
+<Columns cols={3}>
+  <Card title="Pi" icon="terminal" href="/integrations/pi">
     Connect another terminal coding agent through OpenAI Chat Completions.
   </Card>
 
-  <Card title="Open WebUI" href="/integrations/open-web-ui">
+  <Card title="Open WebUI" icon="browser" href="/integrations/open-web-ui">
     Add a browser-based chat interface backed by Hivenet Router.
   </Card>
 
-  <Card title="Use from code" href="/integrations/use-from-code">
+  <Card title="Use from code" icon="code-branch" href="/integrations/use-from-code">
     Call Hivenet Router from SDKs, scripts, and custom services.
   </Card>
 
-  <Card title="Chat completions and messages" href="/use-the-api/chat-completions">
+  <Card title="Chat completions and messages" icon="messages" href="/use-the-api/chat-completions">
     Review request forwarding, streaming, headers, and error behavior.
   </Card>
 
-  <Card title="API keys" href="/security/api-keys">
+  <Card title="API keys" icon="key" href="/security/api-keys">
     Configure model access, quotas, expiration, and rotation.
   </Card>
 
-  <Card title="vLLM agent" href="/deploy/agents/vllm">
+  <Card title="vLLM agent" icon="server" href="/deploy/agents/vllm">
     Deploy and register an OpenAI-compatible inference backend.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/integrations/open-web-ui.mdx
+++ b/docs/integrations/open-web-ui.mdx
@@ -984,218 +984,220 @@ Compare the audit records with visible user actions to identify background title
 
 ## Troubleshooting
 
-### The connection verification fails
+<AccordionGroup>
+  <Accordion title="The connection verification fails">
+    Test the same URL and key directly:
 
-Test the same URL and key directly:
+    ```bash
+    curl \
+      -H "Authorization: Bearer <hivenet-router-api-key>" \
+      https://router.example.com/v1/models
+    ```
 
-```bash
-curl \
-  -H "Authorization: Bearer <hivenet-router-api-key>" \
-  https://router.example.com/v1/models
-```
+    Check:
 
-Check:
+    - URL ends in `/v1`
+    - API key is the raw client credential
+    - Open WebUI can reach the router
+    - TLS certificates are trusted
+    - the router has registered agents
+    - a reverse proxy preserves `Authorization`
+  </Accordion>
 
-- URL ends in `/v1`
-- API key is the raw client credential
-- Open WebUI can reach the router
-- TLS certificates are trusted
-- the router has registered agents
-- a reverse proxy preserves `Authorization`
+  <Accordion title="The model selector is empty">
+    Check the live catalog:
 
-### The model selector is empty
+    ```bash
+    curl \
+      -H "Authorization: Bearer <hivenet-router-api-key>" \
+      https://router.example.com/v1/models \
+      | jq .
+    ```
 
-Check the live catalog:
+    Then add exact LLM IDs to the connection’s **Model IDs** filter.
 
-```bash
-curl \
-  -H "Authorization: Bearer <hivenet-router-api-key>" \
-  https://router.example.com/v1/models \
-  | jq .
-```
+    Also check whether:
 
-Then add exact LLM IDs to the connection’s **Model IDs** filter.
+    - the API key hides the models
+    - strict per-model quotas omit them
+    - the model-list timeout is too short
+    - the saved connection is disabled
+    - persistent configuration contains an older URL or key
+  </Accordion>
 
-Also check whether:
+  <Accordion title="An embedding model appears in the chat selector">
+    Limit the connection’s Model IDs to `llm` models.
 
-- the API key hides the models
-- strict per-model quotas omit them
-- the model-list timeout is too short
-- the saved connection is disabled
-- persistent configuration contains an older URL or key
+    Configure embeddings separately through the RAG settings.
+  </Accordion>
 
-### An embedding model appears in the chat selector
+  <Accordion title="Chat requests go to `/v1/responses`">
+    The connection uses the wrong API type.
 
-Limit the connection’s Model IDs to `llm` models.
+    Edit it and select:
 
-Configure embeddings separately through the RAG settings.
+    ```text
+    Chat Completions
+    ```
 
-### Chat requests go to `/v1/responses`
+    Hivenet Router does not support `/v1/responses`.
+  </Accordion>
 
-The connection uses the wrong API type.
+  <Accordion title="Requests return `401 Unauthorized`">
+    Confirm that Open WebUI stores the raw Hivenet Router client key.
 
-Edit it and select:
+    Do not use:
 
-```text
-Chat Completions
-```
+    - the key hash from `auth.yaml`
+    - an administrator key
+    - the agent JWT secret
 
-Hivenet Router does not support `/v1/responses`.
+    Test the raw value directly with `/v1/models`.
+  </Accordion>
 
-### Requests return `401 Unauthorized`
+  <Accordion title="Hivenet Router returns `model_forbidden`">
+    The shared key’s explicit allowlist does not include the selected model.
 
-Confirm that Open WebUI stores the raw Hivenet Router client key.
+    Add the exact model ID to the key or remove the model from Open WebUI.
+  </Accordion>
 
-Do not use:
+  <Accordion title="Hivenet Router returns `429` for an apparently permitted model">
+    The key probably uses `quota.per_model`, and the selected model has no entry.
 
-- the key hash from `auth.yaml`
-- an administrator key
-- the agent JWT secret
+    Every model used for chat, tasks, embeddings, or reranking needs its own per-model quota entry.
+  </Accordion>
 
-Test the raw value directly with `/v1/models`.
+  <Accordion title="Hivenet Router returns `no_agents_available`">
+    Check:
 
-### Hivenet Router returns `model_forbidden`
+    - selected model ID
+    - `llm` capability
+    - agent health
+    - routing policy
+    - model availability
+    - static metadata matches
 
-The shared key’s explicit allowlist does not include the selected model.
+    An embedding or reranking agent cannot serve a Chat Completions request.
+  </Accordion>
 
-Add the exact model ID to the key or remove the model from Open WebUI.
+  <Accordion title="There are more requests than user messages">
+    Open WebUI background tasks are using the shared model.
 
-### Hivenet Router returns `429` for an apparently permitted model
+    Check:
 
-The key probably uses `quota.per_model`, and the selected model has no entry.
+    - title generation
+    - tag generation
+    - follow-up generation
+    - autocomplete
+    - retrieval-query generation
+    - context compaction
 
-Every model used for chat, tasks, embeddings, or reranking needs its own per-model quota entry.
+    Set `TASK_MODEL_EXTERNAL` or disable unnecessary features.
+  </Accordion>
 
-### Hivenet Router returns `no_agents_available`
+  <Accordion title="Text works but tools fail">
+    Check that:
 
-Check:
+    - the model supports native function calling
+    - the backend accepts `tools` and `tool_choice`
+    - the correct tool-call parser is enabled
+    - the chat template supports tools
+    - the response contains structured `tool_calls`
+    - the user has access to the attached Open WebUI tool
 
-- selected model ID
-- `llm` capability
-- agent health
-- routing policy
-- model availability
-- static metadata matches
+    Inspect the backend log first.
+  </Accordion>
 
-An embedding or reranking agent cannot serve a Chat Completions request.
+  <Accordion title="Streaming arrives all at once">
+    Test streaming directly against Hivenet Router.
 
-### There are more requests than user messages
+    If direct streaming works, inspect:
 
-Open WebUI background tasks are using the shared model.
+    - the proxy in front of Hivenet Router
+    - Open WebUI’s upstream connection
+    - browser-to-Open-WebUI proxy settings
+    - response buffering
+    - read and idle timeouts
+  </Accordion>
 
-Check:
+  <Accordion title="The router is on the host but cannot be reached">
+    Do not use:
 
-- title generation
-- tag generation
-- follow-up generation
-- autocomplete
-- retrieval-query generation
-- context compaction
+    ```text
+    http://localhost:8080/v1
+    ```
 
-Set `TASK_MODEL_EXTERNAL` or disable unnecessary features.
+    from inside the container.
 
-### Text works but tools fail
+    Use:
 
-Check that:
+    ```text
+    http://host.docker.internal:8080/v1
+    ```
 
-- the model supports native function calling
-- the backend accepts `tools` and `tool_choice`
-- the correct tool-call parser is enabled
-- the chat template supports tools
-- the response contains structured `tool_calls`
-- the user has access to the attached Open WebUI tool
+    and add a Linux host-gateway mapping when required.
+  </Accordion>
 
-Inspect the backend log first.
+  <Accordion title="Environment changes do not apply">
+    Open WebUI may be using the value persisted in its database.
 
-### Streaming arrives all at once
+    Update it through the administrator settings or review the persistent-configuration behavior.
+  </Accordion>
 
-Test streaming directly against Hivenet Router.
+  <Accordion title="Sign-in state is lost after recreating the container">
+    Confirm that:
 
-If direct streaming works, inspect:
+    - `/app/backend/data` uses a persistent volume
+    - the same volume is mounted after recreation
+    - `WEBUI_SECRET_KEY` has not changed
 
-- the proxy in front of Hivenet Router
-- Open WebUI’s upstream connection
-- browser-to-Open-WebUI proxy settings
-- response buffering
-- read and idle timeouts
+    Changing the secret invalidates existing sessions.
+  </Accordion>
 
-### The router is on the host but cannot be reached
+  <Accordion title="Open WebUI stops after an upgrade">
+    Inspect:
 
-Do not use:
+    ```bash
+    docker compose logs open-webui \
+      | tail -200
+    ```
 
-```text
-http://localhost:8080/v1
-```
+    Look for:
 
-from inside the container.
+    - database migration errors
+    - invalid persistent configuration
+    - volume permission problems
+    - incompatible environment variables
+    - frontend cache problems
 
-Use:
-
-```text
-http://host.docker.internal:8080/v1
-```
-
-and add a Linux host-gateway mapping when required.
-
-### Environment changes do not apply
-
-Open WebUI may be using the value persisted in its database.
-
-Update it through the administrator settings or review the persistent-configuration behavior.
-
-### Sign-in state is lost after recreating the container
-
-Confirm that:
-
-- `/app/backend/data` uses a persistent volume
-- the same volume is mounted after recreation
-- `WEBUI_SECRET_KEY` has not changed
-
-Changing the secret invalidates existing sessions.
-
-### Open WebUI stops after an upgrade
-
-Inspect:
-
-```bash
-docker compose logs open-webui \
-  | tail -200
-```
-
-Look for:
-
-- database migration errors
-- invalid persistent configuration
-- volume permission problems
-- incompatible environment variables
-- frontend cache problems
-
-Restore the pre-upgrade volume backup when rollback requires the previous database state.
+    Restore the pre-upgrade volume backup when rollback requires the previous database state.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Use from code" href="/integrations/use-from-code">
+<Columns cols={3}>
+  <Card title="Use from code" icon="code-branch" href="/integrations/use-from-code">
     Call Hivenet Router from curl, Python, JavaScript, SDKs, and services.
   </Card>
 
-  <Card title="Chat completions and messages" href="/use-the-api/chat-completions">
+  <Card title="Chat completions and messages" icon="messages" href="/use-the-api/chat-completions">
     Review Chat Completions forwarding, streaming, headers, and errors.
   </Card>
 
-  <Card title="Embeddings" href="/use-the-api/embeddings">
+  <Card title="Embeddings" icon="vector-square" href="/use-the-api/embeddings">
     Configure a Hivenet Router embedding model for Open WebUI retrieval.
   </Card>
 
-  <Card title="Reranking" href="/use-the-api/reranking">
+  <Card title="Reranking" icon="arrow-down-wide-short" href="/use-the-api/reranking">
     Connect an external reranking model to the retrieval pipeline.
   </Card>
 
-  <Card title="API keys" href="/security/api-keys">
+  <Card title="API keys" icon="key" href="/security/api-keys">
     Configure the shared model access, quotas, expiration, and rotation.
   </Card>
 
-  <Card title="Audit logging" href="/observability/audit-logging">
+  <Card title="Audit logging" icon="clipboard-list" href="/observability/audit-logging">
     Investigate user-facing and background requests through structured records.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/integrations/pi.mdx
+++ b/docs/integrations/pi.mdx
@@ -1193,270 +1193,272 @@ Use the request or trace ID from an audit record to investigate one failed tool 
 
 ## Troubleshooting
 
-### The provider or model does not appear
+<AccordionGroup>
+  <Accordion title="The provider or model does not appear">
+    Check the configuration file:
 
-Check the configuration file:
+    ```bash
+    jq . \
+      ~/.pi/agent/models.json
+    ```
 
-```bash
-jq . \
-  ~/.pi/agent/models.json
-```
+    List matching models:
 
-List matching models:
+    ```bash
+    pi --list-models hivenet-router
+    ```
 
-```bash
-pi --list-models hivenet-router
-```
+    Check that:
 
-Check that:
+    - the file is in the active Pi configuration directory
+    - `providers.hivenet-router` exists
+    - `baseUrl` ends in `/v1`
+    - `api` is `openai-completions`
+    - `authHeader` is `true`
+    - `models` contains at least one entry
+    - each model has an `id`
+    - the API-key value can be resolved
 
-- the file is in the active Pi configuration directory
-- `providers.hivenet-router` exists
-- `baseUrl` ends in `/v1`
-- `api` is `openai-completions`
-- `authHeader` is `true`
-- `models` contains at least one entry
-- each model has an `id`
-- the API-key value can be resolved
+    Open `/model` again after editing the file.
+  </Accordion>
 
-Open `/model` again after editing the file.
+  <Accordion title="Pi reports that no API key is available">
+    Check the variable:
 
-### Pi reports that no API key is available
+    ```bash
+    test -n "$HIVENET_ROUTER_API_KEY" \
+      && echo set \
+      || echo missing
+    ```
 
-Check the variable:
+    The configuration must include the `$`:
 
-```bash
-test -n "$HIVENET_ROUTER_API_KEY" \
-  && echo set \
-  || echo missing
-```
+    ```json
+    "apiKey": "$HIVENET_ROUTER_API_KEY"
+    ```
 
-The configuration must include the `$`:
+    This is a literal string rather than environment interpolation:
 
-```json
-"apiKey": "$HIVENET_ROUTER_API_KEY"
-```
+    ```json
+    "apiKey": "HIVENET_ROUTER_API_KEY"
+    ```
+  </Accordion>
 
-This is a literal string rather than environment interpolation:
+  <Accordion title="Hivenet Router returns `401 Unauthorized`">
+    Check that:
 
-```json
-"apiKey": "HIVENET_ROUTER_API_KEY"
-```
+    - the variable contains the raw client key
+    - the key has not expired
+    - the key belongs to client authentication
+    - the variable reached the Pi process
 
-### Hivenet Router returns `401 Unauthorized`
+    Test the same value directly:
 
-Check that:
+    ```bash
+    curl \
+      -H "Authorization: Bearer $HIVENET_ROUTER_API_KEY" \
+      https://router.example.com/v1/models
+    ```
+  </Accordion>
 
-- the variable contains the raw client key
-- the key has not expired
-- the key belongs to client authentication
-- the variable reached the Pi process
+  <Accordion title="Requests return a plain `404`">
+    Check the base URL.
 
-Test the same value directly:
+    It should be:
 
-```bash
-curl \
-  -H "Authorization: Bearer $HIVENET_ROUTER_API_KEY" \
-  https://router.example.com/v1/models
-```
+    ```text
+    https://router.example.com/v1
+    ```
 
-### Requests return a plain `404`
+    not:
 
-Check the base URL.
+    ```text
+    https://router.example.com
+    ```
 
-It should be:
+    and not:
 
-```text
-https://router.example.com/v1
-```
+    ```text
+    https://router.example.com/v1/chat/completions
+    ```
 
-not:
+    Also confirm that the provider uses:
 
-```text
-https://router.example.com
-```
+    ```json
+    "api": "openai-completions"
+    ```
 
-and not:
+    rather than `openai-responses`.
+  </Accordion>
 
-```text
-https://router.example.com/v1/chat/completions
-```
+  <Accordion title="Hivenet Router returns `model_not_found`">
+    Compare Pi’s configuration with the live catalog:
 
-Also confirm that the provider uses:
+    ```bash
+    pi --list-models hivenet-router
+    ```
 
-```json
-"api": "openai-completions"
-```
+    ```bash
+    curl \
+      -H "Authorization: Bearer $HIVENET_ROUTER_API_KEY" \
+      https://router.example.com/v1/models \
+      | jq -r '.data[].id'
+    ```
 
-rather than `openai-responses`.
+    Check:
 
-### Hivenet Router returns `model_not_found`
+    - capitalization
+    - punctuation and slashes
+    - backend served-model name
+    - agent registration
+    - key model access
+    - agent health
+  </Accordion>
 
-Compare Pi’s configuration with the live catalog:
+  <Accordion title="Text works but tools do not">
+    Check that:
 
-```bash
-pi --list-models hivenet-router
-```
+    - the model supports tool calling
+    - the backend uses a model-appropriate tool parser
+    - vLLM was started with `--enable-auto-tool-choice`
+    - the chat template supports tool and tool-result messages
+    - the backend returns structured `tool_calls`
+    - the model follows the schemas reliably
 
-```bash
-curl \
-  -H "Authorization: Bearer $HIVENET_ROUTER_API_KEY" \
-  https://router.example.com/v1/models \
-  | jq -r '.data[].id'
-```
+    Test the backend directly with a Chat Completions request containing a `tools` array.
 
-Check:
+    Hivenet Router forwards the response. It does not convert plain model text into a structured tool call.
+  </Accordion>
 
-- capitalization
-- punctuation and slashes
-- backend served-model name
-- agent registration
-- key model access
-- agent health
+  <Accordion title="Tool calls appear as text">
+    The backend parser did not recognize the model’s tool syntax.
 
-### Text works but tools do not
+    Review:
 
-Check that:
+    - model family
+    - tool-call parser
+    - chat template
+    - backend version
+    - streaming tool-call support
 
-- the model supports tool calling
-- the backend uses a model-appropriate tool parser
-- vLLM was started with `--enable-auto-tool-choice`
-- the chat template supports tool and tool-result messages
-- the backend returns structured `tool_calls`
-- the model follows the schemas reliably
+    Inspect the backend logs first.
+  </Accordion>
 
-Test the backend directly with a Chat Completions request containing a `tools` array.
+  <Accordion title="The backend rejects the `developer` role">
+    Add:
 
-Hivenet Router forwards the response. It does not convert plain model text into a structured tool call.
+    ```json
+    "compat": {
+      "supportsDeveloperRole": false
+    }
+    ```
 
-### Tool calls appear as text
+    to the provider or affected model.
 
-The backend parser did not recognize the model’s tool syntax.
+    Open `/model` again to reload the configuration.
+  </Accordion>
 
-Review:
+  <Accordion title="The backend rejects `reasoning_effort`">
+    Add:
 
-- model family
-- tool-call parser
-- chat template
-- backend version
-- streaming tool-call support
+    ```json
+    "compat": {
+      "supportsReasoningEffort": false
+    }
+    ```
 
-Inspect the backend logs first.
+    Do this only for models or backends that reject the field.
+  </Accordion>
 
-### The backend rejects the `developer` role
+  <Accordion title="The backend rejects `max_completion_tokens`">
+    Add:
 
-Add:
+    ```json
+    "compat": {
+      "maxTokensField": "max_tokens"
+    }
+    ```
 
-```json
-"compat": {
-  "supportsDeveloperRole": false
-}
-```
+    Current vLLM supports both fields, but other OpenAI-compatible servers may not.
+  </Accordion>
 
-to the provider or affected model.
+  <Accordion title="Streaming usage causes a validation error">
+    Add:
 
-Open `/model` again to reload the configuration.
+    ```json
+    "compat": {
+      "supportsUsageInStreaming": false
+    }
+    ```
 
-### The backend rejects `reasoning_effort`
+    This prevents Pi from requesting the final streaming usage block.
+  </Accordion>
 
-Add:
+  <Accordion title="Pi compacts too early">
+    Increase the configured:
 
-```json
-"compat": {
-  "supportsReasoningEffort": false
-}
-```
+    ```json
+    "contextWindow"
+    ```
 
-Do this only for models or backends that reject the field.
+    only when the deployed backend genuinely accepts the larger context.
 
-### The backend rejects `max_completion_tokens`
+    Check the backend’s effective maximum model length.
+  </Accordion>
 
-Add:
+  <Accordion title="The backend rejects the prompt as too long">
+    Reduce:
 
-```json
-"compat": {
-  "maxTokensField": "max_tokens"
-}
-```
+    - `contextWindow`
+    - `maxTokens`
+    - included project context
+    - requested output
 
-Current vLLM supports both fields, but other OpenAI-compatible servers may not.
+    An accurate context configuration lets Pi compact before the request reaches the backend limit.
+  </Accordion>
 
-### Streaming usage causes a validation error
+  <Accordion title="Output arrives only after completion">
+    Test streaming directly with curl.
 
-Add:
+    Then check:
 
-```json
-"compat": {
-  "supportsUsageInStreaming": false
-}
-```
+    - backend SSE behavior
+    - reverse-proxy buffering
+    - proxy read and idle timeouts
+    - Hivenet Router request timeout
+    - agent logs
+  </Accordion>
 
-This prevents Pi from requesting the final streaming usage block.
+  <Accordion title="Pi modifies files without asking">
+    This is expected behavior.
 
-### Pi compacts too early
+    Pi does not have a built-in permission-prompt system.
 
-Increase the configured:
+    Restart it with restricted tools:
 
-```json
-"contextWindow"
-```
+    ```bash
+    pi \
+      --tools read,grep,find,ls
+    ```
 
-only when the deployed backend genuinely accepts the larger context.
+    Use a container, virtual machine, or equivalent sandbox when tools need stronger boundaries.
+  </Accordion>
 
-Check the backend’s effective maximum model length.
+  <Accordion title="Requests return `504 request_timeout`">
+    The request exceeded the Hivenet Router deadline.
 
-### The backend rejects the prompt as too long
+    Check:
 
-Reduce:
+    - backend readiness
+    - prompt size
+    - output size
+    - engine queue depth
+    - router-side capacity queueing
+    - current request timeout
 
-- `contextWindow`
-- `maxTokens`
-- included project context
-- requested output
-
-An accurate context configuration lets Pi compact before the request reaches the backend limit.
-
-### Output arrives only after completion
-
-Test streaming directly with curl.
-
-Then check:
-
-- backend SSE behavior
-- reverse-proxy buffering
-- proxy read and idle timeouts
-- Hivenet Router request timeout
-- agent logs
-
-### Pi modifies files without asking
-
-This is expected behavior.
-
-Pi does not have a built-in permission-prompt system.
-
-Restart it with restricted tools:
-
-```bash
-pi \
-  --tools read,grep,find,ls
-```
-
-Use a container, virtual machine, or equivalent sandbox when tools need stronger boundaries.
-
-### Requests return `504 request_timeout`
-
-The request exceeded the Hivenet Router deadline.
-
-Check:
-
-- backend readiness
-- prompt size
-- output size
-- engine queue depth
-- router-side capacity queueing
-- current request timeout
-
-Increase the deadline only after confirming that the backend is progressing normally.
+    Increase the deadline only after confirming that the backend is progressing normally.
+  </Accordion>
+</AccordionGroup>
 
 ## Read the relevant logs
 

--- a/docs/integrations/pi.mdx
+++ b/docs/integrations/pi.mdx
@@ -1486,28 +1486,28 @@ Request-schema, context, chat-template, and tool-parser failures usually appear 
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Open WebUI" href="/integrations/open-web-ui">
+<Columns cols={3}>
+  <Card title="Open WebUI" icon="browser" href="/integrations/open-web-ui">
     Add a browser-based chat interface backed by Hivenet Router.
   </Card>
 
-  <Card title="Use from code" href="/integrations/use-from-code">
+  <Card title="Use from code" icon="code-branch" href="/integrations/use-from-code">
     Call Hivenet Router from SDKs, scripts, and custom applications.
   </Card>
 
-  <Card title="Chat completions and messages" href="/use-the-api/chat-completions">
+  <Card title="Chat completions and messages" icon="messages" href="/use-the-api/chat-completions">
     Review the supported LLM request paths and streaming behavior.
   </Card>
 
-  <Card title="API keys" href="/security/api-keys">
+  <Card title="API keys" icon="key" href="/security/api-keys">
     Configure model access, quotas, expiration, and rotation.
   </Card>
 
-  <Card title="vLLM agent" href="/deploy/agents/vllm">
+  <Card title="vLLM agent" icon="server" href="/deploy/agents/vllm">
     Deploy and register an OpenAI-compatible inference backend.
   </Card>
 
-  <Card title="Audit logging" href="/observability/audit-logging">
+  <Card title="Audit logging" icon="clipboard-list" href="/observability/audit-logging">
     Investigate Pi requests by tenant, model, status, and agent.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/integrations/use-from-code.mdx
+++ b/docs/integrations/use-from-code.mdx
@@ -1230,209 +1230,211 @@ unless the backend is explicitly trusted to receive them.
 
 ## Troubleshooting
 
-### The SDK returns `401 Unauthorized`
+<AccordionGroup>
+  <Accordion title="The SDK returns `401 Unauthorized`">
+    Check that:
 
-Check that:
+    - the raw client key is being used
+    - the key has not expired
+    - the key is not a SHA-256 hash
+    - the environment variable reached the process
+    - the reverse proxy preserves `Authorization`
 
-- the raw client key is being used
-- the key has not expired
-- the key is not a SHA-256 hash
-- the environment variable reached the process
-- the reverse proxy preserves `Authorization`
+    Test the same key with:
 
-Test the same key with:
+    ```bash
+    curl \
+      -H "Authorization: Bearer $HIVENET_ROUTER_API_KEY" \
+      "$HIVENET_ROUTER_URL/v1/models"
+    ```
+  </Accordion>
 
-```bash
-curl \
-  -H "Authorization: Bearer $HIVENET_ROUTER_API_KEY" \
-  "$HIVENET_ROUTER_URL/v1/models"
-```
+  <Accordion title="The Anthropic SDK returns `401`">
+    Use:
 
-### The Anthropic SDK returns `401`
+    ```text
+    auth_token
+    ```
+
+    in Python or:
 
-Use:
+    ```text
+    authToken
+    ```
 
-```text
-auth_token
-```
+    in TypeScript.
 
-in Python or:
+    Using only `api_key` or `apiKey` sends `X-Api-Key`, which Hivenet Router does not accept for client authentication.
+  </Accordion>
 
-```text
-authToken
-```
+  <Accordion title="A request goes to `/v1/responses`">
+    Call:
 
-in TypeScript.
+    ```text
+    client.chat.completions.create
+    ```
 
-Using only `api_key` or `apiKey` sends `X-Api-Key`, which Hivenet Router does not accept for client authentication.
+    rather than:
 
-### A request goes to `/v1/responses`
+    ```text
+    client.responses.create
+    ```
 
-Call:
+    For LangChain, set:
 
-```text
-client.chat.completions.create
-```
+    ```python
+    use_responses_api=False
+    ```
+  </Accordion>
 
-rather than:
+  <Accordion title="The endpoint returns a plain `404`">
+    Check the base URL.
 
-```text
-client.responses.create
-```
+    | Client | Base URL |
+    | --- | --- |
+    | OpenAI SDK | `https://router.example.com/v1` |
+    | Anthropic SDK | `https://router.example.com` |
+    | Reranking HTTP call | `https://router.example.com/v1/rerank` |
 
-For LangChain, set:
+    Do not duplicate or omit `/v1`.
+  </Accordion>
 
-```python
-use_responses_api=False
-```
+  <Accordion title="Hivenet Router returns `model_not_found`">
+    Compare the application model with:
 
-### The endpoint returns a plain `404`
+    ```bash
+    curl \
+      -H "Authorization: Bearer $HIVENET_ROUTER_API_KEY" \
+      "$HIVENET_ROUTER_URL/v1/models" \
+      | jq -r '.data[].id'
+    ```
 
-Check the base URL.
+    Check:
 
-| Client | Base URL |
-| --- | --- |
-| OpenAI SDK | `https://router.example.com/v1` |
-| Anthropic SDK | `https://router.example.com` |
-| Reranking HTTP call | `https://router.example.com/v1/rerank` |
+    - capitalization
+    - slashes and punctuation
+    - agent registration
+    - model capability
+    - API-key access
+    - agent health
+  </Accordion>
 
-Do not duplicate or omit `/v1`.
+  <Accordion title="Text works but tool calls are missing">
+    Check:
 
-### Hivenet Router returns `model_not_found`
+    - model tool support
+    - backend tool parser
+    - backend chat template
+    - structured `tool_calls` in the raw response
+    - tool use while streaming
+    - model compliance with the supplied schema
 
-Compare the application model with:
+    The problem is usually in the model or backend rather than the SDK or router.
+  </Accordion>
+
+  <Accordion title="Streaming arrives only at the end">
+    Test the router with streaming curl.
 
-```bash
-curl \
-  -H "Authorization: Bearer $HIVENET_ROUTER_API_KEY" \
-  "$HIVENET_ROUTER_URL/v1/models" \
-  | jq -r '.data[].id'
-```
-
-Check:
-
-- capitalization
-- slashes and punctuation
-- agent registration
-- model capability
-- API-key access
-- agent health
-
-### Text works but tool calls are missing
-
-Check:
-
-- model tool support
-- backend tool parser
-- backend chat template
-- structured `tool_calls` in the raw response
-- tool use while streaming
-- model compliance with the supplied schema
-
-The problem is usually in the model or backend rather than the SDK or router.
-
-### Streaming arrives only at the end
-
-Test the router with streaming curl.
-
-When curl streams but the application does not, check the SDK code.
-
-When neither streams, check:
-
-- backend SSE behavior
-- Hivenet Router agent version
-- reverse-proxy buffering
-- proxy read and idle timeouts
-- response `Content-Type`
-
-### Streaming usage is missing
-
-The backend may not support:
-
-```json
-{
-  "stream_options": {
-    "include_usage": true
-  }
-}
-```
-
-Remove the field or handle a missing final usage chunk.
-
-Hivenet Router’s own stream meter can still record usage for quotas, audit data, and metrics.
-
-### A single request receives `429`
-
-Inspect the error code.
-
-| Code | Likely cause |
-| --- | --- |
-| `rate_limit_exceeded` | RPM bucket exhausted or no per-model quota declared |
-| `token_limit_exceeded` | Daily token budget cannot admit the requested worst case |
-
-Also inspect:
-
-```text
-X-RateLimit-Remaining-Requests
-X-RateLimit-Remaining-Tokens
-```
-
-### The SDK makes more requests than expected
-
-Check its retry configuration.
-
-The official SDKs retry selected failures by default. Set retries to zero while diagnosing:
-
-```python
-max_retries=0
-```
-
-```js
-maxRetries: 0
-```
-
-### Hivenet Router returns `503`
-
-Check the specific error code:
-
-- `no_agents_available`
-- `no_capacity`
-- `agent_disconnected`
-- `backend_unavailable`
-- `queue_full`
-
-Then inspect:
-
-```text
-GET /admin/health
-GET /admin/routing-table
-```
-
-### Hivenet Router returns `504 request_timeout`
-
-The router deadline expired.
-
-Check:
-
-- backend readiness
-- model loading
-- prompt size
-- requested output
-- engine waiting requests
-- router-side queueing
-- client and proxy deadlines
-
-### The reranker response has no document text
-
-This is expected for backends that return:
-
-```json
-{
-  "document": null
-}
-```
-
-Use the result’s `index` to retrieve the original input document.
+    When curl streams but the application does not, check the SDK code.
+
+    When neither streams, check:
+
+    - backend SSE behavior
+    - Hivenet Router agent version
+    - reverse-proxy buffering
+    - proxy read and idle timeouts
+    - response `Content-Type`
+  </Accordion>
+
+  <Accordion title="Streaming usage is missing">
+    The backend may not support:
+
+    ```json
+    {
+      "stream_options": {
+        "include_usage": true
+      }
+    }
+    ```
+
+    Remove the field or handle a missing final usage chunk.
+
+    Hivenet Router’s own stream meter can still record usage for quotas, audit data, and metrics.
+  </Accordion>
+
+  <Accordion title="A single request receives `429`">
+    Inspect the error code.
+
+    | Code | Likely cause |
+    | --- | --- |
+    | `rate_limit_exceeded` | RPM bucket exhausted or no per-model quota declared |
+    | `token_limit_exceeded` | Daily token budget cannot admit the requested worst case |
+
+    Also inspect:
+
+    ```text
+    X-RateLimit-Remaining-Requests
+    X-RateLimit-Remaining-Tokens
+    ```
+  </Accordion>
+
+  <Accordion title="The SDK makes more requests than expected">
+    Check its retry configuration.
+
+    The official SDKs retry selected failures by default. Set retries to zero while diagnosing:
+
+    ```python
+    max_retries=0
+    ```
+
+    ```js
+    maxRetries: 0
+    ```
+  </Accordion>
+
+  <Accordion title="Hivenet Router returns `503`">
+    Check the specific error code:
+
+    - `no_agents_available`
+    - `no_capacity`
+    - `agent_disconnected`
+    - `backend_unavailable`
+    - `queue_full`
+
+    Then inspect:
+
+    ```text
+    GET /admin/health
+    GET /admin/routing-table
+    ```
+  </Accordion>
+
+  <Accordion title="Hivenet Router returns `504 request_timeout`">
+    The router deadline expired.
+
+    Check:
+
+    - backend readiness
+    - model loading
+    - prompt size
+    - requested output
+    - engine waiting requests
+    - router-side queueing
+    - client and proxy deadlines
+  </Accordion>
+
+  <Accordion title="The reranker response has no document text">
+    This is expected for backends that return:
+
+    ```json
+    {
+      "document": null
+    }
+    ```
+
+    Use the result’s `index` to retrieve the original input document.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 

--- a/docs/integrations/use-from-code.mdx
+++ b/docs/integrations/use-from-code.mdx
@@ -1438,28 +1438,28 @@ unless the backend is explicitly trusted to receive them.
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Chat completions and messages" href="/use-the-api/chat-completions">
+<Columns cols={3}>
+  <Card title="Chat completions and messages" icon="messages" href="/use-the-api/chat-completions">
     Review the OpenAI and Anthropic request paths, forwarding, streaming, and headers.
   </Card>
 
-  <Card title="Embeddings" href="/use-the-api/embeddings">
+  <Card title="Embeddings" icon="vector-square" href="/use-the-api/embeddings">
     Review embedding request and response behavior.
   </Card>
 
-  <Card title="Reranking" href="/use-the-api/reranking">
+  <Card title="Reranking" icon="arrow-down-wide-short" href="/use-the-api/reranking">
     Review reranking schemas, capabilities, and responses.
   </Card>
 
-  <Card title="API keys" href="/security/api-keys">
+  <Card title="API keys" icon="key" href="/security/api-keys">
     Configure service-specific access, quotas, expiration, and rotation.
   </Card>
 
-  <Card title="Error codes" href="/reference/error-codes">
+  <Card title="Error codes" icon="triangle-exclamation" href="/reference/error-codes">
     Handle Hivenet Router’s structured router and backend failures.
   </Card>
 
-  <Card title="Audit logging" href="/observability/audit-logging">
+  <Card title="Audit logging" icon="clipboard-list" href="/observability/audit-logging">
     Correlate application requests with tenants, models, agents, and traces.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/observability/audit-logging.mdx
+++ b/docs/observability/audit-logging.mdx
@@ -741,12 +741,26 @@ See [Grafana dashboards](/observability/grafana-dashboards) for provisioning and
 
 A practical investigation flow is:
 
-1. Obtain the request’s `X-Request-ID` or `traceparent` response header.
-2. Search the audit logs for `request_id` or `trace_id`.
-3. Inspect the status, tenant, model, agent, latency, and error code.
-4. Open the matching trace in Tempo.
-5. Review router application logs for the same request ID.
-6. Inspect Prometheus metrics for the selected agent and model.
+<Steps>
+  <Step title="Obtain the request identifier">
+    Obtain the request’s `X-Request-ID` or `traceparent` response header.
+  </Step>
+  <Step title="Search the audit logs">
+    Search the audit logs for `request_id` or `trace_id`.
+  </Step>
+  <Step title="Inspect the audit record">
+    Inspect the status, tenant, model, agent, latency, and error code.
+  </Step>
+  <Step title="Open the matching trace">
+    Open the matching trace in Tempo.
+  </Step>
+  <Step title="Review router application logs">
+    Review router application logs for the same request ID.
+  </Step>
+  <Step title="Inspect Prometheus metrics">
+    Inspect Prometheus metrics for the selected agent and model.
+  </Step>
+</Steps>
 
 For example:
 
@@ -861,156 +875,158 @@ as part of the complete data-flow assessment.
 
 ## Troubleshooting
 
-### The audit file does not exist
+<AccordionGroup>
+  <Accordion title="The audit file does not exist">
+    Check the configured path:
 
-Check the configured path:
+    ```bash
+    echo "$HIVENET_ROUTER_AUDIT_LOG_PATH"
+    ```
 
-```bash
-echo "$HIVENET_ROUTER_AUDIT_LOG_PATH"
-```
+    Check the router logs for:
 
-Check the router logs for:
+    ```text
+    audit: cannot create log dir
+    ```
 
-```text
-audit: cannot create log dir
-```
+    or:
 
-or:
+    ```text
+    audit: cannot open
+    ```
 
-```text
-audit: cannot open
-```
+    Confirm that the router process can create the directory and file.
 
-Confirm that the router process can create the directory and file.
+    For systemd:
 
-For systemd:
+    ```bash
+    sudo -u hivenet-router \
+      touch /var/log/hivenet-router/test-write
+    ```
 
-```bash
-sudo -u hivenet-router \
-  touch /var/log/hivenet-router/test-write
-```
+    Remove the test file afterward:
 
-Remove the test file afterward:
+    ```bash
+    sudo rm \
+      /var/log/hivenet-router/test-write
+    ```
+  </Accordion>
 
-```bash
-sudo rm \
-  /var/log/hivenet-router/test-write
-```
+  <Accordion title="Audit JSON appears in application stdout">
+    The file could not be opened, so Hivenet Router fell back to stdout.
 
-### Audit JSON appears in application stdout
+    Correct the path or permissions, then restart the router.
+  </Accordion>
 
-The file could not be opened, so Hivenet Router fell back to stdout.
+  <Accordion title="Promtail does not ingest records">
+    Check that the shared file is visible:
 
-Correct the path or permissions, then restart the router.
+    ```bash
+    docker compose exec promtail \
+      tail -n 5 \
+      /var/log/hivenet-router/audit.jsonl
+    ```
 
-### Promtail does not ingest records
+    Inspect Promtail logs:
 
-Check that the shared file is visible:
+    ```bash
+    docker compose logs promtail \
+      | tail -100
+    ```
 
-```bash
-docker compose exec promtail \
-  tail -n 5 \
-  /var/log/hivenet-router/audit.jsonl
-```
+    Check its positions file and Loki connection.
+  </Accordion>
 
-Inspect Promtail logs:
+  <Accordion title="Loki has no audit stream">
+    Query the labels API:
 
-```bash
-docker compose logs promtail \
-  | tail -100
-```
+    ```bash
+    docker compose exec grafana \
+      wget -qO- \
+      http://loki:3100/loki/api/v1/labels
+    ```
 
-Check its positions file and Loki connection.
+    Then query the stream:
 
-### Loki has no audit stream
+    ```bash
+    docker compose exec grafana \
+      wget -qO- \
+      'http://loki:3100/loki/api/v1/query?query=%7Bjob%3D%22hivenet-router%22%2Clog_type%3D%22audit%22%7D' \
+      | head
+    ```
 
-Query the labels API:
+    Check that Promtail uses:
 
-```bash
-docker compose exec grafana \
-  wget -qO- \
-  http://loki:3100/loki/api/v1/labels
-```
+    ```text
+    job="hivenet-router"
+    log_type="audit"
+    ```
 
-Then query the stream:
+    rather than values from the older example configuration.
+  </Accordion>
 
-```bash
-docker compose exec grafana \
-  wget -qO- \
-  'http://loki:3100/loki/api/v1/query?query=%7Bjob%3D%22hivenet-router%22%2Clog_type%3D%22audit%22%7D' \
-  | head
-```
+  <Accordion title="A field is empty">
+    The field may not apply to that request.
 
-Check that Promtail uses:
+    Examples:
 
-```text
-job="hivenet-router"
-log_type="audit"
-```
+    - auth failure: empty tenant and key
+    - model-list request: empty model
+    - pre-routing rejection: empty agent ID
+    - no tracing: empty trace ID
+    - static key: empty key ID
+    - embedding or reranking: zero token counts
+  </Accordion>
 
-rather than values from the older example configuration.
+  <Accordion title="The request ID was replaced">
+    Hivenet Router accepts only valid UUIDs in `X-Request-ID`.
 
-### A field is empty
+    Use a UUID such as:
 
-The field may not apply to that request.
+    ```text
+    8b9e4a6d-dfb4-4b95-bada-319e7e5b878a
+    ```
 
-Examples:
+    Other values are replaced with a generated UUID.
+  </Accordion>
 
-- auth failure: empty tenant and key
-- model-list request: empty model
-- pre-routing rejection: empty agent ID
-- no tracing: empty trace ID
-- static key: empty key ID
-- embedding or reranking: zero token counts
+  <Accordion title="The source IP is unexpected">
+    Check the proxy path and forwarding headers.
 
-### The request ID was replaced
+    The recorded value may be the proxy address or a header-derived address, depending on how the router is reached and configured.
+  </Accordion>
 
-Hivenet Router accepts only valid UUIDs in `X-Request-ID`.
+  <Accordion title="Token totals are zero">
+    Possible causes include:
 
-Use a UUID such as:
+    - the request failed before inference
+    - it was an embedding or reranking request
+    - the backend did not report usage
+    - streaming usage could not be measured
+    - the handler did not have token information for that route
 
-```text
-8b9e4a6d-dfb4-4b95-bada-319e7e5b878a
-```
+    Compare the audit record with the backend response and Prometheus tenant-token metrics.
+  </Accordion>
 
-Other values are replaced with a generated UUID.
+  <Accordion title="Records continue in a rotated file">
+    The router keeps the audit file open.
 
-### The source IP is unexpected
-
-Check the proxy path and forwarding headers.
-
-The recorded value may be the proxy address or a header-derived address, depending on how the router is reached and configured.
-
-### Token totals are zero
-
-Possible causes include:
-
-- the request failed before inference
-- it was an embedding or reranking request
-- the backend did not report usage
-- streaming usage could not be measured
-- the handler did not have token information for that route
-
-Compare the audit record with the backend response and Prometheus tenant-token metrics.
-
-### Records continue in a rotated file
-
-The router keeps the audit file open.
-
-Use `copytruncate`, or restart the router after a rename-based rotation so it opens the new path.
+    Use `copytruncate`, or restart the router after a rename-based rotation so it opens the new path.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Hardware metrics" href="/observability/hardware-metrics">
+<Columns cols={3}>
+  <Card title="Hardware metrics" icon="microchip" href="/observability/hardware-metrics">
     Review the GPU, CPU, and memory data reported by agents.
   </Card>
 
-  <Card title="Engine metrics" href="/observability/engine-metrics">
+  <Card title="Engine metrics" icon="gauge-high" href="/observability/engine-metrics">
     Understand cache, queue, latency, and throughput metrics by backend.
   </Card>
 
-  <Card title="Error codes" href="/reference/error-codes">
+  <Card title="Error codes" icon="triangle-exclamation" href="/reference/error-codes">
     Review the structured errors recorded in audit entries.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/observability/engine-metrics.mdx
+++ b/docs/observability/engine-metrics.mdx
@@ -1078,155 +1078,157 @@ groups:
 
 ## Troubleshooting
 
-### No engine metrics appear
+<AccordionGroup>
+  <Accordion title="No engine metrics appear">
+    Check whether the selected engine supports metrics:
 
-Check whether the selected engine supports metrics:
-
-```text
-vllm
-sglang
-llamacpp
-```
-
-Then check the backend directly:
-
-```bash
-curl -i \
-  http://localhost:<backend-port>/metrics
-```
-
-Inspect the agent logs:
-
-<Tabs>
-  <Tab title="systemd">
-    ```bash
-    sudo journalctl \
-      -u hivenet-agent \
-      | grep -i "engine metrics"
+    ```text
+    vllm
+    sglang
+    llamacpp
     ```
-  </Tab>
-  <Tab title="Docker">
+
+    Then check the backend directly:
+
     ```bash
-    docker logs hivenet-agent \
-      2>&1 \
-      | grep -i "engine metrics"
+    curl -i \
+      http://localhost:<backend-port>/metrics
     ```
-  </Tab>
-</Tabs>
 
-### SGLang metrics are missing
+    Inspect the agent logs:
 
-Start SGLang with:
+    <Tabs>
+      <Tab title="systemd">
+        ```bash
+        sudo journalctl \
+          -u hivenet-agent \
+          | grep -i "engine metrics"
+        ```
+      </Tab>
+      <Tab title="Docker">
+        ```bash
+        docker logs hivenet-agent \
+          2>&1 \
+          | grep -i "engine metrics"
+        ```
+      </Tab>
+    </Tabs>
+  </Accordion>
 
-```bash
---enable-metrics
-```
+  <Accordion title="SGLang metrics are missing">
+    Start SGLang with:
 
-Restart SGLang, then check:
+    ```bash
+    --enable-metrics
+    ```
 
-```bash
-curl http://localhost:3000/metrics \
-  | head
-```
+    Restart SGLang, then check:
 
-### llama.cpp metrics are missing
+    ```bash
+    curl http://localhost:3000/metrics \
+      | head
+    ```
+  </Accordion>
 
-Start llama.cpp with:
+  <Accordion title="llama.cpp metrics are missing">
+    Start llama.cpp with:
 
-```bash
---metrics
-```
+    ```bash
+    --metrics
+    ```
 
-Restart the server, then check:
+    Restart the server, then check:
 
-```bash
-curl http://localhost:8888/metrics \
-  | head
-```
+    ```bash
+    curl http://localhost:8888/metrics \
+      | head
+    ```
+  </Accordion>
 
-### Values appear stale
+  <Accordion title="Values appear stale">
+    Check the agent logs for:
 
-Check the agent logs for:
+    ```text
+    Engine metrics scrape started failing
+    ```
 
-```text
-Engine metrics scrape started failing
-```
+    Test the backend metrics endpoint locally.
 
-Test the backend metrics endpoint locally.
+    The agent deliberately retains its latest successful snapshot during a scrape failure.
 
-The agent deliberately retains its latest successful snapshot during a scrape failure.
+    Restarting the agent clears its local cache, but the better fix is to restore the backend metrics endpoint.
+  </Accordion>
 
-Restarting the agent clears its local cache, but the better fix is to restore the backend metrics endpoint.
+  <Accordion title="TTFT or ITL is absent">
+    The backend may not expose that metric, or it may not have recorded any observations yet.
 
-### TTFT or ITL is absent
+    Check:
 
-The backend may not expose that metric, or it may not have recorded any observations yet.
+    - engine type
+    - backend metrics configuration
+    - whether requests have completed
+    - whether the expected histogram exists on the backend
 
-Check:
+    SGLang does not provide ITL through the current integration.
+  </Accordion>
 
-- engine type
-- backend metrics configuration
-- whether requests have completed
-- whether the expected histogram exists on the backend
+  <Accordion title="Raw histogram queries are empty">
+    The current Hivenet Router implementation re-exports raw engine histograms from vLLM.
 
-SGLang does not provide ITL through the current integration.
+    SGLang and llama.cpp currently supply scalar average and P90 values but not raw histogram series through the router.
 
-### Raw histogram queries are empty
+    Filter for vLLM:
 
-The current Hivenet Router implementation re-exports raw engine histograms from vLLM.
+    ```promql
+    hivenet_router_agent_engine_ttft_seconds_count{
+      engine="vllm"
+    }
+    ```
+  </Accordion>
 
-SGLang and llama.cpp currently supply scalar average and P90 values but not raw histogram series through the router.
+  <Accordion title="Preemption calculations become negative">
+    The backend cumulative value can reset when vLLM restarts.
 
-Filter for vLLM:
+    Use:
 
-```promql
-hivenet_router_agent_engine_ttft_seconds_count{
-  engine="vllm"
-}
-```
+    ```promql
+    clamp_min(
+      delta(
+        hivenet_router_agent_engine_preemptions_total[5m]
+      ),
+      0
+    )
+    ```
 
-### Preemption calculations become negative
+    rather than treating the series as a normal Prometheus counter.
+  </Accordion>
 
-The backend cumulative value can reset when vLLM restarts.
+  <Accordion title="Engine values exist but policy gates do not behave as expected">
+    Check:
 
-Use:
+    - policy field spelling
+    - units
+    - current routing-table value
+    - whether the agent passes earlier routing gates
+    - whether the metric is missing rather than zero
+    - whether cached data is stale after scrape failure
 
-```promql
-clamp_min(
-  delta(
-    hivenet_router_agent_engine_preemptions_total[5m]
-  ),
-  0
-)
-```
-
-rather than treating the series as a normal Prometheus counter.
-
-### Engine values exist but policy gates do not behave as expected
-
-Check:
-
-- policy field spelling
-- units
-- current routing-table value
-- whether the agent passes earlier routing gates
-- whether the metric is missing rather than zero
-- whether cached data is stale after scrape failure
-
-Policy utilization fields use fractions rather than percentages.
+    Policy utilization fields use fractions rather than percentages.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Latency tracking" href="/observability/latency-tracking">
+<Columns cols={3}>
+  <Card title="Latency tracking" icon="stopwatch" href="/observability/latency-tracking">
     Understand Hivenet Router’s RFC 6298 SRTT and RTTVAR measurements.
   </Card>
 
-  <Card title="Hardware-aware routing" href="/observability/hardware-aware-routing">
+  <Card title="Hardware-aware routing" icon="microchip" href="/observability/hardware-aware-routing">
     Combine engine pressure with GPU, CPU, memory, and hardware-tier policies.
   </Card>
 
-  <Card title="Grafana dashboards" href="/observability/grafana-dashboards">
+  <Card title="Grafana dashboards" icon="chart-line" href="/observability/grafana-dashboards">
     Explore the provisioned engine tables and time-series panels.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/observability/grafana-dashboards.mdx
+++ b/docs/observability/grafana-dashboards.mdx
@@ -710,240 +710,242 @@ See [Prometheus metrics](/observability/prometheus-metrics#alerting-examples) fo
 
 ## Troubleshooting
 
-### Grafana does not start
+<AccordionGroup>
+  <Accordion title="Grafana does not start">
+    Check the container:
+
+    ```bash
+    docker compose ps grafana
+    ```
+
+    Inspect its logs:
+
+    ```bash
+    docker compose logs grafana \
+      | tail -100
+    ```
+
+    Common causes include:
+
+    - invalid provisioning YAML
+    - unreadable mounted files
+    - an unwritable Grafana data volume
+    - an occupied host port `3000`
+  </Accordion>
+
+  <Accordion title="Dashboards are missing">
+    Check the mounted directory:
+
+    ```bash
+    docker compose exec grafana \
+      find /etc/grafana/provisioning \
+      -maxdepth 3 \
+      -type f
+    ```
+
+    Confirm that it contains the dashboard JSON files and `dashboard.yml`.
+
+    Check provisioning logs:
+
+    ```bash
+    docker compose logs grafana \
+      | grep -i "provision\|dashboard"
+    ```
+  </Accordion>
+
+  <Accordion title="A data source reports an error">
+    Test connectivity from the Grafana container.
+
+    Prometheus:
+
+    ```bash
+    docker compose exec grafana \
+      wget -qO- \
+      http://prometheus:9090/-/ready
+    ```
+
+    Loki:
+
+    ```bash
+    docker compose exec grafana \
+      wget -qO- \
+      http://loki:3100/ready
+    ```
+
+    Tempo:
+
+    ```bash
+    docker compose exec grafana \
+      wget -qO- \
+      http://tempo:3200/ready
+    ```
+
+    Inspect the corresponding service logs when a check fails.
+  </Accordion>
 
-Check the container:
+  <Accordion title="The router dashboard has no data">
+    Check the Prometheus target:
 
-```bash
-docker compose ps grafana
-```
+    ```bash
+    docker compose exec prometheus \
+      wget -qO- \
+      http://localhost:9090/api/v1/targets \
+      | jq '.data.activeTargets[] | {
+          health,
+          lastError
+        }'
+    ```
+
+    Query one registration metric:
+
+    ```bash
+    docker compose exec prometheus \
+      wget -qO- \
+      'http://localhost:9090/api/v1/query?query=hivenet_router_routing_agent_info' \
+      | jq .
+    ```
+
+    If the query is empty:
 
-Inspect its logs:
+    - confirm that agents are registered
+    - confirm that Prometheus scrapes `router:2112`
+    - inspect router and Prometheus logs
+    - check whether the selected dashboard filters exclude all agents
+  </Accordion>
 
-```bash
-docker compose logs grafana \
-  | tail -100
-```
+  <Accordion title="Hardware panels are empty">
+    Check whether the agent reports hardware data:
 
-Common causes include:
+    ```bash
+    curl \
+      -H "Authorization: Bearer <admin-api-key>" \
+      http://localhost:8080/admin/routing-table \
+      | jq '.agents[] | {
+          peer_id,
+          hardware
+        }'
+    ```
 
-- invalid provisioning YAML
-- unreadable mounted files
-- an unwritable Grafana data volume
-- an occupied host port `3000`
+    For GPU panels, check:
 
-### Dashboards are missing
+    - NVIDIA drivers
+    - NVML availability
+    - container GPU access
+    - the agent process permissions
 
-Check the mounted directory:
+    CPU-only agents do not produce GPU series.
+  </Accordion>
 
-```bash
-docker compose exec grafana \
-  find /etc/grafana/provisioning \
-  -maxdepth 3 \
-  -type f
-```
+  <Accordion title="Engine panels are empty">
+    Check backend support and configuration:
 
-Confirm that it contains the dashboard JSON files and `dashboard.yml`.
+    - SGLang needs `--enable-metrics`
+    - llama.cpp needs `--metrics`
+    - Ollama, Infinity, and custom engines do not currently supply engine metrics
 
-Check provisioning logs:
+    Test the engine endpoint on the agent host:
 
-```bash
-docker compose logs grafana \
-  | grep -i "provision\|dashboard"
-```
+    ```bash
+    curl http://localhost:8888/metrics \
+      | head
+    ```
 
-### A data source reports an error
+    Inspect the agent logs for scrape errors.
+  </Accordion>
 
-Test connectivity from the Grafana container.
+  <Accordion title="The tenant dashboard has no tenants">
+    Tenant metrics appear only after authenticated or no-auth traffic creates them.
 
-Prometheus:
+    Check:
 
-```bash
-docker compose exec grafana \
-  wget -qO- \
-  http://prometheus:9090/-/ready
-```
+    ```bash
+    curl -s \
+      http://localhost:2112/metrics \
+      | grep hivenet_router_tenant
+    ```
 
-Loki:
+    A tenant using only per-model quota gauges may not appear in the current selector. Query the per-model metrics directly in Explore when necessary.
+  </Accordion>
 
-```bash
-docker compose exec grafana \
-  wget -qO- \
-  http://loki:3100/ready
-```
+  <Accordion title="The audit dashboard is empty">
+    Confirm that audit records exist:
 
-Tempo:
+    ```bash
+    docker compose exec router \
+      ls -la /var/log/hivenet-router
+    ```
 
-```bash
-docker compose exec grafana \
-  wget -qO- \
-  http://tempo:3200/ready
-```
+    Check Promtail:
 
-Inspect the corresponding service logs when a check fails.
+    ```bash
+    docker compose logs promtail \
+      | tail -100
+    ```
 
-### The router dashboard has no data
+    Check Loki:
 
-Check the Prometheus target:
+    ```bash
+    docker compose logs loki \
+      | tail -100
+    ```
 
-```bash
-docker compose exec prometheus \
-  wget -qO- \
-  http://localhost:9090/api/v1/targets \
-  | jq '.data.activeTargets[] | {
-      health,
-      lastError
-    }'
-```
+    Query Loki through its API:
 
-Query one registration metric:
+    ```bash
+    docker compose exec grafana \
+      wget -qO- \
+      'http://loki:3100/loki/api/v1/query?query=%7Bjob%3D%22hivenet-router%22%2Clog_type%3D%22audit%22%7D' \
+      | head
+    ```
+  </Accordion>
 
-```bash
-docker compose exec prometheus \
-  wget -qO- \
-  'http://localhost:9090/api/v1/query?query=hivenet_router_routing_agent_info' \
-  | jq .
-```
+  <Accordion title="Trace search is empty">
+    Check that the router received:
 
-If the query is empty:
+    ```text
+    OTEL_EXPORTER_OTLP_ENDPOINT=tempo:4317
+    ```
 
-- confirm that agents are registered
-- confirm that Prometheus scrapes `router:2112`
-- inspect router and Prometheus logs
-- check whether the selected dashboard filters exclude all agents
+    Inspect the router logs for tracing initialization or export errors.
 
-### Hardware panels are empty
+    Confirm that Tempo is ready:
 
-Check whether the agent reports hardware data:
+    ```bash
+    docker compose exec grafana \
+      wget -qO- \
+      http://tempo:3200/ready
+    ```
+  </Accordion>
 
-```bash
-curl \
-  -H "Authorization: Bearer <admin-api-key>" \
-  http://localhost:8080/admin/routing-table \
-  | jq '.agents[] | {
-      peer_id,
-      hardware
-    }'
-```
+  <Accordion title="Dashboard edits disappear">
+    The dashboards are provisioned from files.
 
-For GPU panels, check:
+    Make durable changes in:
 
-- NVIDIA drivers
-- NVML availability
-- container GPU access
-- the agent process permissions
+    ```text
+    deploy/grafana/provisioning/dashboards/
+    ```
 
-CPU-only agents do not produce GPU series.
+    then allow Grafana’s provisioning interval to reload them, or restart Grafana:
 
-### Engine panels are empty
-
-Check backend support and configuration:
-
-- SGLang needs `--enable-metrics`
-- llama.cpp needs `--metrics`
-- Ollama, Infinity, and custom engines do not currently supply engine metrics
-
-Test the engine endpoint on the agent host:
-
-```bash
-curl http://localhost:8888/metrics \
-  | head
-```
-
-Inspect the agent logs for scrape errors.
-
-### The tenant dashboard has no tenants
-
-Tenant metrics appear only after authenticated or no-auth traffic creates them.
-
-Check:
-
-```bash
-curl -s \
-  http://localhost:2112/metrics \
-  | grep hivenet_router_tenant
-```
-
-A tenant using only per-model quota gauges may not appear in the current selector. Query the per-model metrics directly in Explore when necessary.
-
-### The audit dashboard is empty
-
-Confirm that audit records exist:
-
-```bash
-docker compose exec router \
-  ls -la /var/log/hivenet-router
-```
-
-Check Promtail:
-
-```bash
-docker compose logs promtail \
-  | tail -100
-```
-
-Check Loki:
-
-```bash
-docker compose logs loki \
-  | tail -100
-```
-
-Query Loki through its API:
-
-```bash
-docker compose exec grafana \
-  wget -qO- \
-  'http://loki:3100/loki/api/v1/query?query=%7Bjob%3D%22hivenet-router%22%2Clog_type%3D%22audit%22%7D' \
-  | head
-```
-
-### Trace search is empty
-
-Check that the router received:
-
-```text
-OTEL_EXPORTER_OTLP_ENDPOINT=tempo:4317
-```
-
-Inspect the router logs for tracing initialization or export errors.
-
-Confirm that Tempo is ready:
-
-```bash
-docker compose exec grafana \
-  wget -qO- \
-  http://tempo:3200/ready
-```
-
-### Dashboard edits disappear
-
-The dashboards are provisioned from files.
-
-Make durable changes in:
-
-```text
-deploy/grafana/provisioning/dashboards/
-```
-
-then allow Grafana’s provisioning interval to reload them, or restart Grafana:
-
-```bash
-docker compose restart grafana
-```
+    ```bash
+    docker compose restart grafana
+    ```
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Audit logging" href="/observability/audit-logging">
+<Columns cols={3}>
+  <Card title="Audit logging" icon="file-lines" href="/observability/audit-logging">
     Configure structured request records and query them through Loki.
   </Card>
 
-  <Card title="Hardware metrics" href="/observability/hardware-metrics">
+  <Card title="Hardware metrics" icon="microchip" href="/observability/hardware-metrics">
     Understand the GPU, CPU, and memory values shown in Grafana.
   </Card>
 
-  <Card title="Engine metrics" href="/observability/engine-metrics">
+  <Card title="Engine metrics" icon="gears" href="/observability/engine-metrics">
     Review cache, queue, TTFT, ITL, and throughput metrics by backend.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/observability/hardware-aware-routing.mdx
+++ b/docs/observability/hardware-aware-routing.mdx
@@ -1016,110 +1016,112 @@ Use thresholds with practical headroom rather than treating a single decimal poi
 
 ## Troubleshooting
 
-### A GPU-tier policy matches nothing
+<AccordionGroup>
+  <Accordion title="A GPU-tier policy matches nothing">
+    Check the registered metadata:
 
-Check the registered metadata:
+    ```bash
+    curl \
+      -H "Authorization: Bearer <admin-api-key>" \
+      http://localhost:8080/admin/routing-table \
+      | jq -r '.agents[].metadata.gpu_model'
+    ```
 
-```bash
-curl \
-  -H "Authorization: Bearer <admin-api-key>" \
-  http://localhost:8080/admin/routing-table \
-  | jq -r '.agents[].metadata.gpu_model'
-```
+    Check exact spelling, capitalization, and whitespace.
 
-Check exact spelling, capitalization, and whitespace.
+    Hivenet Router does not populate `gpu_model` automatically.
+  </Accordion>
 
-Hivenet Router does not populate `gpu_model` automatically.
+  <Accordion title="A VRAM requirement cannot be expressed">
+    Hivenet Router does not support an absolute VRAM match.
 
-### A VRAM requirement cannot be expressed
+    Use an operator-defined tag such as:
 
-Hivenet Router does not support an absolute VRAM match.
+    ```text
+    vram-80gb
+    ```
 
-Use an operator-defined tag such as:
+    or a carefully standardized `gpu_model` value.
 
-```text
-vram-80gb
-```
+    Use `gpu_vram_used_percent` only for live pressure, not total device capacity.
+  </Accordion>
 
-or a carefully standardized `gpu_model` value.
+  <Accordion title="A hardware gate does not exclude an agent">
+    The metric may be missing.
 
-Use `gpu_vram_used_percent` only for live pressure, not total device capacity.
+    Check the routing-table hardware object.
 
-### A hardware gate does not exclude an agent
+    Also verify the units:
 
-The metric may be missing.
+    | Prometheus | Policy |
+    | --- | --- |
+    | `95` | `0.95` |
+    | `82°C` | `82` |
 
-Check the routing-table hardware object.
+    Missing metrics pass.
+  </Accordion>
 
-Also verify the units:
+  <Accordion title="One hot GPU excludes a multi-GPU agent">
+    This is expected.
 
-| Prometheus | Policy |
-| --- | --- |
-| `95` | `0.95` |
-| `82°C` | `82` |
+    Hivenet Router uses the highest temperature, utilization, and VRAM fraction across the GPUs reported by the agent.
 
-Missing metrics pass.
+    Restrict collection with `--gpu-devices-file` if the agent should represent only a subset of the host’s devices.
+  </Accordion>
 
-### One hot GPU excludes a multi-GPU agent
+  <Accordion title="Power cannot be used in `exclude_if`">
+    GPU power is currently an observability metric only.
 
-This is expected.
+    Use static hardware metadata, tags, or one of the supported dynamic gate fields.
+  </Accordion>
 
-Hivenet Router uses the highest temperature, utilization, and VRAM fraction across the GPUs reported by the agent.
+  <Accordion title="The preferred tier is skipped">
+    Check the earlier hard constraints:
 
-Restrict collection with `--gpu-devices-file` if the agent should represent only a subset of the host’s devices.
+    - requested model
+    - capability
+    - agent health
+    - static metadata
+    - previous failures
+    - declared capacity
 
-### Power cannot be used in `exclude_if`
+    A hardware match does not make an agent eligible when it fails one of those checks.
+  </Accordion>
 
-GPU power is currently an observability metric only.
+  <Accordion title="Fallback traffic rises after adding gates">
+    Inspect:
 
-Use static hardware metadata, tags, or one of the supported dynamic gate fields.
+    - policy-exhaustion logs
+    - current metric distributions
+    - missing-metric behavior
+    - preferred-tier capacity
+    - threshold units
+    - whether one agent reports a persistent outlier
 
-### The preferred tier is skipped
+    Relax one condition at a time rather than removing the complete policy.
+  </Accordion>
 
-Check the earlier hard constraints:
+  <Accordion title="Hardware data appears stale">
+    Check agent logs for collection errors and confirm the latest heartbeat.
 
-- requested model
-- capability
-- agent health
-- static metadata
-- previous failures
-- declared capacity
+    The current system does not expose a dedicated hardware-snapshot age metric.
 
-A hardware match does not make an agent eligible when it fails one of those checks.
-
-### Fallback traffic rises after adding gates
-
-Inspect:
-
-- policy-exhaustion logs
-- current metric distributions
-- missing-metric behavior
-- preferred-tier capacity
-- threshold units
-- whether one agent reports a persistent outlier
-
-Relax one condition at a time rather than removing the complete policy.
-
-### Hardware data appears stale
-
-Check agent logs for collection errors and confirm the latest heartbeat.
-
-The current system does not expose a dedicated hardware-snapshot age metric.
-
-A healthy heartbeat does not prove that every recent hardware sample succeeded.
+    A healthy heartbeat does not prove that every recent hardware sample succeeded.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Prometheus metrics" href="/observability/prometheus-metrics">
+<Columns cols={3}>
+  <Card title="Prometheus metrics" icon="chart-line" href="/observability/prometheus-metrics">
     Query the live hardware, engine, latency, capacity, and routing signals used in these policies.
   </Card>
 
-  <Card title="Policy gates" href="/routing/policy-gates">
+  <Card title="Policy gates" icon="filter" href="/routing/policy-gates">
     Review the exact evaluation behavior and all supported gate fields.
   </Card>
 
-  <Card title="Hardware metrics" href="/observability/hardware-metrics">
+  <Card title="Hardware metrics" icon="microchip" href="/observability/hardware-metrics">
     Understand how GPU, CPU, memory, temperature, and power values are collected.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/observability/hardware-metrics.mdx
+++ b/docs/observability/hardware-metrics.mdx
@@ -844,177 +844,179 @@ Increase declared capacity gradually rather than deriving it from one hardware m
 
 ## Troubleshooting
 
-### GPU metrics are missing
+<AccordionGroup>
+  <Accordion title="GPU metrics are missing">
+    Check the host:
 
-Check the host:
-
-```bash
-nvidia-smi
-```
-
-Check device permissions:
-
-```bash
-ls -la /dev/nvidia*
-```
-
-Check the agent logs:
-
-<Tabs>
-  <Tab title="systemd">
     ```bash
-    sudo journalctl \
-      -u hivenet-agent \
-      | grep -i "nvml\|hardware"
+    nvidia-smi
     ```
-  </Tab>
-  <Tab title="Docker">
+
+    Check device permissions:
+
     ```bash
-    docker logs hivenet-agent \
-      2>&1 \
-      | grep -i "nvml\|hardware"
+    ls -la /dev/nvidia*
     ```
-  </Tab>
-</Tabs>
 
-For Docker, confirm that the agent received GPU access:
+    Check the agent logs:
 
-```bash
-docker inspect hivenet-agent \
-  | jq '.[0].HostConfig.DeviceRequests'
-```
+    <Tabs>
+      <Tab title="systemd">
+        ```bash
+        sudo journalctl \
+          -u hivenet-agent \
+          | grep -i "nvml\|hardware"
+        ```
+      </Tab>
+      <Tab title="Docker">
+        ```bash
+        docker logs hivenet-agent \
+          2>&1 \
+          | grep -i "nvml\|hardware"
+        ```
+      </Tab>
+    </Tabs>
 
-Test NVML inside a GPU-enabled container:
+    For Docker, confirm that the agent received GPU access:
 
-```bash
-docker run --rm \
-  --gpus all \
-  nvidia/cuda:12.6.0-base-ubuntu24.04 \
-  nvidia-smi
-```
+    ```bash
+    docker inspect hivenet-agent \
+      | jq '.[0].HostConfig.DeviceRequests'
+    ```
 
-The agent continues with CPU and memory metrics when NVML is unavailable.
+    Test NVML inside a GPU-enabled container:
 
-### The agent reports GPUs it should not monitor
+    ```bash
+    docker run --rm \
+      --gpus all \
+      nvidia/cuda:12.6.0-base-ubuntu24.04 \
+      nvidia-smi
+    ```
 
-Use:
+    The agent continues with CPU and memory metrics when NVML is unavailable.
+  </Accordion>
 
-```bash
---gpu-devices-file <path>
-```
+  <Accordion title="The agent reports GPUs it should not monitor">
+    Use:
 
-with the assigned NVIDIA GPU UUIDs.
+    ```bash
+    --gpu-devices-file <path>
+    ```
 
-Confirm the UUIDs:
+    with the assigned NVIDIA GPU UUIDs.
 
-```bash
-nvidia-smi \
-  --query-gpu=index,uuid \
-  --format=csv
-```
+    Confirm the UUIDs:
 
-Restart the agent after changing a successfully loaded GPU-device file.
+    ```bash
+    nvidia-smi \
+      --query-gpu=index,uuid \
+      --format=csv
+    ```
 
-### The GPU-device file has no effect
+    Restart the agent after changing a successfully loaded GPU-device file.
+  </Accordion>
 
-Check that:
+  <Accordion title="The GPU-device file has no effect">
+    Check that:
 
-- the file exists inside the agent’s filesystem
-- its contents use NVIDIA GPU UUIDs rather than numeric indices
-- the agent can read it
-- the agent was restarted after a previous successful load
-- the UUIDs match the values returned by NVML
+    - the file exists inside the agent’s filesystem
+    - its contents use NVIDIA GPU UUIDs rather than numeric indices
+    - the agent can read it
+    - the agent was restarted after a previous successful load
+    - the UUIDs match the values returned by NVML
 
-For a container, confirm the file is mounted:
+    For a container, confirm the file is mounted:
 
-```bash
-docker inspect hivenet-agent \
-  | jq '.[0].Mounts'
-```
+    ```bash
+    docker inspect hivenet-agent \
+      | jq '.[0].Mounts'
+    ```
+  </Accordion>
 
-### Values show zero for one GPU
+  <Accordion title="Values show zero for one GPU">
+    Individual NVML subqueries can fail independently.
 
-Individual NVML subqueries can fail independently.
+    Hivenet Router keeps the GPU record and sets the failed reading to zero while preserving the other values it could collect.
 
-Hivenet Router keeps the GPU record and sets the failed reading to zero while preserving the other values it could collect.
+    Check the agent log for:
 
-Check the agent log for:
+    ```text
+    hardware: GPU
+    ```
 
-```text
-hardware: GPU
-```
+    and compare with:
 
-and compare with:
+    ```bash
+    nvidia-smi
+    ```
+  </Accordion>
 
-```bash
-nvidia-smi
-```
+  <Accordion title="CPU use looks wrong immediately after startup">
+    The collector seeds a CPU baseline during initialization and then reports non-blocking interval measurements.
 
-### CPU use looks wrong immediately after startup
+    Allow at least one sampling interval and compare several readings rather than relying on one value immediately after startup.
+  </Accordion>
 
-The collector seeds a CPU baseline during initialization and then reports non-blocking interval measurements.
+  <Accordion title="Hardware data is present in the routing table but not Prometheus">
+    Check the router’s metrics endpoint:
 
-Allow at least one sampling interval and compare several readings rather than relying on one value immediately after startup.
+    ```bash
+    curl -s \
+      http://localhost:2112/metrics \
+      | grep hivenet_router_agent_gpu
+    ```
 
-### Hardware data is present in the routing table but not Prometheus
+    Then check Prometheus’s router target.
 
-Check the router’s metrics endpoint:
+    The agent sends hardware data to the router; Prometheus does not scrape the agent.
+  </Accordion>
 
-```bash
-curl -s \
-  http://localhost:2112/metrics \
-  | grep hivenet_router_agent_gpu
-```
+  <Accordion title="Old GPU series remain after reassignment">
+    The router removes series when a reported GPU index disappears from a later snapshot or when the agent is unregistered.
 
-Then check Prometheus’s router target.
+    If an old series remains, check whether:
 
-The agent sends hardware data to the router; Prometheus does not scrape the agent.
+    - the original agent peer ID is still registered
+    - the agent identity changed
+    - Prometheus is displaying historical data within the selected time range
+    - the agent has not yet sent a new filtered snapshot
 
-### Old GPU series remain after reassignment
+    Use an instant query to inspect current series rather than a long-range graph.
+  </Accordion>
 
-The router removes series when a reported GPU index disappears from a later snapshot or when the agent is unregistered.
+  <Accordion title="A hardware gate does not exclude the agent">
+    Check the unit and current value.
 
-If an old series remains, check whether:
+    Prometheus percentages use `0` to `100`, while policy percentages use `0.0` to `1.0`.
 
-- the original agent peer ID is still registered
-- the agent identity changed
-- Prometheus is displaying historical data within the selected time range
-- the agent has not yet sent a new filtered snapshot
+    Inspect the routing table:
 
-Use an instant query to inspect current series rather than a long-range graph.
+    ```bash
+    curl \
+      -H "Authorization: Bearer <admin-api-key>" \
+      http://localhost:8080/admin/routing-table \
+      | jq '.agents[] | {
+          model: .metadata.model,
+          hardware
+        }'
+    ```
 
-### A hardware gate does not exclude the agent
-
-Check the unit and current value.
-
-Prometheus percentages use `0` to `100`, while policy percentages use `0.0` to `1.0`.
-
-Inspect the routing table:
-
-```bash
-curl \
-  -H "Authorization: Bearer <admin-api-key>" \
-  http://localhost:8080/admin/routing-table \
-  | jq '.agents[] | {
-      model: .metadata.model,
-      hardware
-    }'
-```
-
-The metric may also be unavailable. Missing metrics pass the policy gate.
+    The metric may also be unavailable. Missing metrics pass the policy gate.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Engine metrics" href="/observability/engine-metrics">
+<Columns cols={3}>
+  <Card title="Engine metrics" icon="gauge-high" href="/observability/engine-metrics">
     Review cache, queue, latency, finish-reason, and throughput metrics from inference engines.
   </Card>
 
-  <Card title="Hardware-aware routing" href="/observability/hardware-aware-routing">
+  <Card title="Hardware-aware routing" icon="microchip" href="/observability/hardware-aware-routing">
     Build policies around GPU tier, thermal state, VRAM pressure, CPU, and system memory.
   </Card>
 
-  <Card title="Prometheus metrics" href="/observability/prometheus-metrics">
+  <Card title="Prometheus metrics" icon="chart-line" href="/observability/prometheus-metrics">
     Query and alert on the complete Hivenet Router metric set.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/observability/latency-tracking.mdx
+++ b/docs/observability/latency-tracking.mdx
@@ -737,121 +737,123 @@ Use audit or tenant-duration metrics when you need client-visible request durati
 
 ## Troubleshooting
 
-### SRTT remains unknown
+<AccordionGroup>
+  <Accordion title="SRTT remains unknown">
+    The agent has not produced a valid recorded request sample.
 
-The agent has not produced a valid recorded request sample.
+    Check that:
 
-Check that:
+    - the agent is registered
+    - it has served a request
+    - the request reached the agent
+    - the router recorded a success or a failure with a positive sample
 
-- the agent is registered
-- it has served a request
-- the request reached the agent
-- the router recorded a success or a failure with a positive sample
+    Inspect:
 
-Inspect:
+    ```bash
+    curl \
+      -H "Authorization: Bearer <admin-api-key>" \
+      http://localhost:8080/admin/routing-table \
+      | jq '.agents[] | {
+          model: .metadata.model,
+          latency_state: .universal.latency_state,
+          successful: .universal.successful_requests_total,
+          failed: .universal.failed_requests_total
+        }'
+    ```
+  </Accordion>
 
-```bash
-curl \
-  -H "Authorization: Bearer <admin-api-key>" \
-  http://localhost:8080/admin/routing-table \
-  | jq '.agents[] | {
-      model: .metadata.model,
-      latency_state: .universal.latency_state,
-      successful: .universal.successful_requests_total,
-      failed: .universal.failed_requests_total
-    }'
-```
+  <Accordion title="SRTT is much higher than TTFT">
+    The requests may be non-streaming.
 
-### SRTT is much higher than TTFT
+    For native non-streaming Chat Completions, SRTT includes the complete inference before the agent returns headers. Engine TTFT measures only the start of model output.
 
-The requests may be non-streaming.
+    Also check:
 
-For native non-streaming Chat Completions, SRTT includes the complete inference before the agent returns headers. Engine TTFT measures only the start of model output.
+    - router-agent network time
+    - backend queueing
+    - response parsing
+    - mixed request types
+    - different observation windows
+  </Accordion>
 
-Also check:
+  <Accordion title="SRTT changes after switching to streaming">
+    This is expected.
 
-- router-agent network time
-- backend queueing
-- response parsing
-- mixed request types
-- different observation windows
+    Streaming usually records latency near response start, while non-streaming native chat records latency after the complete backend response is ready.
 
-### SRTT changes after switching to streaming
+    Establish separate baselines when both modes are used heavily.
+  </Accordion>
 
-This is expected.
+  <Accordion title="SRTT remains high after a cold start">
+    The estimator moves downward quickly, but it still needs successful faster samples.
 
-Streaming usually records latency near response start, while non-streaming native chat records latency after the complete backend response is ready.
+    Send representative requests and check whether:
 
-Establish separate baselines when both modes are used heavily.
+    - the backend is fully loaded
+    - queue pressure has cleared
+    - new samples are actually lower
+    - the agent is still serving unusually large requests
+  </Accordion>
 
-### SRTT remains high after a cold start
+  <Accordion title="SRTT resets after an agent restart">
+    The agent may have started with a new peer ID.
 
-The estimator moves downward quickly, but it still needs successful faster samples.
+    Check that `--identity-path` points to persistent storage and compare the current peer ID with the previous deployment.
 
-Send representative requests and check whether:
+    Also confirm that:
 
-- the backend is fully loaded
-- queue pressure has cleared
-- new samples are actually lower
-- the agent is still serving unusually large requests
+    - the router uses a persistent BadgerDB directory
+    - universal history was not reset
+    - the previous record has not expired
+    - the router shut down or flushed recently enough to preserve the latest value
+  </Accordion>
 
-### SRTT resets after an agent restart
+  <Accordion title="Policy does not exclude a slow agent">
+    Check that the field is:
 
-The agent may have started with a new peer ID.
+    ```yaml
+    srtt:
+    ```
 
-Check that `--identity-path` points to persistent storage and compare the current peer ID with the previous deployment.
+    rather than:
 
-Also confirm that:
+    ```yaml
+    srtt_ms:
+    ```
 
-- the router uses a persistent BadgerDB directory
-- universal history was not reset
-- the previous record has not expired
-- the router shut down or flushed recently enough to preserve the latest value
+    Inspect the live routing-table value.
 
-### Policy does not exclude a slow agent
+    A new agent with no SRTT passes the gate.
 
-Check that the field is:
+    Also confirm that the agent survived the earlier model, health, capability, match, failure, and capacity gates.
+  </Accordion>
 
-```yaml
-srtt:
-```
+  <Accordion title="Prometheus shows zero before traffic">
+    The SRTT gauge may be seeded at zero when the agent first registers without latency history.
 
-rather than:
+    Use the routing table’s:
 
-```yaml
-srtt_ms:
-```
+    ```text
+    latency_state
+    ```
 
-Inspect the live routing-table value.
-
-A new agent with no SRTT passes the gate.
-
-Also confirm that the agent survived the earlier model, health, capability, match, failure, and capacity gates.
-
-### Prometheus shows zero before traffic
-
-The SRTT gauge may be seeded at zero when the agent first registers without latency history.
-
-Use the routing table’s:
-
-```text
-latency_state
-```
-
-when you need to distinguish an initialized low value from an unknown estimator.
+    when you need to distinguish an initialized low value from an unknown estimator.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Hardware-aware routing" href="/observability/hardware-aware-routing">
+<Columns cols={3}>
+  <Card title="Hardware-aware routing" icon="microchip" href="/observability/hardware-aware-routing">
     Combine latency with GPU, CPU, memory, cache, and queue pressure.
   </Card>
 
-  <Card title="Routing concepts" href="/routing/routing-concepts">
+  <Card title="Routing concepts" icon="route" href="/routing/routing-concepts">
     See where the SRTT gate fits inside the complete routing pipeline.
   </Card>
 
-  <Card title="Performance characteristics" href="/reference/performance-characteristics">
+  <Card title="Performance characteristics" icon="gauge-high" href="/reference/performance-characteristics">
     Review performance measurements, scope, and testing considerations.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/observability/observability-overview.mdx
+++ b/docs/observability/observability-overview.mdx
@@ -456,32 +456,32 @@ Before relying on the observability stack in production:
 
 ## Explore the observability guides
 
-<CardGroup cols={2}>
-  <Card title="Prometheus metrics" href="/observability/prometheus-metrics">
+<Columns cols={2}>
+  <Card title="Prometheus metrics" icon="chart-line" href="/observability/prometheus-metrics">
     Scrape, query, aggregate, and alert on router, agent, tenant, and backend metrics.
   </Card>
 
-  <Card title="Grafana dashboards" href="/observability/grafana-dashboards">
+  <Card title="Grafana dashboards" icon="gauge-high" href="/observability/grafana-dashboards">
     Use the provisioned router, tenant, audit, and trace views.
   </Card>
 
-  <Card title="Audit logging" href="/observability/audit-logging">
+  <Card title="Audit logging" icon="file-lines" href="/observability/audit-logging">
     Search structured request records through JSONL files and Loki.
   </Card>
 
-  <Card title="Hardware metrics" href="/observability/hardware-metrics">
+  <Card title="Hardware metrics" icon="microchip" href="/observability/hardware-metrics">
     Inspect GPU, CPU, memory, temperature, and power data.
   </Card>
 
-  <Card title="Engine metrics" href="/observability/engine-metrics">
+  <Card title="Engine metrics" icon="gears" href="/observability/engine-metrics">
     Monitor cache, backend queues, latency, request shape, and throughput.
   </Card>
 
-  <Card title="Latency tracking" href="/observability/latency-tracking">
+  <Card title="Latency tracking" icon="stopwatch" href="/observability/latency-tracking">
     Understand SRTT, RTTVAR, TTFT, ITL, and request-duration boundaries.
   </Card>
 
-  <Card title="Hardware-aware routing" href="/observability/hardware-aware-routing">
+  <Card title="Hardware-aware routing" icon="route" href="/observability/hardware-aware-routing">
     Turn selected operational signals into routing gates and fallback tiers.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/observability/prometheus-metrics.mdx
+++ b/docs/observability/prometheus-metrics.mdx
@@ -1600,143 +1600,145 @@ groups:
 
 ## Troubleshooting
 
-### Prometheus cannot reach the router
+<AccordionGroup>
+  <Accordion title="Prometheus cannot reach the router">
+    Check the endpoint directly:
 
-Check the endpoint directly:
+    ```bash
+    curl -i \
+      http://<router-host>:2112/metrics
+    ```
 
-```bash
-curl -i \
-  http://<router-host>:2112/metrics
-```
+    Check the router logs:
 
-Check the router logs:
+    ```bash
+    journalctl \
+      -u hivenet-router \
+      | grep -i prometheus
+    ```
 
-```bash
-journalctl \
-  -u hivenet-router \
-  | grep -i prometheus
-```
+    For Docker Compose:
 
-For Docker Compose:
+    ```bash
+    docker compose exec prometheus \
+      wget -qO- \
+      http://router:2112/metrics \
+      | head
+    ```
 
-```bash
-docker compose exec prometheus \
-  wget -qO- \
-  http://router:2112/metrics \
-  | head
-```
+    Check firewall and container-network rules.
+  </Accordion>
 
-Check firewall and container-network rules.
+  <Accordion title="A metric is missing">
+    A series often appears only after the relevant event or data has occurred.
 
-### A metric is missing
+    For example:
 
-A series often appears only after the relevant event or data has occurred.
+    - tenant metrics appear after requests
+    - engine metrics appear after a successful engine scrape
+    - TTFT and ITL appear after completions
+    - GPU metrics require NVML and visible NVIDIA devices
+    - policy counters appear after routing activity
+    - per-model quota gauges appear when those quota paths are used or seeded
 
-For example:
+    Search by prefix:
 
-- tenant metrics appear after requests
-- engine metrics appear after a successful engine scrape
-- TTFT and ITL appear after completions
-- GPU metrics require NVML and visible NVIDIA devices
-- policy counters appear after routing activity
-- per-model quota gauges appear when those quota paths are used or seeded
+    ```bash
+    curl -s \
+      http://localhost:2112/metrics \
+      | grep 'hivenet_router_agent_engine'
+    ```
+  </Accordion>
 
-Search by prefix:
+  <Accordion title="An engine metric is missing">
+    Check the backend endpoint locally on the agent host:
 
-```bash
-curl -s \
-  http://localhost:2112/metrics \
-  | grep 'hivenet_router_agent_engine'
-```
+    ```bash
+    curl \
+      http://localhost:8888/metrics \
+      | head
+    ```
 
-### An engine metric is missing
+    Confirm the engine-specific requirement:
 
-Check the backend endpoint locally on the agent host:
+    - SGLang needs `--enable-metrics`
+    - llama.cpp needs `--metrics`
+    - Ollama, Infinity, and custom engines do not currently supply engine metrics
 
-```bash
-curl \
-  http://localhost:8888/metrics \
-  | head
-```
+    Inspect the agent logs for scrape errors.
 
-Confirm the engine-specific requirement:
+    A failed metrics scrape does not stop request forwarding.
+  </Accordion>
 
-- SGLang needs `--enable-metrics`
-- llama.cpp needs `--metrics`
-- Ollama, Infinity, and custom engines do not currently supply engine metrics
+  <Accordion title="Prometheus shows duplicate or stale agents">
+    The `peer_id` label identifies the agent.
 
-Inspect the agent logs for scrape errors.
+    If an agent starts with a new identity after every restart, Prometheus sees a new series.
 
-A failed metrics scrape does not stop request forwarding.
+    Configure a persistent:
 
-### Prometheus shows duplicate or stale agents
+    ```text
+    --identity-path
+    ```
 
-The `peer_id` label identifies the agent.
+    and preserve the file or mounted volume across restarts.
+  </Accordion>
 
-If an agent starts with a new identity after every restart, Prometheus sees a new series.
+  <Accordion title="Tenant labels show `anonymous` or `default`">
+    In no-auth mode:
 
-Configure a persistent:
+    ```text
+    tenant_id="default"
+    key_id="anonymous"
+    ```
 
-```text
---identity-path
-```
+    Static API keys currently use:
 
-and preserve the file or mounted volume across restarts.
+    ```text
+    key_id="anonymous"
+    ```
 
-### Tenant labels show `anonymous` or `default`
+    because stable key IDs belong to dynamic registry entries.
 
-In no-auth mode:
+    `deployment_id="unset"` is expected before an agent is selected or when the agent does not advertise a deployment ID.
+  </Accordion>
 
-```text
-tenant_id="default"
-key_id="anonymous"
-```
+  <Accordion title="Histogram queries return no data">
+    Check that the corresponding `_bucket` series exists:
 
-Static API keys currently use:
+    ```bash
+    curl -s \
+      http://localhost:2112/metrics \
+      | grep \
+        'hivenet_router_agent_engine_ttft_seconds_bucket'
+    ```
 
-```text
-key_id="anonymous"
-```
+    Use `rate()` over a window that contains completed observations.
 
-because stable key IDs belong to dynamic registry entries.
+    A new or idle engine may not have enough data yet.
+  </Accordion>
 
-`deployment_id="unset"` is expected before an agent is selected or when the agent does not advertise a deployment ID.
+  <Accordion title="Counter graphs drop after a restart">
+    Prometheus counters are process-local series.
 
-### Histogram queries return no data
+    Some per-agent lifetime counters are reseeded from BadgerDB when agents register again, but other router, policy, HTTP, tenant, and queue metrics begin again with the new router process.
 
-Check that the corresponding `_bucket` series exists:
-
-```bash
-curl -s \
-  http://localhost:2112/metrics \
-  | grep \
-    'hivenet_router_agent_engine_ttft_seconds_bucket'
-```
-
-Use `rate()` over a window that contains completed observations.
-
-A new or idle engine may not have enough data yet.
-
-### Counter graphs drop after a restart
-
-Prometheus counters are process-local series.
-
-Some per-agent lifetime counters are reseeded from BadgerDB when agents register again, but other router, policy, HTTP, tenant, and queue metrics begin again with the new router process.
-
-Use `rate()` or `increase()` rather than graphing raw counter values when restart behavior matters.
+    Use `rate()` or `increase()` rather than graphing raw counter values when restart behavior matters.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Grafana dashboards" href="/observability/grafana-dashboards">
+<Columns cols={3}>
+  <Card title="Grafana dashboards" icon="gauge-high" href="/observability/grafana-dashboards">
     Explore the provisioned dashboards, data sources, variables, and panels.
   </Card>
 
-  <Card title="Audit logging" href="/observability/audit-logging">
+  <Card title="Audit logging" icon="file-lines" href="/observability/audit-logging">
     Query structured request records through Loki or local JSONL files.
   </Card>
 
-  <Card title="Hardware metrics" href="/observability/hardware-metrics">
+  <Card title="Hardware metrics" icon="microchip" href="/observability/hardware-metrics">
     Review how agents collect GPU, CPU, and memory data.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/project/code-of-conduct.mdx
+++ b/docs/project/code-of-conduct.mdx
@@ -14,15 +14,15 @@ It applies to maintainers, contributors, and everyone participating in the proje
   This page summarizes how the policy applies. Refer to the canonical file for the complete wording.
 </Note>
 
-<CardGroup cols={2}>
-  <Card title="Read the canonical policy" href="https://github.com/HivenetOSS/hivenet_router/blob/main/CODE_OF_CONDUCT.md">
+<Columns cols={2}>
+  <Card title="Read the canonical policy" icon="scale-balanced" href="https://github.com/HivenetOSS/hivenet_router/blob/main/CODE_OF_CONDUCT.md">
     Review the complete standards, scope, reporting process, and enforcement guidelines.
   </Card>
 
-  <Card title="Report an incident" href="mailto:support@hivenet.com">
+  <Card title="Report an incident" icon="flag" href="mailto:support@hivenet.com">
     Contact the community leaders responsible for reviewing conduct reports.
   </Card>
-</CardGroup>
+</Columns>
 
 ## The community pledge
 
@@ -377,20 +377,20 @@ The repository’s canonical file contains the complete attribution and referenc
 
 ## Next steps
 
-<CardGroup cols={2}>
-  <Card title="Canonical code of conduct" href="https://github.com/HivenetOSS/hivenet_router/blob/main/CODE_OF_CONDUCT.md">
+<Columns cols={2}>
+  <Card title="Canonical code of conduct" icon="book" href="https://github.com/HivenetOSS/hivenet_router/blob/main/CODE_OF_CONDUCT.md">
     Read the complete and authoritative Contributor Covenant policy.
   </Card>
 
-  <Card title="Contributing" href="/project/contributing">
+  <Card title="Contributing" icon="code-pull-request" href="/project/contributing">
     Review the development, documentation, issue, and pull request workflow.
   </Card>
 
-  <Card title="License" href="/project/license">
+  <Card title="License" icon="file-contract" href="/project/license">
     Review the Apache License 2.0 terms applying to the project and its contributions.
   </Card>
 
-  <Card title="GitHub issues" href="https://github.com/HivenetOSS/hivenet_router/issues">
+  <Card title="GitHub issues" icon="github" href="https://github.com/HivenetOSS/hivenet_router/issues">
     Report public bugs and discuss feature proposals that are not security or conduct incidents.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/project/contributing.mdx
+++ b/docs/project/contributing.mdx
@@ -10,23 +10,23 @@ The repository’s root [`CONTRIBUTING.md`](https://github.com/HivenetOSS/hivene
 
 By participating in the project, you agree to follow the [Code of conduct](/project/code-of-conduct).
 
-<CardGroup cols={2}>
-  <Card title="Report a bug" href="https://github.com/HivenetOSS/hivenet_router/issues">
+<Columns cols={2}>
+  <Card title="Report a bug" icon="bug" href="https://github.com/HivenetOSS/hivenet_router/issues">
     Share a reproducible problem with the affected version, configuration, and relevant logs.
   </Card>
 
-  <Card title="Propose a feature" href="https://github.com/HivenetOSS/hivenet_router/issues">
+  <Card title="Propose a feature" icon="lightbulb" href="https://github.com/HivenetOSS/hivenet_router/issues">
     Describe the use case and expected behavior before investing in a substantial implementation.
   </Card>
 
-  <Card title="Improve the documentation" href="https://github.com/HivenetOSS/hivenet_router/tree/main/docs">
+  <Card title="Improve the documentation" icon="book" href="https://github.com/HivenetOSS/hivenet_router/tree/main/docs">
     Correct stale commands, clarify behavior, improve examples, or add missing troubleshooting guidance.
   </Card>
 
-  <Card title="Open a pull request" href="https://github.com/HivenetOSS/hivenet_router/pulls">
+  <Card title="Open a pull request" icon="code-pull-request" href="https://github.com/HivenetOSS/hivenet_router/pulls">
     Submit a focused change with tests, verification details, and a clear explanation of the problem it solves.
   </Card>
-</CardGroup>
+</Columns>
 
 ## Development requirements
 
@@ -343,12 +343,20 @@ Useful documentation contributions include:
 
 When editing an existing technical page:
 
-1. Treat the current implementation as the source of truth.
-2. Preserve exact commands, flags, endpoints, schemas, and units.
-3. Distinguish verified behavior from guidance or interpretation.
-4. Do not add product claims that the repository does not support.
-5. Update related pages when one behavior affects several guides.
-6. Check internal links and sidebar placement.
+<Steps>
+  <Step title="Treat the current implementation as the source of truth.">
+  </Step>
+  <Step title="Preserve exact commands, flags, endpoints, schemas, and units.">
+  </Step>
+  <Step title="Distinguish verified behavior from guidance or interpretation.">
+  </Step>
+  <Step title="Do not add product claims that the repository does not support.">
+  </Step>
+  <Step title="Update related pages when one behavior affects several guides.">
+  </Step>
+  <Step title="Check internal links and sidebar placement.">
+  </Step>
+</Steps>
 
 When documentation and code disagree, verify the relevant implementation before deciding which one needs to change.
 
@@ -554,28 +562,28 @@ Before submitting:
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Canonical contribution guide" href="https://github.com/HivenetOSS/hivenet_router/blob/main/CONTRIBUTING.md">
+<Columns cols={3}>
+  <Card title="Canonical contribution guide" icon="book" href="https://github.com/HivenetOSS/hivenet_router/blob/main/CONTRIBUTING.md">
     Read the authoritative repository version of the contribution instructions.
   </Card>
 
-  <Card title="Code of conduct" href="/project/code-of-conduct">
+  <Card title="Code of conduct" icon="handshake" href="/project/code-of-conduct">
     Review the standards applying to project participation.
   </Card>
 
-  <Card title="License" href="/project/license">
+  <Card title="License" icon="scale-balanced" href="/project/license">
     Review the Apache License 2.0 terms applying to contributions.
   </Card>
 
-  <Card title="GitHub issues" href="https://github.com/HivenetOSS/hivenet_router/issues">
+  <Card title="GitHub issues" icon="circle-dot" href="https://github.com/HivenetOSS/hivenet_router/issues">
     Report bugs and discuss feature proposals.
   </Card>
 
-  <Card title="Pull requests" href="https://github.com/HivenetOSS/hivenet_router/pulls">
+  <Card title="Pull requests" icon="code-pull-request" href="https://github.com/HivenetOSS/hivenet_router/pulls">
     Review current work or submit a focused change.
   </Card>
 
-  <Card title="Detailed architecture" href="/reference/detailed-architecture">
+  <Card title="Detailed architecture" icon="sitemap" href="/reference/detailed-architecture">
     Understand the components and request paths affected by a code change.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/project/license.mdx
+++ b/docs/project/license.mdx
@@ -14,15 +14,15 @@ The license allows broad use, modification, and redistribution of the project, i
   The repository’s root [`LICENSE`](https://github.com/HivenetOSS/hivenet_router/blob/main/LICENSE) file is the authoritative text. When this summary and the license differ, the license controls.
 </Warning>
 
-<CardGroup cols={2}>
-  <Card title="Read the canonical license" href="https://github.com/HivenetOSS/hivenet_router/blob/main/LICENSE">
+<Columns cols={2}>
+  <Card title="Read the canonical license" icon="file-contract" href="https://github.com/HivenetOSS/hivenet_router/blob/main/LICENSE">
     Review the complete Apache License 2.0 terms distributed with Hivenet Router.
   </Card>
 
-  <Card title="Apache License 2.0" href="https://www.apache.org/licenses/LICENSE-2.0">
+  <Card title="Apache License 2.0" icon="feather" href="https://www.apache.org/licenses/LICENSE-2.0">
     Read the standard license text and supporting information from the Apache Software Foundation.
   </Card>
-</CardGroup>
+</Columns>
 
 ## At a glance
 
@@ -454,20 +454,20 @@ LICENSE
 
 in the repository root.
 
-<CardGroup cols={2}>
-  <Card title="Canonical license" href="https://github.com/HivenetOSS/hivenet_router/blob/main/LICENSE">
+<Columns cols={2}>
+  <Card title="Canonical license" icon="file-contract" href="https://github.com/HivenetOSS/hivenet_router/blob/main/LICENSE">
     Read and retain the complete Apache License 2.0 text distributed with Hivenet Router.
   </Card>
 
-  <Card title="Contributing" href="/project/contributing">
+  <Card title="Contributing" icon="code-pull-request" href="/project/contributing">
     Review how submitted contributions are licensed and accepted.
   </Card>
 
-  <Card title="Code of conduct" href="/project/code-of-conduct">
+  <Card title="Code of conduct" icon="handshake" href="/project/code-of-conduct">
     Review the standards applying to participation in the project.
   </Card>
 
-  <Card title="GitHub repository" href="https://github.com/HivenetOSS/hivenet_router">
+  <Card title="GitHub repository" icon="github" href="https://github.com/HivenetOSS/hivenet_router">
     Browse the source code and canonical project files.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/project/project-overview.mdx
+++ b/docs/project/project-overview.mdx
@@ -14,31 +14,31 @@ The source code, issue tracker, pull requests, and canonical project files live 
   The Project pages in this documentation summarize and link to those files rather than creating competing copies.
 </Note>
 
-<CardGroup cols={2}>
-  <Card title="GitHub repository" href="https://github.com/HivenetOSS/hivenet_router">
+<Columns cols={2}>
+  <Card title="GitHub repository" icon="github" href="https://github.com/HivenetOSS/hivenet_router">
     Browse the source code, branches, commits, issues, and pull requests.
   </Card>
 
-  <Card title="Repository README" href="https://github.com/HivenetOSS/hivenet_router/blob/main/README.md">
+  <Card title="Repository README" icon="book-open" href="https://github.com/HivenetOSS/hivenet_router/blob/main/README.md">
     Read the repository-level introduction, build example, feature summary, and source navigation.
   </Card>
 
-  <Card title="Contributing" href="/project/contributing">
+  <Card title="Contributing" icon="code-pull-request" href="/project/contributing">
     Learn how to report bugs, propose features, improve documentation, run tests, and submit a pull request.
   </Card>
 
-  <Card title="Code of conduct" href="/project/code-of-conduct">
+  <Card title="Code of conduct" icon="handshake" href="/project/code-of-conduct">
     Review the standards expected when participating in the project community.
   </Card>
 
-  <Card title="License" href="/project/license">
+  <Card title="License" icon="scale-balanced" href="/project/license">
     Understand how the Apache License 2.0 applies to using, modifying, and distributing Hivenet Router.
   </Card>
 
-  <Card title="Issues and pull requests" href="https://github.com/HivenetOSS/hivenet_router/issues">
+  <Card title="Issues and pull requests" icon="circle-dot" href="https://github.com/HivenetOSS/hivenet_router/issues">
     Report reproducible problems, discuss concrete proposals, and follow work in progress.
   </Card>
-</CardGroup>
+</Columns>
 
 ## Canonical project files
 
@@ -177,16 +177,16 @@ Contributions submitted for inclusion in Hivenet Router are licensed under the s
 
 Read the complete canonical files before contributing:
 
-<CardGroup cols={3}>
-  <Card title="Contributing" href="/project/contributing">
+<Columns cols={3}>
+  <Card title="Contributing" icon="code-pull-request" href="/project/contributing">
     Review the development and pull request workflow.
   </Card>
 
-  <Card title="Code of conduct" href="/project/code-of-conduct">
+  <Card title="Code of conduct" icon="handshake" href="/project/code-of-conduct">
     Review participation and enforcement standards.
   </Card>
 
-  <Card title="License" href="/project/license">
+  <Card title="License" icon="scale-balanced" href="/project/license">
     Review the project’s licensing terms.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -54,6 +54,34 @@ You need:
 
 The compiled Hivenet Router binaries do not require Go on the target machines.
 
+## Deployment path
+
+<Steps>
+  <Step title="Prepare the hosts">
+    Create the installation directory on the router and all three agent machines.
+  </Step>
+
+  <Step title="Build and secure the deployment">
+    Compile the router and agent binaries, distribute them, and create the shared JWT secret.
+  </Step>
+
+  <Step title="Start the inference backends">
+    Start two vLLM servers for the shared model and one Ollama server for the third agent.
+  </Step>
+
+  <Step title="Start the router and agents">
+    Launch the router, then connect each backend through its own agent process.
+  </Step>
+
+  <Step title="Verify registration">
+    Confirm that the router reports three healthy agents with the expected models, engines, and regions.
+  </Step>
+
+  <Step title="Send and observe requests">
+    Route a chat request, generate concurrent traffic, and inspect the Prometheus routing counter.
+  </Step>
+</Steps>
+
 ## Prepare the target machines
 
 On each router and agent machine, create the Hivenet Router directory:
@@ -416,74 +444,78 @@ curl -s http://192.168.1.100:2112/metrics \
 
 ## Troubleshooting
 
-### The router gRPC endpoint is unreachable
+<AccordionGroup>
+  <Accordion title="The router gRPC endpoint is unreachable" icon="network-wired">
+    On `router-server`, check that the port is listening:
 
-On `router-server`, check that the port is listening:
+    ```bash
+    ss -tlnp | grep 50051
+    ```
 
-```bash
-ss -tlnp | grep 50051
-```
+    On an agent machine, test connectivity to the router:
 
-On an agent machine, test connectivity to the router:
+    ```bash
+    nc -zv 192.168.1.100 50051
+    nc -zv 192.168.1.100 9000
+    ```
+  </Accordion>
 
-```bash
-nc -zv 192.168.1.100 50051
-nc -zv 192.168.1.100 9000
-```
+  <Accordion title="An agent does not register" icon="link-slash">
+    Check for these common causes:
 
-### An agent does not register
+    - `--router-grpc` points to the wrong or unreachable address
+    - the router is still listening for libp2p only on `127.0.0.1`
+    - the router advertises a libp2p address the agent cannot reach
+    - the router needs a correct `--p2p-announce-addr`
+    - the inference backend is not ready
+    - the router and agent use different JWT secrets
+  </Accordion>
 
-Check for these common causes:
+  <Accordion title="A backend is not ready" icon="server">
+    Check vLLM:
 
-- `--router-grpc` points to the wrong or unreachable address
-- the router is still listening for libp2p only on `127.0.0.1`
-- the router advertises a libp2p address the agent cannot reach
-- the router needs a correct `--p2p-announce-addr`
-- the inference backend is not ready
-- the router and agent use different JWT secrets
+    ```bash
+    curl http://localhost:8888/health
+    ```
 
-### A backend is not ready
+    Check Ollama:
 
-Check vLLM:
+    ```bash
+    curl http://localhost:11434/api/tags
+    ollama ps
+    ```
+  </Accordion>
 
-```bash
-curl http://localhost:8888/health
-```
+  <Accordion title="The JWT secret does not match" icon="key">
+    Confirm that every machine has the same secret:
 
-Check Ollama:
+    ```bash
+    sha256sum /opt/hivenet-router/jwt.secret
+    ```
 
-```bash
-curl http://localhost:11434/api/tags
-ollama ps
-```
+    The hash should be identical on the router and every agent host.
+  </Accordion>
 
-### The JWT secret does not match
+  <Accordion title="A firewall blocks the connection" icon="shield-halved">
+    The exact commands depend on your firewall. With UFW, a basic router configuration could look like:
 
-Confirm that every machine has the same secret:
+    ```bash
+    sudo ufw allow 50051/tcp
+    sudo ufw allow 9000/tcp
+    sudo ufw allow 8080/tcp
+    sudo ufw allow from <monitoring-ip> to any port 2112 proto tcp
+    ```
 
-```bash
-sha256sum /opt/hivenet-router/jwt.secret
-```
+    Agent hosts do not need an inbound Hivenet Router firewall rule. Allow their outbound connections to the router’s ports `50051` and `9000`.
 
-The hash should be identical on the router and every agent host.
-
-### A firewall blocks the connection
-
-The exact commands depend on your firewall. With UFW, a basic router configuration could look like:
-
-```bash
-sudo ufw allow 50051/tcp
-sudo ufw allow 9000/tcp
-sudo ufw allow 8080/tcp
-sudo ufw allow from <monitoring-ip> to any port 2112 proto tcp
-```
-
-Agent hosts do not need an inbound Hivenet Router firewall rule. Allow their outbound connections to the router’s ports `50051` and `9000`.
-
-<Warning>
-  These are examples, not a complete network-security policy. Restrict every port to the clients, agents, or monitoring systems that require access.
-</Warning>
+    <Warning>
+      These are examples, not a complete network-security policy. Restrict every port to the clients, agents, or monitoring systems that require access.
+    </Warning>
+  </Accordion>
+</AccordionGroup>
 
 ## Next step
 
-Read the [architecture overview](/getting-started/architecture-overview) to understand the router-agent control flow, data plane, storage, authentication, and routing pipeline.
+<Card title="Architecture overview" icon="network-wired" href="/getting-started/architecture-overview" horizontal>
+  Understand the router-agent control flow, data plane, storage, authentication, and routing pipeline.
+</Card>

--- a/docs/reference/configuration-reference.mdx
+++ b/docs/reference/configuration-reference.mdx
@@ -13,23 +13,52 @@ This page covers process-level router and agent configuration.
 
 See [auth.yaml reference](/security/auth-yaml-reference) and [Policy YAML reference](/routing/policy-yaml-reference) for the file schemas.
 
+## Find a setting
+
+<Columns cols={3}>
+  <Card title="Router network" icon="network-wired" href="#router-network-settings">
+    Listener addresses, libp2p discovery, timeouts, and persistence.
+  </Card>
+
+  <Card title="Routing and backpressure" icon="route" href="#router-routing-and-backpressure-settings">
+    Queue limits, retries, policies, sessions, and admission controls.
+  </Card>
+
+  <Card title="Security and authentication" icon="lock" href="#router-security-and-authentication-settings">
+    JWT secrets, client authentication, quotas, and audit output.
+  </Card>
+
+  <Card title="Agent backend" icon="microchip" href="#agent-backend-settings">
+    Inference engines, models, capabilities, and backend timeouts.
+  </Card>
+
+  <Card title="Agent telemetry" icon="chart-line" href="#agent-telemetry-settings">
+    Hardware sampling, routing signals, identity, and metadata.
+  </Card>
+
+  <Card title="Reload or restart" icon="rotate" href="#reload-or-restart">
+    See which changes are live-reloadable and which require a restart.
+  </Card>
+</Columns>
+
 ## View the installed options
 
 Use the binary’s built-in help to confirm the options available in the version you deployed:
 
-```bash
+<CodeGroup>
+
+```bash Router
 ./bin/hivenet-router --help
 ```
 
-```bash
+```bash Agent
 ./bin/hivenet-agent --help
 ```
 
-For API-key generation:
-
-```bash
+```bash Key generation
 ./bin/hivenet-router keygen --help
 ```
+</CodeGroup>
 
 <Note>
   The environment-variable prefix is exactly:
@@ -683,6 +712,8 @@ Changing the path requires a router restart.
 
 The complete current router flag set is:
 
+<Accordion title="Show all router flags" description="Flag, environment variable, and default value" icon="sliders">
+
 | Flag | Environment variable | Default |
 | --- | --- | --- |
 | `--http-port` | `HIVENET_ROUTER_HTTP_PORT` | `:8080` |
@@ -710,6 +741,8 @@ The complete current router flag set is:
 | `--session-ttl` | `HIVENET_ROUTER_SESSION_TTL` | `1h` |
 | `--jwt-secret-file` | `HIVENET_ROUTER_JWT_SECRET` contains the raw value | Required |
 | `--auth-config-file` | `HIVENET_ROUTER_AUTH_CONFIG` | Empty |
+
+</Accordion>
 
 ## Agent backend settings
 
@@ -1022,6 +1055,8 @@ See [Hardware metrics](/observability/hardware-metrics).
 
 The complete current agent flag set is:
 
+<Accordion title="Show all agent flags" description="Flag, environment variable, and default value" icon="sliders">
+
 | Flag | Environment variable | Default |
 | --- | --- | --- |
 | `--engine` | — | `vllm` |
@@ -1052,6 +1087,8 @@ The complete current agent flag set is:
 | `--hide-llm` | — | `false` |
 | `--llm-pretty-name` | — | Empty |
 | `--llm-info` | — | Empty |
+
+</Accordion>
 
 ## Logging configuration
 
@@ -1262,7 +1299,12 @@ Inspect the router logs after reload.
 
 An invalid file leaves the previous valid configuration active, but the attempted change has not taken effect.
 
-## Router startup example
+## Startup examples
+
+<Tabs>
+  <Tab title="Router">
+
+### Router startup example
 
 ```bash
 ./bin/hivenet-router \
@@ -1294,7 +1336,11 @@ This example:
 - uses a policy directory
 - persists state outside the working directory
 
-## vLLM agent example
+  </Tab>
+
+  <Tab title="vLLM agent">
+
+### vLLM agent example
 
 ```bash
 ./bin/hivenet-agent \
@@ -1320,7 +1366,11 @@ This example:
 
 The example does not set `--router-p2p`. The current agent receives the router’s dialable libp2p address during gRPC authentication.
 
-## Custom-engine example
+  </Tab>
+
+  <Tab title="Custom engine">
+
+### Custom-engine example
 
 ```bash
 ./bin/hivenet-agent \
@@ -1341,6 +1391,9 @@ The example does not set `--router-p2p`. The current agent receives the router�
 ```
 
 A custom engine must implement the client-facing endpoint used by the request. Hivenet Router does not translate its API schema.
+
+  </Tab>
+</Tabs>
 
 ## Generate a static client key
 
@@ -1373,28 +1426,28 @@ Store the raw key in a secret manager. Put only the generated hash in `auth.yaml
 
 ## Next steps
 
-<CardGroup cols={2}>
-  <Card title="auth.yaml reference" href="/security/auth-yaml-reference">
+<Columns cols={2}>
+  <Card title="auth.yaml reference" icon="key" href="/security/auth-yaml-reference">
     Configure static keys, administrator access, model restrictions, and quotas.
   </Card>
 
-  <Card title="Policy YAML reference" href="/routing/policy-yaml-reference">
+  <Card title="Policy YAML reference" icon="route" href="/routing/policy-yaml-reference">
     Configure primary routing, fallback chains, provider fallback, and gates.
   </Card>
 
-  <Card title="Detailed architecture" href="/reference/detailed-architecture">
+  <Card title="Detailed architecture" icon="sitemap" href="/reference/detailed-architecture">
     See where each configuration value affects the running system.
   </Card>
 
-  <Card title="Error codes" href="/reference/error-codes">
+  <Card title="Error codes" icon="triangle-exclamation" href="/reference/error-codes">
     Diagnose startup, authentication, routing, and backend failures.
   </Card>
 
-  <Card title="Key rotation" href="/security/key-rotation">
+  <Card title="Key rotation" icon="rotate" href="/security/key-rotation">
     Rotate client, administrator, agent, and provider credentials.
   </Card>
 
-  <Card title="Prometheus metrics" href="/observability/prometheus-metrics">
+  <Card title="Prometheus metrics" icon="chart-line" href="/observability/prometheus-metrics">
     Verify runtime behavior after configuration changes.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/reference/detailed-architecture.mdx
+++ b/docs/reference/detailed-architecture.mdx
@@ -1180,20 +1180,20 @@ The main implementation areas are:
 
 ## Next steps
 
-<CardGroup cols={2}>
-  <Card title="Configuration reference" href="/reference/configuration-reference">
+<Columns cols={2}>
+  <Card title="Configuration reference" icon="sliders" href="/reference/configuration-reference">
     Review router and agent flags, environment variables, defaults, and precedence.
   </Card>
 
-  <Card title="Error codes" href="/reference/error-codes">
+  <Card title="Error codes" icon="triangle-exclamation" href="/reference/error-codes">
     Understand failures from the HTTP API, routing system, agents, and backends.
   </Card>
 
-  <Card title="Performance characteristics" href="/reference/performance-characteristics">
+  <Card title="Performance characteristics" icon="gauge-high" href="/reference/performance-characteristics">
     Review bottlenecks, measurements, capacity limits, and benchmarking guidance.
   </Card>
 
-  <Card title="Architecture overview" href="/getting-started/architecture-overview">
+  <Card title="Architecture overview" icon="sitemap" href="/getting-started/architecture-overview">
     Return to the shorter conceptual explanation of the system.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/reference/error-codes.mdx
+++ b/docs/reference/error-codes.mdx
@@ -1239,41 +1239,63 @@ Official SDKs and frameworks may add their own automatic retries. Account for th
 
 A production client should:
 
-1. Parse structured errors when the body matches the Hivenet Router envelope.
-2. Preserve the HTTP status and `X-Request-ID`.
-3. Handle ordinary HTTP errors when no structured envelope exists.
-4. Distinguish temporary capacity failures from request defects.
-5. Apply bounded retries with exponential backoff and jitter.
-6. Avoid retrying unsafe or ambiguous operations automatically.
-7. Log the code, status, source, request ID, and model.
-8. Avoid logging credentials or complete sensitive prompts.
-9. Alert on sustained error rates rather than individual transient failures.
-10. Use audit records and traces for detailed investigation.
+<Steps>
+  <Step title="Parse structured errors">
+    Parse structured errors when the body matches the Hivenet Router envelope.
+  </Step>
+  <Step title="Preserve the HTTP status and `X-Request-ID`">
+    Preserve the HTTP status and `X-Request-ID`.
+  </Step>
+  <Step title="Handle ordinary HTTP errors when no structured envelope exists">
+    Handle ordinary HTTP errors when no structured envelope exists.
+  </Step>
+  <Step title="Distinguish temporary capacity failures from request defects">
+    Distinguish temporary capacity failures from request defects.
+  </Step>
+  <Step title="Apply bounded retries with exponential backoff and jitter">
+    Apply bounded retries with exponential backoff and jitter.
+  </Step>
+  <Step title="Avoid retrying unsafe or ambiguous operations automatically">
+    Avoid retrying unsafe or ambiguous operations automatically.
+  </Step>
+  <Step title="Log the code, status, source, request ID, and model">
+    Log the code, status, source, request ID, and model.
+  </Step>
+  <Step title="Avoid logging credentials or complete sensitive prompts">
+    Avoid logging credentials or complete sensitive prompts.
+  </Step>
+  <Step title="Alert on sustained error rates rather than individual transient failures">
+    Alert on sustained error rates rather than individual transient failures.
+  </Step>
+  <Step title="Use audit records and traces for detailed investigation">
+    Use audit records and traces for detailed investigation.
+  </Step>
+</Steps>
 
 ## Next steps
 
-<CardGroup cols={2}>
-  <Card title="Performance characteristics" href="/reference/performance-characteristics">
+<Columns cols={2}>
+  <Card title="Performance characteristics" icon="gauge-high" href="/reference/performance-characteristics">
     Understand queueing, concurrency, latency, throughput, and benchmarking behavior.
   </Card>
 
-  <Card title="Use from code" href="/integrations/use-from-code">
+  <Card title="Use from code" icon="code" href="/integrations/use-from-code">
     Handle Hivenet Router errors from Python, JavaScript, SDKs, and direct HTTP clients.
   </Card>
 
-  <Card title="Routing concepts" href="/routing/routing-concepts">
+  <Card title="Routing concepts" icon="route" href="/routing/routing-concepts">
     See how retries, fallback steps, capacity, and policy exhaustion affect the final response.
   </Card>
 
-  <Card title="API keys" href="/security/api-keys">
+  <Card title="API keys" icon="key" href="/security/api-keys">
     Configure the request and token quotas behind `429` responses.
   </Card>
 
-  <Card title="Admin endpoints" href="/use-the-api/admin-endpoints">
+  <Card title="Admin endpoints" icon="screwdriver-wrench" href="/use-the-api/admin-endpoints">
     Diagnose fleet health, capacity, routing state, and dynamic key errors.
   </Card>
 
-  <Card title="Audit logging" href="/observability/audit-logging">
+  <Card title="Audit logging" icon="file-lines" href="/observability/audit-logging">
     Correlate error codes with tenants, models, agents, request IDs, and traces.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/reference/performance-characteristics.mdx
+++ b/docs/reference/performance-characteristics.mdx
@@ -1281,28 +1281,28 @@ X ms across N requests, measured from these trace spans at commit Y.
 
 ## Next steps
 
-<CardGroup cols={2}>
-  <Card title="Detailed architecture" href="/reference/detailed-architecture">
+<Columns cols={2}>
+  <Card title="Detailed architecture" icon="sitemap" href="/reference/detailed-architecture">
     Review the request, queue, policy, transport, and storage paths behind these characteristics.
   </Card>
 
-  <Card title="Configuration reference" href="/reference/configuration-reference">
+  <Card title="Configuration reference" icon="sliders" href="/reference/configuration-reference">
     Tune concurrency, queueing, timeouts, sampling, storage, and agent capacity.
   </Card>
 
-  <Card title="Prometheus metrics" href="/observability/prometheus-metrics">
+  <Card title="Prometheus metrics" icon="chart-line" href="/observability/prometheus-metrics">
     Query router, process, queue, agent, engine, hardware, and tenant performance.
   </Card>
 
-  <Card title="Engine metrics" href="/observability/engine-metrics">
+  <Card title="Engine metrics" icon="microchip" href="/observability/engine-metrics">
     Measure backend queueing, cache pressure, TTFT, ITL, and throughput.
   </Card>
 
-  <Card title="Latency tracking" href="/observability/latency-tracking">
+  <Card title="Latency tracking" icon="stopwatch" href="/observability/latency-tracking">
     Understand SRTT, RTTVAR, and the different streaming and non-streaming boundaries.
   </Card>
 
-  <Card title="Error codes" href="/reference/error-codes">
+  <Card title="Error codes" icon="triangle-exclamation" href="/reference/error-codes">
     Diagnose capacity, queue, backend, connection, and timeout failures during load.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/routing/admission-control.mdx
+++ b/docs/routing/admission-control.mdx
@@ -11,19 +11,37 @@ Admission control applies to:
 - `POST /v1/chat/completions`
 - `POST /v1/messages`
 
-`POST /v1/messages/count_tokens` is deliberately exempt. It runs no model and consumes no KV cache, so it skips the input and image caps, pressure shed, occupancy budgets, per-key token rates, and daily token budget. It remains protected by the request-per-minute limiter.
+<Info>
+  `POST /v1/messages/count_tokens` is deliberately exempt. It runs no model and consumes no KV cache, so it skips the input and image caps, pressure shed, occupancy budgets, per-key token rates, and daily token budget. It remains protected by the request-per-minute limiter.
 
-Embedding and reranking requests are also exempt because these gates model KV-cache-bound generation. Their request-rate, body-size, and agent-concurrency protections still apply.
+  Embedding and reranking requests are also exempt because these gates model KV-cache-bound generation. Their request-rate, body-size, and agent-concurrency protections still apply.
+</Info>
 
 ## Gate order
 
 After authentication and the request-per-minute check, the LLM handler evaluates:
 
-1. **B1: request caps** — input-token and image-count limits
-2. **B3: pressure shed** — live pressure across healthy replicas
-3. **B2: pool occupancy** — token-weighted occupancy and `max_inflight`
-4. **B4: serverless key limits** — per-key occupancy share, output-rate state, and input tokens per minute
-5. **Daily token admission** — the existing tenant token budget
+<Steps>
+  <Step title="B1: Request caps">
+    Enforce the model’s input-token and image-count limits.
+  </Step>
+
+  <Step title="B3: Pressure shed">
+    Evaluate live pressure across healthy replicas before the request enters the queue.
+  </Step>
+
+  <Step title="B2: Pool occupancy">
+    Reserve token-weighted occupancy and enforce the `max_inflight` request backstop.
+  </Step>
+
+  <Step title="B4: Serverless key limits">
+    In serverless mode, check the key’s occupancy share, output-rate state, and input tokens per minute.
+  </Step>
+
+  <Step title="Daily token admission">
+    Apply the existing tenant token budget after the admission-specific gates pass.
+  </Step>
+</Steps>
 
 If a later check rejects the request, every occupancy reservation already taken is released.
 
@@ -143,7 +161,9 @@ shed_if:
 
 The router averages each available signal across healthy agents serving the requested model. If any configured threshold fails, it returns HTTP `429`, sets `Retry-After: 1`, and uses `concurrency_limit_exceeded` with the message `model is under high load, please retry`.
 
-Missing engine signals pass the gate. A single hot replica should normally be handled by per-agent `exclude_if`; `shed_if` is for pressure across the pool.
+<Info>
+  Missing engine signals pass the gate. A single hot replica should normally be handled by per-agent `exclude_if`; `shed_if` is for pressure across the pool.
+</Info>
 
 ## B4: serverless key limits
 
@@ -206,24 +226,24 @@ Every five minutes, the router removes full rate buckets, daily buckets from a p
 
 ## Related pages
 
-<CardGroup cols={2}>
-  <Card title="Policy YAML reference" href="/routing/policy-yaml-reference">
+<Columns cols={2}>
+  <Card title="Policy YAML reference" icon="file-code" href="/routing/policy-yaml-reference">
     Review every routing and admission field.
   </Card>
 
-  <Card title="auth.yaml reference" href="/security/auth-yaml-reference">
+  <Card title="auth.yaml reference" icon="key" href="/security/auth-yaml-reference">
     Configure RPM, daily token, and serverless per-key limits.
   </Card>
 
-  <Card title="Error codes" href="/reference/error-codes">
+  <Card title="Error codes" icon="triangle-exclamation" href="/reference/error-codes">
     Handle admission, routing, and backend failures.
   </Card>
 
-  <Card title="Configuration reference" href="/reference/configuration-reference">
+  <Card title="Configuration reference" icon="sliders" href="/reference/configuration-reference">
     Review admission environment variables and defaults.
   </Card>
 
-  <Card title="Admission control metrics" href="/observability/admission-control-metrics">
+  <Card title="Admission control metrics" icon="chart-line" href="/observability/admission-control-metrics">
     Monitor occupancy, budgets, concurrency, and rejections by gate.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/routing/fallback-chains.mdx
+++ b/docs/routing/fallback-chains.mdx
@@ -798,112 +798,114 @@ Fallback is a continuity mechanism. It should not quietly become the normal rout
 
 ## Troubleshooting
 
-### The chain skips a step
+<AccordionGroup>
+  <Accordion title="The chain skips a step">
+    Check whether the step had any eligible agents.
 
-Check whether the step had any eligible agents.
+    Inspect registered metadata:
 
-Inspect registered metadata:
+    ```bash
+    curl \
+      -H "Authorization: Bearer <admin-api-key>" \
+      http://localhost:8080/admin/routing-table \
+      -H "Authorization: Bearer <admin-api-key>" \
+      | jq '.agents[] | {
+          model: .metadata.model,
+          capability: .metadata.capability,
+          engine: .metadata.engine,
+          region: .metadata.region,
+          tags: .metadata.tags,
+          healthy: .status.healthy,
+          backend_healthy: .status.backend_healthy
+        }'
+    ```
 
-```bash
-curl \
-  -H "Authorization: Bearer <admin-api-key>" \
-  http://localhost:8080/admin/routing-table \
-  -H "Authorization: Bearer <admin-api-key>" \
-  | jq '.agents[] | {
-      model: .metadata.model,
-      capability: .metadata.capability,
-      engine: .metadata.engine,
-      region: .metadata.region,
-      tags: .metadata.tags,
-      healthy: .status.healthy,
-      backend_healthy: .status.backend_healthy
-    }'
-```
+    All static match values are exact and case-sensitive.
+  </Accordion>
 
-All static match values are exact and case-sensitive.
+  <Accordion title="A failed agent is tried again">
+    An agent is excluded only for the remainder of the current step.
 
-### A failed agent is tried again
+    It can become eligible again in a later fallback step because each step has its own failed-agent set and retry budget.
 
-An agent is excluded only for the remainder of the current step.
+    Avoid overlapping steps when retrying the same agents is not useful.
 
-It can become eligible again in a later fallback step because each step has its own failed-agent set and retry budget.
+    For example, these steps overlap completely:
 
-Avoid overlapping steps when retrying the same agents is not useful.
+    ```yaml
+    routing_policy:
+      match:
+        engine: vllm
+      strategy: least-loaded
+    
+    fallback_chain:
+      - name: same-agents-again
+        match:
+          engine: vllm
+        strategy: least-loaded
+    ```
 
-For example, these steps overlap completely:
+    The fallback may retry agents already attempted in the primary step.
+  </Accordion>
 
-```yaml
-routing_policy:
-  match:
-    engine: vllm
-  strategy: least-loaded
+  <Accordion title="Requests wait instead of falling back">
+    Matching agents are probably at capacity and queueing is enabled.
 
-fallback_chain:
-  - name: same-agents-again
-    match:
-      engine: vllm
-    strategy: least-loaded
-```
+    Check:
 
-The fallback may retry agents already attempted in the primary step.
+    ```bash
+    --queue-depth
+    --request-timeout
+    ```
 
-### Requests wait instead of falling back
+    Disable queueing for immediate fallback:
 
-Matching agents are probably at capacity and queueing is enabled.
+    ```bash
+    --queue-depth 0
+    ```
+  </Accordion>
 
-Check:
+  <Accordion title="A fallback engine is never selected">
+    Confirm that it:
 
-```bash
---queue-depth
---request-timeout
-```
+    - registers the same model name
+    - serves the same capability
+    - passes the step’s static filters
+    - passes its dynamic gates
+    - is healthy
+    - has free capacity
+  </Accordion>
 
-Disable queueing for immediate fallback:
+  <Accordion title="Provider fallback is not reached">
+    Check that:
 
-```bash
---queue-depth 0
-```
+    - all local steps are exhausted
+    - the request has not already exceeded its deadline
+    - the request uses the `llm` capability
+    - `fallback_provider` is at the top level
+    - the provider engine and model are configured
+    - the corresponding API key environment variable is set
+  </Accordion>
 
-### A fallback engine is never selected
+  <Accordion title="The exhausted metric increases despite provider fallback">
+    `hivenet_router_policy_exhausted_total` also increases when the local chain is exhausted and the configured provider fallback fails.
 
-Confirm that it:
-
-- registers the same model name
-- serves the same capability
-- passes the step’s static filters
-- passes its dynamic gates
-- is healthy
-- has free capacity
-
-### Provider fallback is not reached
-
-Check that:
-
-- all local steps are exhausted
-- the request has not already exceeded its deadline
-- the request uses the `llm` capability
-- `fallback_provider` is at the top level
-- the provider engine and model are configured
-- the corresponding API key environment variable is set
-
-### The exhausted metric increases despite provider fallback
-
-`hivenet_router_policy_exhausted_total` also increases when the local chain is exhausted and the configured provider fallback fails.
-
-Check provider logs and outbound HTTP metrics before assuming the router returned a normal local-capacity error.
+    Check provider logs and outbound HTTP metrics before assuming the router returned a normal local-capacity error.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Provider fallback" href="/routing/provider-fallback">
+<Columns cols={3}>
+  <Card title="Provider fallback" icon="cloud-arrow-up" href="/routing/provider-fallback">
     Configure OpenAI or Anthropic after all local routing options fail.
   </Card>
 
-  <Card title="Policy gates" href="/routing/policy-gates">
+  <Card title="Policy gates" icon="filter" href="/routing/policy-gates">
     Apply practical health, cache, latency, and hardware thresholds.
   </Card>
 
-  <Card title="Prometheus metrics" href="/observability/prometheus-metrics">
+  <Card title="Prometheus metrics" icon="chart-line" href="/observability/prometheus-metrics">
     Monitor fallback, exhaustion, queueing, failures, and routing activity.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/routing/policy-gates.mdx
+++ b/docs/routing/policy-gates.mdx
@@ -1009,16 +1009,16 @@ Keep routing policy and alerting policy separate.
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Prometheus metrics" href="/observability/prometheus-metrics">
+<Columns cols={3}>
+  <Card title="Prometheus metrics" icon="chart-line" href="/observability/prometheus-metrics">
     Observe the live metrics used by routing gates.
   </Card>
 
-  <Card title="Hardware metrics" href="/observability/hardware-metrics">
+  <Card title="Hardware metrics" icon="microchip" href="/observability/hardware-metrics">
     Understand GPU, CPU, and memory values reported by agents.
   </Card>
 
-  <Card title="Engine metrics" href="/observability/engine-metrics">
+  <Card title="Engine metrics" icon="gauge-high" href="/observability/engine-metrics">
     Review cache, queue, TTFT, ITL, and throughput signals from supported engines.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/routing/policy-yaml-reference.mdx
+++ b/docs/routing/policy-yaml-reference.mdx
@@ -1069,82 +1069,84 @@ Before loading a policy, check that:
 
 ## Troubleshooting
 
-### The router rejects the policy
+<AccordionGroup>
+  <Accordion title="The router rejects the policy">
+    Check its logs for the first validation error.
 
-Check its logs for the first validation error.
+    Common causes include:
 
-Common causes include:
+    - missing `strategy`
+    - unsupported strategy
+    - unknown metric field
+    - missing comparison operator
+    - several operators on one metric
+    - missing provider engine or model
+    - provider API key not configured
+    - invalid YAML indentation
+  </Accordion>
 
-- missing `strategy`
-- unsupported strategy
-- unknown metric field
-- missing comparison operator
-- several operators on one metric
-- missing provider engine or model
-- provider API key not configured
-- invalid YAML indentation
+  <Accordion title="A policy file is ignored">
+    For a named file, check that:
 
-### A policy file is ignored
+    - its extension is `.yaml` or `.yml`
+    - it contains a non-empty `models` array
+    - another file does not already claim one of its models
+    - it passed YAML and policy validation
+  </Accordion>
 
-For a named file, check that:
+  <Accordion title="A model uses the global policy">
+    Confirm that the model name in the file exactly matches the model registered by the agent:
 
-- its extension is `.yaml` or `.yml`
-- it contains a non-empty `models` array
-- another file does not already claim one of its models
-- it passed YAML and policy validation
+    ```bash
+    curl \
+      -H "Authorization: Bearer <admin-api-key>" \
+      http://localhost:8080/admin/models \
+      -H "Authorization: Bearer <admin-api-key>" \
+      | jq -r '.data[].id'
+    ```
 
-### A model uses the global policy
+    Model names are case-sensitive.
+  </Accordion>
 
-Confirm that the model name in the file exactly matches the model registered by the agent:
+  <Accordion title="A gate does not exclude an agent">
+    Inspect the live value:
 
-```bash
-curl \
-  -H "Authorization: Bearer <admin-api-key>" \
-  http://localhost:8080/admin/models \
-  -H "Authorization: Bearer <admin-api-key>" \
-  | jq -r '.data[].id'
-```
+    ```bash
+    curl \
+      -H "Authorization: Bearer <admin-api-key>" \
+      http://localhost:8080/admin/routing-table \
+      -H "Authorization: Bearer <admin-api-key>" \
+      | jq '.agents[]'
+    ```
 
-Model names are case-sensitive.
+    The metric may be unavailable, use another unit, or remain unset until the agent has served requests.
+  </Accordion>
 
-### A gate does not exclude an agent
+  <Accordion title="A changed policy does not take effect">
+    File changes are not watched continuously.
 
-Inspect the live value:
+    Send `SIGHUP`:
 
-```bash
-curl \
-  -H "Authorization: Bearer <admin-api-key>" \
-  http://localhost:8080/admin/routing-table \
-  -H "Authorization: Bearer <admin-api-key>" \
-  | jq '.agents[]'
-```
+    ```bash
+    sudo kill -HUP "$(pgrep hivenet-router)"
+    ```
 
-The metric may be unavailable, use another unit, or remain unset until the agent has served requests.
-
-### A changed policy does not take effect
-
-File changes are not watched continuously.
-
-Send `SIGHUP`:
-
-```bash
-sudo kill -HUP "$(pgrep hivenet-router)"
-```
-
-Then inspect the router logs for the reload result.
+    Then inspect the router logs for the reload result.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Fallback chains" href="/routing/fallback-chains">
+<Columns cols={3}>
+  <Card title="Fallback chains" icon="link" href="/routing/fallback-chains">
     Build ordered local alternatives with independent filters and retry budgets.
   </Card>
 
-  <Card title="Provider fallback" href="/routing/provider-fallback">
+  <Card title="Provider fallback" icon="cloud-arrow-up" href="/routing/provider-fallback">
     Configure OpenAI or Anthropic as a final fallback for chat requests.
   </Card>
 
-  <Card title="Policy gates" href="/routing/policy-gates">
+  <Card title="Policy gates" icon="filter" href="/routing/policy-gates">
     Review practical gate patterns for health, latency, cache, and hardware pressure.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/routing/provider-fallback.mdx
+++ b/docs/routing/provider-fallback.mdx
@@ -835,117 +835,119 @@ After rotating a provider key:
 
 ## Troubleshooting
 
-### The router does not start
+<AccordionGroup>
+  <Accordion title="The router does not start">
+    Check the error message.
 
-Check the error message.
+    If the policy uses OpenAI, confirm:
 
-If the policy uses OpenAI, confirm:
+    ```bash
+    echo "${HIVENET_ROUTER_OPENAI_API_KEY:+configured}"
+    ```
 
-```bash
-echo "${HIVENET_ROUTER_OPENAI_API_KEY:+configured}"
-```
+    If it uses Anthropic:
 
-If it uses Anthropic:
+    ```bash
+    echo "${HIVENET_ROUTER_ANTHROPIC_API_KEY:+configured}"
+    ```
 
-```bash
-echo "${HIVENET_ROUTER_ANTHROPIC_API_KEY:+configured}"
-```
+    Also check that the policy engine is exactly:
 
-Also check that the policy engine is exactly:
+    ```text
+    openai
+    ```
 
-```text
-openai
-```
+    or:
 
-or:
+    ```text
+    anthropic
+    ```
+  </Accordion>
 
-```text
-anthropic
-```
+  <Accordion title="A policy reload is rejected">
+    A policy added through `SIGHUP` or the admin API is validated against the provider credentials loaded at router startup.
 
-### A policy reload is rejected
+    Adding the environment variable to your shell after the router is running is not enough. Restart the router so it can create the provider adapter.
+  </Accordion>
 
-A policy added through `SIGHUP` or the admin API is validated against the provider credentials loaded at router startup.
+  <Accordion title="Fallback is never attempted">
+    Check that:
 
-Adding the environment variable to your shell after the router is running is not enough. Restart the router so it can create the provider adapter.
+    - every local routing step was exhausted
+    - the request uses the `llm` capability
+    - the request did not fail with a non-retryable client error
+    - `fallback_provider` is at the policy’s top level
+    - the request deadline has not already expired
 
-### Fallback is never attempted
+    Enable debug logs:
 
-Check that:
+    ```bash
+    export GOLOG_LOG_LEVEL="policy=debug,router=debug"
+    ```
+  </Accordion>
 
-- every local routing step was exhausted
-- the request uses the `llm` capability
-- the request did not fail with a non-retryable client error
-- `fallback_provider` is at the policy’s top level
-- the request deadline has not already expired
+  <Accordion title="The provider model is rejected">
+    The external model name is independent of the model registered in Hivenet Router.
 
-Enable debug logs:
+    Confirm that:
 
-```bash
-export GOLOG_LOG_LEVEL="policy=debug,router=debug"
-```
+    - the model exists at the provider
+    - the provider account may access it
+    - the model name is spelled exactly
+    - the credential belongs to the expected provider account or project
+  </Accordion>
 
-### The provider model is rejected
+  <Accordion title="OpenAI fallback fails only for streaming requests">
+    Set:
 
-The external model name is independent of the model registered in Hivenet Router.
+    ```json
+    {
+      "stream": false
+    }
+    ```
 
-Confirm that:
+    The current provider adapter expects one JSON response and cannot decode an SSE stream.
+  </Accordion>
 
-- the model exists at the provider
-- the provider account may access it
-- the model name is spelled exactly
-- the credential belongs to the expected provider account or project
+  <Accordion title="Anthropic fallback loses system or content data">
+    System-role messages are joined into the top-level Anthropic `system` field.
 
-### OpenAI fallback fails only for streaming requests
+    Anthropic-native top-level fields and non-text content may not survive the conversion into Hivenet Router’s internal OpenAI-style request.
 
-Set:
+    Use a simple text Chat Completions request when provider fallback must behave predictably.
+  </Accordion>
 
-```json
-{
-  "stream": false
-}
-```
+  <Accordion title="Anthropic returns a tool-use response and fallback fails">
+    The current response translator requires at least one text content block.
 
-The current provider adapter expects one JSON response and cannot decode an SSE stream.
+    Tool-only responses are treated as provider errors.
 
-### Anthropic fallback loses system or content data
+    Do not depend on Anthropic tools through provider fallback in the current implementation.
+  </Accordion>
 
-System-role messages are joined into the top-level Anthropic `system` field.
+  <Accordion title="The provider call times out">
+    Check how much of the original request deadline was consumed by:
 
-Anthropic-native top-level fields and non-text content may not survive the conversion into Hivenet Router’s internal OpenAI-style request.
+    - local retries
+    - capacity waiting
+    - local fallback steps
 
-Use a simple text Chat Completions request when provider fallback must behave predictably.
-
-### Anthropic returns a tool-use response and fallback fails
-
-The current response translator requires at least one text content block.
-
-Tool-only responses are treated as provider errors.
-
-Do not depend on Anthropic tools through provider fallback in the current implementation.
-
-### The provider call times out
-
-Check how much of the original request deadline was consumed by:
-
-- local retries
-- capacity waiting
-- local fallback steps
-
-Increase the router request timeout only after considering the effect on client latency and queued work.
+    Increase the router request timeout only after considering the effect on client latency and queued work.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Policy gates" href="/routing/policy-gates">
+<Columns cols={3}>
+  <Card title="Policy gates" icon="filter" href="/routing/policy-gates">
     Apply practical health, latency, cache, and hardware thresholds.
   </Card>
 
-  <Card title="Prometheus metrics" href="/observability/prometheus-metrics">
+  <Card title="Prometheus metrics" icon="chart-line" href="/observability/prometheus-metrics">
     Monitor provider usage, latency, failures, and policy exhaustion.
   </Card>
 
-  <Card title="Audit logging" href="/observability/audit-logging">
+  <Card title="Audit logging" icon="file-lines" href="/observability/audit-logging">
     Record request outcomes, tenants, models, and routing behavior.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/routing/routing-concepts.mdx
+++ b/docs/routing/routing-concepts.mdx
@@ -712,86 +712,88 @@ export GOLOG_LOG_LEVEL="policy=debug,router=debug"
 
 ## Troubleshooting
 
-### The policy does not load
+<AccordionGroup>
+  <Accordion title="The policy does not load">
+    Check the router logs for validation errors.
 
-Check the router logs for validation errors.
+    Common causes include:
 
-Common causes include:
+    - missing `strategy`
+    - an unknown strategy
+    - a misspelled `exclude_if` field
+    - no comparison operator
+    - several operators on one gate
+    - an incomplete provider fallback
+    - invalid YAML indentation
 
-- missing `strategy`
-- an unknown strategy
-- a misspelled `exclude_if` field
-- no comparison operator
-- several operators on one gate
-- an incomplete provider fallback
-- invalid YAML indentation
+    Only `least-loaded` is currently accepted as a strategy.
+  </Accordion>
 
-Only `least-loaded` is currently accepted as a strategy.
+  <Accordion title="An agent does not match">
+    All match values are exact and case-sensitive.
 
-### An agent does not match
+    Compare the policy with live metadata:
 
-All match values are exact and case-sensitive.
+    ```bash
+    curl \
+      -H "Authorization: Bearer <admin-api-key>" \
+      http://localhost:8080/admin/routing-table \
+      | jq '.agents[] | {
+          model: .metadata.model,
+          engine: .metadata.engine,
+          region: .metadata.region,
+          organization: .metadata.organization,
+          machine: .metadata.machine,
+          tags: .metadata.tags,
+          gpu_model: .metadata.gpu_model
+        }'
+    ```
 
-Compare the policy with live metadata:
+    Check that every tag in the policy appears on the agent.
+  </Accordion>
 
-```bash
-curl \
-  -H "Authorization: Bearer <admin-api-key>" \
-  http://localhost:8080/admin/routing-table \
-  | jq '.agents[] | {
-      model: .metadata.model,
-      engine: .metadata.engine,
-      region: .metadata.region,
-      organization: .metadata.organization,
-      machine: .metadata.machine,
-      tags: .metadata.tags,
-      gpu_model: .metadata.gpu_model
-    }'
-```
+  <Accordion title="A metric gate does not exclude an agent">
+    The metric may be unavailable.
 
-Check that every tag in the policy appears on the agent.
+    Inspect the agent through the routing table and confirm that the relevant engine or hardware field is present.
 
-### A metric gate does not exclude an agent
+    Missing metrics skip the gate.
+  </Accordion>
 
-The metric may be unavailable.
+  <Accordion title="Requests wait instead of falling back">
+    Matching agents may exist but be at capacity.
 
-Inspect the agent through the routing table and confirm that the relevant engine or hardware field is present.
+    Hivenet Router waits in the per-model queue before advancing to fallback. Reduce or disable the queue when immediate fallback is more appropriate:
 
-Missing metrics skip the gate.
+    ```bash
+    --queue-depth 0
+    ```
+  </Accordion>
 
-### Requests wait instead of falling back
+  <Accordion title="An external provider is never called">
+    Check that:
 
-Matching agents may exist but be at capacity.
-
-Hivenet Router waits in the per-model queue before advancing to fallback. Reduce or disable the queue when immediate fallback is more appropriate:
-
-```bash
---queue-depth 0
-```
-
-### An external provider is never called
-
-Check that:
-
-- every local policy step was exhausted
-- the request is a language-model chat request
-- `fallback_provider` is at the policy’s top level
-- the engine is `openai` or `anthropic`
-- the corresponding environment variable is configured
-- the provider model is not empty
+    - every local policy step was exhausted
+    - the request is a language-model chat request
+    - `fallback_provider` is at the policy’s top level
+    - the engine is `openai` or `anthropic`
+    - the corresponding environment variable is configured
+    - the provider model is not empty
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Policy YAML reference" href="/routing/policy-yaml-reference">
+<Columns cols={3}>
+  <Card title="Policy YAML reference" icon="file-code" href="/routing/policy-yaml-reference">
     Review the complete policy schema, fields, operators, and validation rules.
   </Card>
 
-  <Card title="Fallback chains" href="/routing/fallback-chains">
+  <Card title="Fallback chains" icon="link" href="/routing/fallback-chains">
     Configure ordered local alternatives and retry budgets.
   </Card>
 
-  <Card title="Provider fallback" href="/routing/provider-fallback">
+  <Card title="Provider fallback" icon="cloud-arrow-up" href="/routing/provider-fallback">
     Add OpenAI or Anthropic as a final fallback for chat requests.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/security/api-keys.mdx
+++ b/docs/security/api-keys.mdx
@@ -832,140 +832,142 @@ The router refuses to start with unauthenticated administrator endpoints unless 
 
 ## Troubleshooting
 
-### Every request returns `401 unauthorized`
+<AccordionGroup>
+  <Accordion title="Every request returns `401 unauthorized`">
+    Check that:
 
-Check that:
+    - the router is using `api-key` or `dynamic` mode
+    - the application sends the raw key rather than the hash
+    - the `Authorization` header reaches the router
+    - a static hash matches the exact raw key
+    - the static key has not expired
+    - the dynamic key is enabled
+    - the dynamic registry has been repopulated after restart
 
-- the router is using `api-key` or `dynamic` mode
-- the application sends the raw key rather than the hash
-- the `Authorization` header reaches the router
-- a static hash matches the exact raw key
-- the static key has not expired
-- the dynamic key is enabled
-- the dynamic registry has been repopulated after restart
+    Hivenet Router does not reveal which authentication condition failed.
+  </Accordion>
 
-Hivenet Router does not reveal which authentication condition failed.
+  <Accordion title="A static key does not load">
+    Check the router logs.
 
-### A static key does not load
+    Common causes include:
 
-Check the router logs.
+    - empty `key_hash`
+    - empty `metadata.name`
+    - empty `metadata.owner`
+    - duplicate hashes
+    - invalid `expires_at`
+    - invalid quota configuration
+    - empty `api.keys` while mode is `api-key`
 
-Common causes include:
+    The previous provider remains active when a SIGHUP reload fails.
+  </Accordion>
 
-- empty `key_hash`
-- empty `metadata.name`
-- empty `metadata.owner`
-- duplicate hashes
-- invalid `expires_at`
-- invalid quota configuration
-- empty `api.keys` while mode is `api-key`
+  <Accordion title="A key can see the wrong models">
+    Check whether the key uses:
 
-The previous provider remains active when a SIGHUP reload fails.
+    ```yaml
+    models:
+    ```
 
-### A key can see the wrong models
+    or:
 
-Check whether the key uses:
+    ```yaml
+    quota:
+      per_model:
+    ```
 
-```yaml
-models:
-```
+    When `quota.per_model` exists, its keys define the effective allowlist and take precedence over `models`.
+  </Accordion>
 
-or:
+  <Accordion title="Several keys consume one quota unexpectedly">
+    Check their owner values.
 
-```yaml
-quota:
-  per_model:
-```
+    Keys with the same:
 
-When `quota.per_model` exists, its keys define the effective allowlist and take precedence over `models`.
+    ```yaml
+    metadata:
+      owner: acme-corp
+    ```
 
-### Several keys consume one quota unexpectedly
+    share quota buckets.
 
-Check their owner values.
+    Assign different owners when the limits should remain independent.
+  </Accordion>
 
-Keys with the same:
+  <Accordion title="The effective per-model RPM is unexpected">
+    The rate is:
 
-```yaml
-metadata:
-  owner: acme-corp
-```
+    ```text
+    requests_per_minute_per_replica
+    × healthy agents serving the model
+    ```
 
-share quota buckets.
+    Check the current healthy replica count:
 
-Assign different owners when the limits should remain independent.
+    ```bash
+    curl \
+      -H "Authorization: Bearer <admin-key>" \
+      http://localhost:8080/admin/models/<model> \
+      | jq '.agents.healthy'
+    ```
+  </Accordion>
 
-### The effective per-model RPM is unexpected
+  <Accordion title="Daily usage resets after restart">
+    The quota backend is probably using:
 
-The rate is:
+    ```text
+    memory
+    ```
 
-```text
-requests_per_minute_per_replica
-× healthy agents serving the model
-```
+    Enable:
 
-Check the current healthy replica count:
+    ```bash
+    HIVENET_ROUTER_QUOTA_BACKEND=badger
+    ```
 
-```bash
-curl \
-  -H "Authorization: Bearer <admin-key>" \
-  http://localhost:8080/admin/models/<model> \
-  | jq '.agents.healthy'
-```
+    to persist daily token use.
 
-### Daily usage resets after restart
+    Request-per-minute state remains in memory by design.
+  </Accordion>
 
-The quota backend is probably using:
+  <Accordion title="A dynamic update returns `409 stale version`">
+    Read the current registry version:
 
-```text
-memory
-```
+    ```bash
+    curl \
+      -H "Authorization: Bearer <admin-key>" \
+      http://localhost:8080/admin/api-keys/version \
+      | jq .
+    ```
 
-Enable:
+    Retry with a version that sorts equal to or after the current one.
+  </Accordion>
 
-```bash
-HIVENET_ROUTER_QUOTA_BACKEND=badger
-```
+  <Accordion title="A dynamic update rejects the hash">
+    Check that it is exactly 64 hexadecimal characters:
 
-to persist daily token use.
+    ```bash
+    printf '%s' "$RAW_API_KEY" \
+      | sha256sum
+    ```
 
-Request-per-minute state remains in memory by design.
-
-### A dynamic update returns `409 stale version`
-
-Read the current registry version:
-
-```bash
-curl \
-  -H "Authorization: Bearer <admin-key>" \
-  http://localhost:8080/admin/api-keys/version \
-  | jq .
-```
-
-Retry with a version that sorts equal to or after the current one.
-
-### A dynamic update rejects the hash
-
-Check that it is exactly 64 hexadecimal characters:
-
-```bash
-printf '%s' "$RAW_API_KEY" \
-  | sha256sum
-```
-
-Do not send the raw key in `key_hash`.
+    Do not send the raw key in `key_hash`.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="auth.yaml reference" href="/security/auth-yaml-reference">
+<Columns cols={3}>
+  <Card title="auth.yaml reference" icon="file-code" href="/security/auth-yaml-reference">
     Review the full static authentication and quota schema.
   </Card>
 
-  <Card title="Model restrictions" href="/security/model-restrictions">
+  <Card title="Model restrictions" icon="shield-halved" href="/security/model-restrictions">
     Design model access for applications, tenants, and workload types.
   </Card>
 
-  <Card title="Key rotation" href="/security/key-rotation">
+  <Card title="Key rotation" icon="rotate" href="/security/key-rotation">
     Rotate static, dynamic, administration, agent, and provider credentials safely.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/security/auth-yaml-reference.mdx
+++ b/docs/security/auth-yaml-reference.mdx
@@ -465,11 +465,9 @@ quota:
 - **Input tokens per minute (ITPM)** uses a continuously refilling, one-minute-capacity bucket. The same learned estimate used by B1 and occupancy is deducted before the daily budget, so an ITPM rejection does not spend daily tokens. Cached prompt prefixes currently count in full.
 - **Output tokens per minute (OTPM)** is charged from exact completion usage after a local response. Output is not reserved. If recent output drains the bucket, the next request returns `429 rate_limit_exceeded`. One response can drain at most one minute of capacity.
 - **Occupancy share** limits the key's simultaneous token-weighted footprint to:
-
   ```text
   max_occupancy_share × admit_budget_tokens × healthy_replicas
   ```
-
   The per-key fairness controller intentionally does not apply `HIVENET_ROUTER_ADMIT_FRACTION`. The global B2 controller still applies that fraction and remains the safety limit for the pool.
 
 These limits do not run for `mode: reserved`, and `0` disables each limit. Their shares may be deliberately oversubscribed and do not need to add up to `1`. B4 rejections set `Retry-After: 1`; the ordinary request-per-minute limiter uses the same `rate_limit_exceeded` code without that header.
@@ -983,130 +981,132 @@ During SIGHUP reload, a validation error leaves the previous authentication prov
 
 ## Troubleshooting
 
-### The router says the key list is empty
+<AccordionGroup>
+  <Accordion title="The router says the key list is empty">
+    When using:
 
-When using:
+    ```yaml
+    api:
+      mode: api-key
+    ```
 
-```yaml
-api:
-  mode: api-key
-```
+    define at least one item under:
 
-define at least one item under:
+    ```yaml
+    api:
+      keys:
+    ```
 
-```yaml
-api:
-  keys:
-```
+    For dynamic mode, use:
 
-For dynamic mode, use:
+    ```yaml
+    api:
+      mode: dynamic
+    ```
 
-```yaml
-api:
-  mode: dynamic
-```
+    instead.
+  </Accordion>
 
-instead.
+  <Accordion title="A static key always returns 401">
+    Check that:
 
-### A static key always returns `401`
+    - the application sends the raw key rather than its hash
+    - `key_hash` was generated from the exact raw value
+    - the key has not expired
+    - the updated file loaded successfully
+    - the request reaches the intended router
+    - the authorization header is preserved by proxies
 
-Check that:
+    Generate a fresh key rather than editing hashes manually.
+  </Accordion>
 
-- the application sends the raw key rather than its hash
-- `key_hash` was generated from the exact raw value
-- the key has not expired
-- the updated file loaded successfully
-- the request reaches the intended router
-- the authorization header is preserved by proxies
+  <Accordion title="A key receives 403 model_forbidden">
+    The key uses the explicit `models` allowlist and the requested model is absent.
 
-Generate a fresh key rather than editing hashes manually.
+    Check exact spelling and capitalization.
+  </Accordion>
 
-### A key receives `403 model_forbidden`
+  <Accordion title="A per-model key receives 429">
+    Read the error message.
 
-The key uses the explicit `models` allowlist and the requested model is absent.
+    When it says:
 
-Check exact spelling and capitalization.
+    ```text
+    no quota declared for model <model> on this API key
+    ```
 
-### A per-model key receives `429`
+    add an exact entry under:
 
-Read the error message.
+    ```yaml
+    quota:
+      per_model:
+    ```
 
-When it says:
+    or use a flat quota shape instead.
+  </Accordion>
 
-```text
-no quota declared for model <model> on this API key
-```
+  <Accordion title="The router rejects an expiration date">
+    Static dates must use:
 
-add an exact entry under:
+    ```text
+    DD-MM-YYYY
+    ```
 
-```yaml
-quota:
-  per_model:
-```
+    Valid:
 
-or use a flat quota shape instead.
+    ```yaml
+    expires_at: "31-12-2026"
+    ```
 
-### The router rejects an expiration date
+    Invalid:
 
-Static dates must use:
+    ```yaml
+    expires_at: "2026-12-31"
+    ```
+  </Accordion>
 
-```text
-DD-MM-YYYY
-```
+  <Accordion title="SIGHUP does not apply the new mode">
+    Changing between static and dynamic authentication requires a router restart.
 
-Valid:
+    SIGHUP supports changes within the current mode, such as:
 
-```yaml
-expires_at: "31-12-2026"
-```
+    - adding or revoking static keys
+    - changing model restrictions
+    - changing quotas
+    - changing static expirations
+    - rebuilding administrator keys from the current environment
+  </Accordion>
 
-Invalid:
+  <Accordion title="Administration endpoints remain open">
+    Set:
 
-```yaml
-expires_at: "2026-12-31"
-```
+    ```yaml
+    admin:
+      mode: api-key
+    ```
 
-### SIGHUP does not apply the new mode
+    and provide:
 
-Changing between static and dynamic authentication requires a router restart.
+    ```bash
+    export HIVENET_ROUTER_ADMIN_API_KEYS="<admin-key>"
+    ```
 
-SIGHUP supports changes within the current mode, such as:
-
-- adding or revoking static keys
-- changing model restrictions
-- changing quotas
-- changing static expirations
-- rebuilding administrator keys from the current environment
-
-### Administration endpoints remain open
-
-Set:
-
-```yaml
-admin:
-  mode: api-key
-```
-
-and provide:
-
-```bash
-export HIVENET_ROUTER_ADMIN_API_KEYS="<admin-key>"
-```
-
-Then restart the router if you changed its process environment.
+    Then restart the router if you changed its process environment.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Model restrictions" href="/security/model-restrictions">
+<Columns cols={3}>
+  <Card title="Model restrictions" icon="shield-halved" href="/security/model-restrictions">
     Design model access and discovery boundaries for applications and tenants.
   </Card>
 
-  <Card title="Key rotation" href="/security/key-rotation">
+  <Card title="Key rotation" icon="key" href="/security/key-rotation">
     Rotate static, dynamic, administrator, agent, and provider credentials.
   </Card>
 
-  <Card title="Audit logging" href="/observability/audit-logging">
+  <Card title="Audit logging" icon="clipboard-list" href="/observability/audit-logging">
     Record authenticated owners, key identifiers, models, and request outcomes.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/security/auth-yaml-reference.mdx
+++ b/docs/security/auth-yaml-reference.mdx
@@ -1007,7 +1007,7 @@ During SIGHUP reload, a validation error leaves the previous authentication prov
     instead.
   </Accordion>
 
-  <Accordion title="A static key always returns 401">
+  <Accordion title="A static key always returns `401`">
     Check that:
 
     - the application sends the raw key rather than its hash
@@ -1020,13 +1020,13 @@ During SIGHUP reload, a validation error leaves the previous authentication prov
     Generate a fresh key rather than editing hashes manually.
   </Accordion>
 
-  <Accordion title="A key receives 403 model_forbidden">
+  <Accordion title="A key receives `403 model_forbidden`">
     The key uses the explicit `models` allowlist and the requested model is absent.
 
     Check exact spelling and capitalization.
   </Accordion>
 
-  <Accordion title="A per-model key receives 429">
+  <Accordion title="A per-model key receives `429`">
     Read the error message.
 
     When it says:

--- a/docs/security/authentication-overview.mdx
+++ b/docs/security/authentication-overview.mdx
@@ -80,42 +80,43 @@ export HIVENET_ROUTER_JWT_SECRET="<shared-secret>"
 
 An agent joins the network in two stages.
 
-### 1. Authenticate over gRPC
+<Steps>
+  <Step title="Authenticate over gRPC">
+    The agent:
 
-The agent:
+    1. creates a JWT signed with HMAC-SHA256
+    2. includes its libp2p peer ID as the JWT subject
+    3. connects to the router’s gRPC authentication endpoint
+    4. verifies the router’s pinned TLS public key
+    5. sends the JWT and its agent metadata
 
-1. creates a JWT signed with HMAC-SHA256
-2. includes its libp2p peer ID as the JWT subject
-3. connects to the router’s gRPC authentication endpoint
-4. verifies the router’s pinned TLS public key
-5. sends the JWT and its agent metadata
+    The router:
 
-The router:
+    1. verifies the JWT signature
+    2. validates its issuer, issue time, expiry, and subject
+    3. validates required agent metadata
+    4. creates a random session token
+    5. returns the session token, router libp2p addresses, and runtime configuration
 
-1. verifies the JWT signature
-2. validates its issuer, issue time, expiry, and subject
-3. validates required agent metadata
-4. creates a random session token
-5. returns the session token, router libp2p addresses, and runtime configuration
+    The gRPC endpoint uses TLS 1.3.
 
-The gRPC endpoint uses TLS 1.3.
+    Hivenet Router deterministically derives an Ed25519 certificate and public key from the shared JWT secret using HKDF-SHA256. The agent pins that public key, so the deployment does not need a separate certificate authority or pre-distributed gRPC certificate files.
 
-Hivenet Router deterministically derives an Ed25519 certificate and public key from the shared JWT secret using HKDF-SHA256. The agent pins that public key, so the deployment does not need a separate certificate authority or pre-distributed gRPC certificate files.
+    A router and agent using different secrets fail the TLS identity check before registration.
+  </Step>
+  <Step title="Register over libp2p">
+    After gRPC authentication, the agent connects to the router’s libp2p endpoint and presents the session token.
 
-A router and agent using different secrets fail the TLS identity check before registration.
+    The router links:
 
-### 2. Register over libp2p
+    - the authenticated agent identity
+    - the agent’s libp2p peer ID
+    - its registered model and metadata
+    - the short-lived session
 
-After gRPC authentication, the agent connects to the router’s libp2p endpoint and presents the session token.
-
-The router links:
-
-- the authenticated agent identity
-- the agent’s libp2p peer ID
-- its registered model and metadata
-- the short-lived session
-
-Router-agent traffic then uses libp2p with Noise encryption.
+    Router-agent traffic then uses libp2p with Noise encryption.
+  </Step>
+</Steps>
 
 ## Agent metadata validation
 
@@ -576,106 +577,108 @@ Compromise has different consequences:
 
 ## Troubleshooting
 
-### An agent reports a TLS key mismatch
+<AccordionGroup>
+  <Accordion title="An agent reports a TLS key mismatch">
+    The router and agent are using different JWT secrets.
 
-The router and agent are using different JWT secrets.
+    Compare their secret files without printing their contents:
 
-Compare their secret files without printing their contents:
+    ```bash
+    sha256sum /etc/hivenet-router/jwt.secret
+    ```
 
-```bash
-sha256sum /etc/hivenet-router/jwt.secret
-```
+    The hashes must match.
 
-The hashes must match.
+    Restart the affected process after correcting the secret.
+  </Accordion>
 
-Restart the affected process after correcting the secret.
+  <Accordion title="The router rejects the agent metadata">
+    Check the agent logs for the field named in the rejection.
 
-### The router rejects the agent metadata
+    Required values include:
 
-Check the agent logs for the field named in the rejection.
+    - model
+    - positive capacity
+    - version
+    - engine
+    - region
+    - organization
+  </Accordion>
 
-Required values include:
+  <Accordion title="A client receives `401 unauthorized`">
+    Check that:
 
-- model
-- positive capacity
-- version
-- engine
-- region
-- organization
+    - the correct key is being sent
+    - the header uses the expected value
+    - the router loaded the intended auth configuration
+    - the static key has not expired
+    - a dynamic key is enabled and present after the latest router restart
+    - the request is reaching the intended router environment
 
-### A client receives `401 unauthorized`
+    Do not expect the response to distinguish these cases. Check operator logs and configuration.
+  </Accordion>
 
-Check that:
+  <Accordion title="A valid client key receives `403 model_forbidden`">
+    Authentication succeeded, but the key may not use the requested model.
 
-- the correct key is being sent
-- the header uses the expected value
-- the router loaded the intended auth configuration
-- the static key has not expired
-- a dynamic key is enabled and present after the latest router restart
-- the request is reaching the intended router environment
+    Review:
 
-Do not expect the response to distinguish these cases. Check operator logs and configuration.
+    - `models` for static keys
+    - `allowed_models` for dynamic keys
+    - `quota.per_model`
+    - exact model spelling and capitalization
+  </Accordion>
 
-### A valid client key receives `403 model_forbidden`
+  <Accordion title="Administration requests receive `401`">
+    Client and administration credentials are separate.
 
-Authentication succeeded, but the key may not use the requested model.
+    Confirm that:
 
-Review:
+    ```yaml
+    admin:
+      mode: api-key
+    ```
 
-- `models` for static keys
-- `allowed_models` for dynamic keys
-- `quota.per_model`
-- exact model spelling and capitalization
+    and that the submitted value appears in:
 
-### Administration requests receive `401`
+    ```text
+    HIVENET_ROUTER_ADMIN_API_KEYS
+    ```
 
-Client and administration credentials are separate.
+    Restart the router after changing the environment variable.
+  </Accordion>
 
-Confirm that:
+  <Accordion title="Static changes do not take effect">
+    Send `SIGHUP`:
 
-```yaml
-admin:
-  mode: api-key
-```
+    ```bash
+    sudo kill -HUP "$(pgrep hivenet-router)"
+    ```
 
-and that the submitted value appears in:
+    Then inspect the router logs for parsing or validation errors.
 
-```text
-HIVENET_ROUTER_ADMIN_API_KEYS
-```
+    Dynamic registry entries are not reloaded from `auth.yaml`.
+  </Accordion>
 
-Restart the router after changing the environment variable.
+  <Accordion title="Dynamic keys disappear">
+    The dynamic registry is stored in memory.
 
-### Static changes do not take effect
-
-Send `SIGHUP`:
-
-```bash
-sudo kill -HUP "$(pgrep hivenet-router)"
-```
-
-Then inspect the router logs for parsing or validation errors.
-
-Dynamic registry entries are not reloaded from `auth.yaml`.
-
-### Dynamic keys disappear
-
-The dynamic registry is stored in memory.
-
-Repopulate it through the administration API after every router restart.
+    Repopulate it through the administration API after every router restart.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="API keys" href="/security/api-keys">
+<Columns cols={3}>
+  <Card title="API keys" icon="key" href="/security/api-keys">
     Generate, configure, manage, and revoke static and dynamic client keys.
   </Card>
 
-  <Card title="auth.yaml reference" href="/security/auth-yaml-reference">
+  <Card title="auth.yaml reference" icon="file-code" href="/security/auth-yaml-reference">
     Review the complete static authentication and quota schema.
   </Card>
 
-  <Card title="Key rotation" href="/security/key-rotation">
+  <Card title="Key rotation" icon="rotate" href="/security/key-rotation">
     Rotate agent, client, administrator, and provider credentials safely.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/security/key-rotation.mdx
+++ b/docs/security/key-rotation.mdx
@@ -39,111 +39,108 @@ For an active compromise, revoke or disable the exposed credential first when co
 
 Static client keys are stored as SHA-256 hashes in `auth.yaml`. The safest rotation keeps both entries active for a short overlap period.
 
-### 1. Generate the replacement
+<Steps>
+  <Step title="Generate the replacement">
+    ```bash
+    ./bin/hivenet-router \
+      keygen \
+      --tenant acme-corp
+    ```
 
-```bash
-./bin/hivenet-router \
-  keygen \
-  --tenant acme-corp
-```
+    Store the raw key securely. Copy the generated hash and YAML entry into `auth.yaml`.
 
-Store the raw key securely. Copy the generated hash and YAML entry into `auth.yaml`.
+    Use the exact lowercase hash printed by the generator or `sha256sum`.
+  </Step>
+  <Step title="Keep both keys temporarily">
+    ```yaml
+    api:
+      mode: api-key
+    
+      keys:
+        - key_hash: "<old-key-sha256>"
+          key_preview: "sk-...old"
+    
+          metadata:
+            name: "Acme production, old"
+            owner: "acme-corp"
+    
+          models:
+            - "meta-llama/Llama-3.1-8B-Instruct"
+    
+          quota:
+            requests_per_minute: 100
+            tokens_per_day: 500000
+    
+        - key_hash: "<new-key-sha256>"
+          key_preview: "sk-...new"
+    
+          metadata:
+            name: "Acme production, new"
+            owner: "acme-corp"
+    
+          models:
+            - "meta-llama/Llama-3.1-8B-Instruct"
+    
+          quota:
+            requests_per_minute: 100
+            tokens_per_day: 500000
+    
+    admin:
+      mode: api-key
+    ```
 
-Use the exact lowercase hash printed by the generator or `sha256sum`.
+    Using the same owner preserves one shared quota bucket during the overlap. Use different owners only when the two credentials should have independent quota accounting.
 
-### 2. Keep both keys temporarily
+    Keep the model restrictions and quotas aligned unless the rotation is also an intentional access change.
+  </Step>
+  <Step title="Reload the file">
+    ```bash
+    sudo kill -HUP "$(pgrep hivenet-router)"
+    ```
 
-```yaml
-api:
-  mode: api-key
+    For Docker Compose:
 
-  keys:
-    - key_hash: "<old-key-sha256>"
-      key_preview: "sk-...old"
+    ```bash
+    docker compose kill \
+      --signal SIGHUP \
+      router
+    ```
 
-      metadata:
-        name: "Acme production, old"
-        owner: "acme-corp"
+    Hivenet Router validates the replacement provider before swapping it in. A failed reload leaves the previous provider active.
 
-      models:
-        - "meta-llama/Llama-3.1-8B-Instruct"
+    <Warning>
+      A successful static-auth reload rebuilds the in-memory quota limiter.
 
-      quota:
-        requests_per_minute: 100
-        tokens_per_day: 500000
+      Request-per-minute buckets reset. With the `memory` quota backend, current daily token usage is also lost. With the `badger` backend, Hivenet Router flushes daily token state before rebuilding the limiter and restores it on later requests.
+    </Warning>
+  </Step>
+  <Step title="Test the new key">
+    ```bash
+    curl \
+      -H "Authorization: Bearer <new-client-key>" \
+      http://localhost:8080/v1/models
+    ```
 
-    - key_hash: "<new-key-sha256>"
-      key_preview: "sk-...new"
+    Also test an inference request and confirm:
 
-      metadata:
-        name: "Acme production, new"
-        owner: "acme-corp"
+    - the intended models are visible
+    - the intended model can be invoked
+    - quotas are correct
+    - audit records use the expected owner; static keys do not populate a stable `key_id`
+  </Step>
+  <Step title="Move applications to the new key">
+    Update every application, job, SDK, proxy, and secret reference that uses the old value.
 
-      models:
-        - "meta-llama/Llama-3.1-8B-Instruct"
+    Keep the overlap only as long as necessary. Two active credentials increase the number of values that can be exposed.
+  </Step>
+  <Step title="Remove the old entry">
+    Delete the old key from `auth.yaml`, send `SIGHUP` again, and verify that it now returns:
 
-      quota:
-        requests_per_minute: 100
-        tokens_per_day: 500000
-
-admin:
-  mode: api-key
-```
-
-Using the same owner preserves one shared quota bucket during the overlap. Use different owners only when the two credentials should have independent quota accounting.
-
-Keep the model restrictions and quotas aligned unless the rotation is also an intentional access change.
-
-### 3. Reload the file
-
-```bash
-sudo kill -HUP "$(pgrep hivenet-router)"
-```
-
-For Docker Compose:
-
-```bash
-docker compose kill \
-  --signal SIGHUP \
-  router
-```
-
-Hivenet Router validates the replacement provider before swapping it in. A failed reload leaves the previous provider active.
-
-<Warning>
-  A successful static-auth reload rebuilds the in-memory quota limiter.
-
-  Request-per-minute buckets reset. With the `memory` quota backend, current daily token usage is also lost. With the `badger` backend, Hivenet Router flushes daily token state before rebuilding the limiter and restores it on later requests.
-</Warning>
-
-### 4. Test the new key
-
-```bash
-curl \
-  -H "Authorization: Bearer <new-client-key>" \
-  http://localhost:8080/v1/models
-```
-
-Also test an inference request and confirm:
-
-- the intended models are visible
-- the intended model can be invoked
-- quotas are correct
-- audit records use the expected owner; static keys do not populate a stable `key_id`
-
-### 5. Move applications to the new key
-
-Update every application, job, SDK, proxy, and secret reference that uses the old value.
-
-Keep the overlap only as long as necessary. Two active credentials increase the number of values that can be exposed.
-
-### 6. Remove the old entry
-
-Delete the old key from `auth.yaml`, send `SIGHUP` again, and verify that it now returns:
-
-```text
-401 unauthorized
-```
+    ```text
+    401 unauthorized
+    ```
+  </Step>
+</Steps>
 
 ## Rotate a dynamic client key
 
@@ -407,62 +404,64 @@ or:
 
 ## Troubleshooting
 
-### The new static key returns `401`
+<AccordionGroup>
+  <Accordion title="The new static key returns `401`">
+    Check that:
 
-Check that:
+    - the application sends the raw key, not its SHA-256 hash
+    - the hash in `auth.yaml` was generated from the exact raw value
+    - the successful `SIGHUP` reload appears in router logs
+    - the key has not already expired
+    - the request reaches the intended router
+  </Accordion>
 
-- the application sends the raw key, not its SHA-256 hash
-- the hash in `auth.yaml` was generated from the exact raw value
-- the successful `SIGHUP` reload appears in router logs
-- the key has not already expired
-- the request reaches the intended router
+  <Accordion title="The old static key still works">
+    Confirm that its entry was removed from the file that the running router actually loads, then send `SIGHUP` again.
 
-### The old static key still works
+    A failed reload leaves the previous provider active.
+  </Accordion>
 
-Confirm that its entry was removed from the file that the running router actually loads, then send `SIGHUP` again.
+  <Accordion title="A dynamic mutation returns `409 stale version`">
+    Read the current version:
 
-A failed reload leaves the previous provider active.
+    ```bash
+    curl \
+      -H "Authorization: Bearer <admin-key>" \
+      http://localhost:8080/admin/api-keys/version \
+      | jq .
+    ```
 
-### A dynamic mutation returns `409 stale version`
+    Retry with a value that sorts after the current version.
+  </Accordion>
 
-Read the current version:
+  <Accordion title="The new administrator key returns `401`">
+    The running process probably still has the old environment.
 
-```bash
-curl \
-  -H "Authorization: Bearer <admin-key>" \
-  http://localhost:8080/admin/api-keys/version \
-  | jq .
-```
+    Restart or recreate the router after updating `HIVENET_ROUTER_ADMIN_API_KEYS`.
+  </Accordion>
 
-Retry with a value that sorts after the current version.
+  <Accordion title="Agents do not reconnect after secret rotation">
+    Check that:
 
-### The new administrator key returns `401`
+    - the router and every agent loaded the same new secret
+    - the secret contains at least 32 bytes
+    - agents can reach the router’s gRPC and libp2p ports
+    - all affected processes were restarted
+    - no host still references an older secret file or secret version
 
-The running process probably still has the old environment.
+    Compare secret files by hash without printing their contents.
+  </Accordion>
 
-Restart or recreate the router after updating `HIVENET_ROUTER_ADMIN_API_KEYS`.
+  <Accordion title="Provider fallback fails after rotation">
+    Confirm that:
 
-### Agents do not reconnect after secret rotation
-
-Check that:
-
-- the router and every agent loaded the same new secret
-- the secret contains at least 32 bytes
-- agents can reach the router’s gRPC and libp2p ports
-- all affected processes were restarted
-- no host still references an older secret file or secret version
-
-Compare secret files by hash without printing their contents.
-
-### Provider fallback fails after rotation
-
-Confirm that:
-
-- the router was restarted
-- the active policy still declares the provider
-- the new credential can access the configured provider model
-- provider billing or project limits permit the request
-- the test request uses the supported non-streaming fallback path
+    - the router was restarted
+    - the active policy still declares the provider
+    - the new credential can access the configured provider model
+    - provider billing or project limits permit the request
+    - the test request uses the supported non-streaming fallback path
+  </Accordion>
+</AccordionGroup>
 
 ## Rotation checklist
 
@@ -481,16 +480,16 @@ Confirm that:
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="API keys" href="/security/api-keys">
+<Columns cols={3}>
+  <Card title="API keys" icon="key" href="/security/api-keys">
     Review static and dynamic client-key configuration and persistence.
   </Card>
 
-  <Card title="Authentication overview" href="/security/authentication-overview">
+  <Card title="Authentication overview" icon="lock" href="/security/authentication-overview">
     Understand the separate trust boundaries behind each credential.
   </Card>
 
-  <Card title="Audit logging" href="/observability/audit-logging">
+  <Card title="Audit logging" icon="file-lines" href="/observability/audit-logging">
     Correlate credential use, denials, tenants, models, and request outcomes.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/security/model-restrictions.mdx
+++ b/docs/security/model-restrictions.mdx
@@ -792,123 +792,125 @@ The failed-request metric includes other failure types. Use audit logs when you 
 
 ## Troubleshooting
 
-### A key sees every model
+<AccordionGroup>
+  <Accordion title="A key sees every model">
+    Check whether its model list is empty or omitted:
 
-Check whether its model list is empty or omitted:
+    ```yaml
+    models: []
+    ```
 
-```yaml
-models: []
-```
+    or:
 
-or:
+    ```json
+    {
+      "allowed_models": []
+    }
+    ```
 
-```json
-{
-  "allowed_models": []
-}
-```
+    An empty allowlist means unrestricted access.
 
-An empty allowlist means unrestricted access.
+    Also check whether you edited the correct key and router environment.
+  </Accordion>
 
-Also check whether you edited the correct key and router environment.
+  <Accordion title="A permitted model is missing">
+    Compare the configured name with the operator catalog:
 
-### A permitted model is missing
+    ```bash
+    curl \
+      -H "Authorization: Bearer <admin-api-key>" \
+      http://localhost:8080/admin/models \
+      | jq -r '.data[].id'
+    ```
 
-Compare the configured name with the operator catalog:
+    Check capitalization, slashes, punctuation, and model aliases.
 
-```bash
-curl \
-  -H "Authorization: Bearer <admin-api-key>" \
-  http://localhost:8080/admin/models \
-  | jq -r '.data[].id'
-```
+    If `quota.per_model` is present, confirm that the model has an entry there.
+  </Accordion>
 
-Check capitalization, slashes, punctuation, and model aliases.
+  <Accordion title="The list endpoint hides a model, but the admin endpoint shows it">
+    The client key is restricted.
 
-If `quota.per_model` is present, confirm that the model has an entry there.
+    Review:
 
-### The list endpoint hides a model, but the admin endpoint shows it
+    - `models`
+    - `allowed_models`
+    - `quota.per_model`
 
-The client key is restricted.
+    This is expected tenant-filtering behavior.
+  </Accordion>
 
-Review:
+  <Accordion title="Inference returns 403 model_forbidden">
+    The key uses an explicit allowlist and the requested model is not permitted.
 
-- `models`
-- `allowed_models`
-- `quota.per_model`
+    Add the exact model name or use an unrestricted list when that is intentional.
+  </Accordion>
 
-This is expected tenant-filtering behavior.
+  <Accordion title="Inference returns 429 for an unlisted model">
+    The key uses `quota.per_model`.
 
-### Inference returns `403 model_forbidden`
+    Add a complete quota entry for the model:
 
-The key uses an explicit allowlist and the requested model is not permitted.
+    ```yaml
+    quota:
+      per_model:
+        model-name:
+          requests_per_minute_per_replica: 0
+          tokens_per_day: 0
+    ```
 
-Add the exact model name or use an unrestricted list when that is intentional.
+    Both fields are required even when they are unlimited.
+  </Accordion>
 
-### Inference returns `429` for an unlisted model
+  <Accordion title="A model is allowed but the request still fails">
+    Model authorization succeeded. Check the later routing stages:
 
-The key uses `quota.per_model`.
+    - registered capability
+    - agent health
+    - available capacity
+    - routing-policy filters
+    - backend compatibility
+    - request validity
 
-Add a complete quota entry for the model:
+    Use:
 
-```yaml
-quota:
-  per_model:
-    model-name:
-      requests_per_minute_per_replica: 0
-      tokens_per_day: 0
-```
+    ```bash
+    curl \
+      -H "Authorization: Bearer <admin-api-key>" \
+      http://localhost:8080/admin/routing-table \
+      | jq '.agents[] | select(.metadata.model == "<model>")'
+    ```
+  </Accordion>
 
-Both fields are required even when they are unlimited.
+  <Accordion title="A changed static restriction does not take effect">
+    Send `SIGHUP` and inspect the router logs:
 
-### A model is allowed but the request still fails
+    ```bash
+    sudo kill -HUP "$(pgrep hivenet-router)"
+    ```
 
-Model authorization succeeded. Check the later routing stages:
+    A validation failure leaves the previous configuration active.
+  </Accordion>
 
-- registered capability
-- agent health
-- available capacity
-- routing-policy filters
-- backend compatibility
-- request validity
+  <Accordion title="A dynamic restriction disappears after restart">
+    Dynamic key state is memory-only.
 
-Use:
-
-```bash
-curl \
-  -H "Authorization: Bearer <admin-api-key>" \
-  http://localhost:8080/admin/routing-table \
-  | jq '.agents[] | select(.metadata.model == "<model>")'
-```
-
-### A changed static restriction does not take effect
-
-Send `SIGHUP` and inspect the router logs:
-
-```bash
-sudo kill -HUP "$(pgrep hivenet-router)"
-```
-
-A validation failure leaves the previous configuration active.
-
-### A dynamic restriction disappears after restart
-
-Dynamic key state is memory-only.
-
-Repopulate the registry through the administration API after every router restart.
+    Repopulate the registry through the administration API after every router restart.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Key rotation" href="/security/key-rotation">
+<Columns cols={3}>
+  <Card title="Key rotation" icon="key" href="/security/key-rotation">
     Replace client, administrator, agent, and provider credentials safely.
   </Card>
 
-  <Card title="Models" href="/use-the-api/models">
+  <Card title="Models" icon="cubes" href="/use-the-api/models">
     Understand filtered client discovery and the unfiltered operator catalog.
   </Card>
 
-  <Card title="Audit logging" href="/observability/audit-logging">
+  <Card title="Audit logging" icon="clipboard-list" href="/observability/audit-logging">
     Track owners, keys, models, denials, and request outcomes.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/security/model-restrictions.mdx
+++ b/docs/security/model-restrictions.mdx
@@ -840,13 +840,13 @@ The failed-request metric includes other failure types. Use audit logs when you 
     This is expected tenant-filtering behavior.
   </Accordion>
 
-  <Accordion title="Inference returns 403 model_forbidden">
+  <Accordion title="Inference returns `403 model_forbidden`">
     The key uses an explicit allowlist and the requested model is not permitted.
 
     Add the exact model name or use an unrestricted list when that is intentional.
   </Accordion>
 
-  <Accordion title="Inference returns 429 for an unlisted model">
+  <Accordion title="Inference returns `429` for an unlisted model">
     The key uses `quota.per_model`.
 
     Add a complete quota entry for the model:

--- a/docs/use-the-api/admin-endpoints.mdx
+++ b/docs/use-the-api/admin-endpoints.mdx
@@ -1157,16 +1157,16 @@ Common statuses include:
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Routing concepts" href="/routing/routing-concepts">
+<Columns cols={3}>
+  <Card title="Routing concepts" icon="route" href="/routing/routing-concepts">
     Understand how global and named policies select agents.
   </Card>
 
-  <Card title="API keys" href="/security/api-keys">
+  <Card title="API keys" icon="key" href="/security/api-keys">
     Configure static and dynamic client authentication, access, and quotas.
   </Card>
 
-  <Card title="Prometheus metrics" href="/observability/prometheus-metrics">
+  <Card title="Prometheus metrics" icon="chart-line" href="/observability/prometheus-metrics">
     Query router, agent, tenant, policy, and hardware metrics.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/use-the-api/chat-completions.mdx
+++ b/docs/use-the-api/chat-completions.mdx
@@ -9,28 +9,49 @@ Hivenet Router exposes OpenAI-compatible Chat Completions and Anthropic-compatib
 
 The router reads the top-level `model` field, selects a healthy language-model agent, and forwards the original request to the same path on that agent’s backend.
 
-| API dialect | Endpoint |
-| --- | --- |
-| OpenAI Chat Completions | `POST /v1/chat/completions` |
-| Anthropic Messages | `POST /v1/messages` |
-| Anthropic token counting | `POST /v1/messages/count_tokens` |
+<Columns cols={3}>
+  <Card title="OpenAI Chat Completions" icon="comments" href="#openai-chat-completions">
+    `POST /v1/chat/completions`
+  </Card>
 
-<Note>
+  <Card title="Anthropic Messages" icon="message" href="#anthropic-messages">
+    `POST /v1/messages`
+  </Card>
+
+  <Card title="Anthropic token counting" icon="calculator" href="#count-anthropic-input-tokens">
+    `POST /v1/messages/count_tokens`
+  </Card>
+</Columns>
+
+<Info>
   The selected backend must support the endpoint used by the client. Hivenet Router does not translate between the OpenAI and Anthropic request formats.
-</Note>
+</Info>
 
 ## How passthrough works
 
-For each request, Hivenet Router:
+For each request, Hivenet Router follows the same pipeline:
 
-1. authenticates the client when API authentication is enabled
-2. applies request and token quotas when configured
-3. reads and validates the top-level `model` field
-4. checks that the API key may use that model
-5. applies the model's request caps, pressure shed, occupancy budget, and serverless per-key admission limits
-6. selects a healthy `llm` agent through the routing policy
-7. forwards the original body to the same path on the selected backend
-8. returns the backend response to the client
+<Steps>
+  <Step title="Authenticate and apply quotas">
+    Authenticate the client when API authentication is enabled, then apply configured request and token quotas.
+  </Step>
+
+  <Step title="Resolve and authorize the model">
+    Read and validate the top-level `model` field, then confirm that the API key may use it.
+  </Step>
+
+  <Step title="Apply admission control">
+    Check the model’s request caps, pressure shed, occupancy budget, and serverless per-key limits.
+  </Step>
+
+  <Step title="Select and forward">
+    Select a healthy `llm` agent through the routing policy and forward the original body to the same backend path.
+  </Step>
+
+  <Step title="Return the response">
+    Return the backend response to the client.
+  </Step>
+</Steps>
 
 Apart from the fields needed for routing and quota estimation, Hivenet Router does not impose its own generation schema or defaults. Parameters such as sampling controls, tools, structured output, multimodal input, and backend-specific extensions work only when the selected backend supports them.
 
@@ -102,7 +123,9 @@ POST /v1/chat/completions
 
 ### Basic request
 
-```bash
+<CodeGroup>
+
+```bash Without authentication
 curl -X POST \
   http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
@@ -121,9 +144,7 @@ curl -X POST \
   }'
 ```
 
-When authentication is enabled:
-
-```bash
+```bash With API key
 curl -X POST \
   http://localhost:8080/v1/chat/completions \
   -H "Authorization: Bearer <api-key>" \
@@ -138,6 +159,8 @@ curl -X POST \
     ]
   }'
 ```
+
+</CodeGroup>
 
 ### Fields used by Hivenet Router
 
@@ -155,9 +178,9 @@ Hivenet Router forwards the complete request, but it reads a small number of fie
 
 All other fields are passed to the backend without Hivenet Router assigning its own default values.
 
-<Note>
+<Info>
   The selected backend decides which request fields, message roles, modalities, tools, and sampling values it accepts.
-</Note>
+</Info>
 
 ### Multimodal message content
 
@@ -268,9 +291,9 @@ data: [DONE]
 
 The exact event structure comes from the backend.
 
-<Note>
+<Info>
   Hivenet Router can relay a backend’s SSE stream, but it cannot convert a non-streaming backend response into streaming output.
-</Note>
+</Info>
 
 ## Anthropic Messages
 
@@ -436,7 +459,9 @@ A token-budget rejection can still report a nonzero `X-RateLimit-Remaining-Token
 
 Router errors use this envelope:
 
-```json
+<CodeGroup>
+
+```json Router error
 {
   "error": {
     "code": "error_code",
@@ -446,9 +471,7 @@ Router errors use this envelope:
 }
 ```
 
-Backend-derived errors use:
-
-```json
+```json Backend error
 {
   "error": {
     "code": "error_code",
@@ -457,6 +480,8 @@ Backend-derived errors use:
   }
 }
 ```
+
+</CodeGroup>
 
 Common responses include:
 
@@ -481,16 +506,16 @@ See [Error codes](/reference/error-codes) for the complete reference.
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Embeddings" href="/use-the-api/embeddings">
+<Columns cols={3}>
+  <Card title="Embeddings" icon="layer-group" href="/use-the-api/embeddings">
     Generate vectors through capability-specific embedding agents.
   </Card>
 
-  <Card title="Models" href="/use-the-api/models">
+  <Card title="Models" icon="list" href="/use-the-api/models">
     Discover which models and capabilities are currently available.
   </Card>
 
-  <Card title="API keys" href="/security/api-keys">
+  <Card title="API keys" icon="key" href="/security/api-keys">
     Configure client authentication, model access, and quotas.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/use-the-api/embeddings.mdx
+++ b/docs/use-the-api/embeddings.mdx
@@ -376,114 +376,116 @@ See [Error codes](/reference/error-codes) for the complete reference.
 
 ## Troubleshooting
 
-### The model is not found
+<AccordionGroup>
+  <Accordion title="The model is not found">
+    List available embedding models:
 
-List available embedding models:
+    ```bash
+    curl http://localhost:8080/v1/models \
+      | jq '.data[]
+          | select(.capability == "embedding")'
+    ```
 
-```bash
-curl http://localhost:8080/v1/models \
-  | jq '.data[]
-      | select(.capability == "embedding")'
-```
+    Check that:
 
-Check that:
+    - the agent uses `--capability embedding`
+    - the requested model matches the registered model exactly
+    - the agent is healthy
+    - the API key may access the model
+  </Accordion>
 
-- the agent uses `--capability embedding`
-- the requested model matches the registered model exactly
-- the agent is healthy
-- the API key may access the model
+  <Accordion title="The request reaches the wrong backend type">
+    Inspect the agent registration:
 
-### The request reaches the wrong backend type
+    ```bash
+    curl http://localhost:8080/admin/routing-table \
+      | jq '.agents[]
+          | select(.metadata.model == "bge-m3")
+          | {
+              model: .metadata.model,
+              capability: .metadata.capability,
+              engine: .metadata.engine
+            }'
+    ```
 
-Inspect the agent registration:
+    The capability must be:
 
-```bash
-curl http://localhost:8080/admin/routing-table \
-  | jq '.agents[]
-      | select(.metadata.model == "bge-m3")
-      | {
-          model: .metadata.model,
-          capability: .metadata.capability,
-          engine: .metadata.engine
-        }'
-```
+    ```text
+    embedding
+    ```
 
-The capability must be:
+    Use distinct model names if the same model identifier would otherwise be registered under different capabilities.
+  </Accordion>
 
-```text
-embedding
-```
+  <Accordion title="The backend rejects the input">
+    Test the backend directly:
 
-Use distinct model names if the same model identifier would otherwise be registered under different capabilities.
+    ```bash
+    curl -X POST \
+      http://localhost:7997/v1/embeddings \
+      -H "Content-Type: application/json" \
+      -d '{
+        "model": "bge-m3",
+        "input": "Test input"
+      }'
+    ```
 
-### The backend rejects the input
+    A backend may reject:
 
-Test the backend directly:
+    - empty strings
+    - unsupported input formats
+    - batches that are too large
+    - inputs above the model’s token limit
+    - unsupported optional fields
+  </Accordion>
 
-```bash
-curl -X POST \
-  http://localhost:7997/v1/embeddings \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "bge-m3",
-    "input": "Test input"
-  }'
-```
+  <Accordion title="The batch response has fewer items than expected">
+    Check the backend response directly.
 
-A backend may reject:
+    Hivenet Router does not combine, remove, reorder, or deduplicate input strings. It returns the successful backend response as received.
+  </Accordion>
 
-- empty strings
-- unsupported input formats
-- batches that are too large
-- inputs above the model’s token limit
-- unsupported optional fields
+  <Accordion title="Requests time out">
+    Reduce the batch size or increase the router and agent request timeout where appropriate.
 
-### The batch response has fewer items than expected
+    The agent’s backend HTTP timeout defaults to two minutes:
 
-Check the backend response directly.
+    ```bash
+    --http-timeout 10m
+    ```
 
-Hivenet Router does not combine, remove, reorder, or deduplicate input strings. It returns the successful backend response as received.
+    Also check:
 
-### Requests time out
+    - model loading state
+    - backend queue pressure
+    - agent capacity
+    - input length
+    - accelerator memory
+  </Accordion>
 
-Reduce the batch size or increase the router and agent request timeout where appropriate.
+  <Accordion title="The request is rate-limited">
+    Check the returned header:
 
-The agent’s backend HTTP timeout defaults to two minutes:
+    ```text
+    X-RateLimit-Remaining-Requests
+    ```
 
-```bash
---http-timeout 10m
-```
-
-Also check:
-
-- model loading state
-- backend queue pressure
-- agent capacity
-- input length
-- accelerator memory
-
-### The request is rate-limited
-
-Check the returned header:
-
-```text
-X-RateLimit-Remaining-Requests
-```
-
-Review the quota assigned to the API key and the per-model quota entry when per-model quotas are enabled.
+    Review the quota assigned to the API key and the per-model quota entry when per-model quotas are enabled.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Reranking" href="/use-the-api/reranking">
+<Columns cols={3}>
+  <Card title="Reranking" icon="arrow-down-wide-short" href="/use-the-api/reranking">
     Score and reorder documents by relevance to a query.
   </Card>
 
-  <Card title="Models" href="/use-the-api/models">
+  <Card title="Models" icon="list" href="/use-the-api/models">
     Discover models, capabilities, engines, and healthy capacity.
   </Card>
 
-  <Card title="Infinity agent" href="/deploy/agents/infinity">
+  <Card title="Infinity agent" icon="microchip" href="/deploy/agents/infinity">
     Configure embedding and reranking models through Infinity.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/use-the-api/models.mdx
+++ b/docs/use-the-api/models.mdx
@@ -496,103 +496,105 @@ Errors use the standard envelope:
 
 ## Troubleshooting
 
-### A model is missing from the list
+<AccordionGroup>
+  <Accordion title="A model is missing from the list">
+    Check the public view with the intended API key:
 
-Check the public view with the intended API key:
+    ```bash
+    curl http://localhost:8080/v1/models \
+      -H "Authorization: Bearer <api-key>" \
+      | jq -r '.data[].id'
+    ```
 
-```bash
-curl http://localhost:8080/v1/models \
-  -H "Authorization: Bearer <api-key>" \
-  | jq -r '.data[].id'
-```
+    Then check the operator view:
 
-Then check the operator view:
+    ```bash
+    curl http://localhost:8080/admin/models \
+      -H "Authorization: Bearer <admin-api-key>" \
+      | jq -r '.data[].id'
+    ```
 
-```bash
-curl http://localhost:8080/admin/models \
-  -H "Authorization: Bearer <admin-api-key>" \
-  | jq -r '.data[].id'
-```
+    If the model appears only in the admin response, review:
 
-If the model appears only in the admin response, review:
+    - `quota.per_model`
+    - `allowed_models`
+    - which API key is being sent
+    - whether inference and admin authentication use different keys
+  </Accordion>
 
-- `quota.per_model`
-- `allowed_models`
-- which API key is being sent
-- whether inference and admin authentication use different keys
+  <Accordion title="The model is listed but cannot serve requests">
+    Check:
 
-### The model is listed but cannot serve requests
+    ```bash
+    curl http://localhost:8080/v1/models/<model> \
+      | jq '.agents | {
+          total,
+          healthy,
+          total_capacity
+        }'
+    ```
 
-Check:
+    Then inspect the live routing table:
 
-```bash
-curl http://localhost:8080/v1/models/<model> \
-  | jq '.agents | {
-      total,
-      healthy,
-      total_capacity
-    }'
-```
+    ```bash
+    curl http://localhost:8080/admin/routing-table \
+      -H "Authorization: Bearer <admin-api-key>" \
+      | jq '.agents[]
+          | select(.metadata.model == "<model>")'
+    ```
 
-Then inspect the live routing table:
+    Common causes include:
 
-```bash
-curl http://localhost:8080/admin/routing-table \
-  -H "Authorization: Bearer <admin-api-key>" \
-  | jq '.agents[]
-      | select(.metadata.model == "<model>")'
-```
+    - all agents are unhealthy
+    - all healthy agents are at capacity
+    - a routing policy excludes the agents
+    - the requested capability does not match
+    - the API key cannot invoke the model
+  </Accordion>
 
-Common causes include:
+  <Accordion title="The capability is wrong">
+    Check whether agents sharing the model name were started with different capability values.
 
-- all agents are unhealthy
-- all healthy agents are at capacity
-- a routing policy excludes the agents
-- the requested capability does not match
-- the API key cannot invoke the model
+    Use separate model names for language-model, embedding, and reranking registrations.
+  </Accordion>
 
-### The capability is wrong
+  <Accordion title="Display metadata is inconsistent">
+    Make sure every agent serving the model uses the same:
 
-Check whether agents sharing the model name were started with different capability values.
+    ```text
+    --llm-pretty-name
+    --llm-info
+    ```
 
-Use separate model names for language-model, embedding, and reranking registrations.
+    Hivenet Router uses the first non-empty values found while aggregating the catalog.
+  </Accordion>
 
-### Display metadata is inconsistent
+  <Accordion title="Capacity looks higher than available capacity">
+    `total_capacity` is the sum of the agents’ declared maximum capacity.
 
-Make sure every agent serving the model uses the same:
+    It does not subtract:
 
-```text
---llm-pretty-name
---llm-info
-```
+    - active requests
+    - unhealthy-agent capacity
+    - policy exclusions
+    - backend queue pressure
 
-Hivenet Router uses the first non-empty values found while aggregating the catalog.
-
-### Capacity looks higher than available capacity
-
-`total_capacity` is the sum of the agents’ declared maximum capacity.
-
-It does not subtract:
-
-- active requests
-- unhealthy-agent capacity
-- policy exclusions
-- backend queue pressure
-
-Use `/admin/routing-table` for live state.
+    Use `/admin/routing-table` for live state.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Admin endpoints" href="/use-the-api/admin-endpoints">
+<Columns cols={3}>
+  <Card title="Admin endpoints" icon="screwdriver-wrench" href="/use-the-api/admin-endpoints">
     Inspect the complete operator catalog, routing table, storage, policies, and API keys.
   </Card>
 
-  <Card title="API keys" href="/security/api-keys">
+  <Card title="API keys" icon="key" href="/security/api-keys">
     Control which models each client can discover and invoke.
   </Card>
 
-  <Card title="Routing concepts" href="/routing/routing-concepts">
+  <Card title="Routing concepts" icon="route" href="/routing/routing-concepts">
     Understand how matching agents are filtered and selected for inference.
   </Card>
-</CardGroup>
+</Columns>

--- a/docs/use-the-api/reranking.mdx
+++ b/docs/use-the-api/reranking.mdx
@@ -461,133 +461,135 @@ See [Error codes](/reference/error-codes) for the complete reference.
 
 ## Troubleshooting
 
-### The model is not found
+<AccordionGroup>
+  <Accordion title="The model is not found">
+    List available reranking models:
 
-List available reranking models:
+    ```bash
+    curl http://localhost:8080/v1/models \
+      | jq '.data[]
+          | select(.capability == "reranker")'
+    ```
 
-```bash
-curl http://localhost:8080/v1/models \
-  | jq '.data[]
-      | select(.capability == "reranker")'
-```
+    Check that:
 
-Check that:
+    - the agent uses `--capability reranker`
+    - the requested model matches the registered model exactly
+    - the agent is healthy
+    - the API key may access the model
+  </Accordion>
 
-- the agent uses `--capability reranker`
-- the requested model matches the registered model exactly
-- the agent is healthy
-- the API key may access the model
+  <Accordion title="The request reaches the wrong capability">
+    Inspect the agent registration:
 
-### The request reaches the wrong capability
+    ```bash
+    curl http://localhost:8080/admin/routing-table \
+      | jq '.agents[]
+          | select(.metadata.model == "bge-reranker-large")
+          | {
+              model: .metadata.model,
+              capability: .metadata.capability,
+              engine: .metadata.engine
+            }'
+    ```
 
-Inspect the agent registration:
+    The capability must be:
 
-```bash
-curl http://localhost:8080/admin/routing-table \
-  | jq '.agents[]
-      | select(.metadata.model == "bge-reranker-large")
-      | {
-          model: .metadata.model,
-          capability: .metadata.capability,
-          engine: .metadata.engine
-        }'
-```
+    ```text
+    reranker
+    ```
+  </Accordion>
 
-The capability must be:
+  <Accordion title="The backend rejects the request">
+    Test it directly:
 
-```text
-reranker
-```
+    ```bash
+    curl -X POST \
+      http://localhost:7997/v1/rerank \
+      -H "Content-Type: application/json" \
+      -d '{
+        "model": "bge-reranker-large",
+        "query": "Test query",
+        "documents": [
+          "First document",
+          "Second document"
+        ],
+        "top_n": 2
+      }'
+    ```
 
-### The backend rejects the request
+    A backend may reject:
 
-Test it directly:
+    - an empty query
+    - an empty document list
+    - unsupported document formats
+    - too many documents
+    - documents above the model’s token limit
+    - an invalid `top_n`
+    - unsupported optional fields
+  </Accordion>
 
-```bash
-curl -X POST \
-  http://localhost:7997/v1/rerank \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "bge-reranker-large",
-    "query": "Test query",
-    "documents": [
-      "First document",
-      "Second document"
-    ],
-    "top_n": 2
-  }'
-```
+  <Accordion title="The response contains `document: null`">
+    This is expected for backends that do not return document text by default.
 
-A backend may reject:
+    Use each result’s `index` to retrieve the original document from the input array.
+  </Accordion>
 
-- an empty query
-- an empty document list
-- unsupported document formats
-- too many documents
-- documents above the model’s token limit
-- an invalid `top_n`
-- unsupported optional fields
+  <Accordion title="Results do not contain every document">
+    Check `top_n`.
 
-### The response contains `document: null`
+    For example:
 
-This is expected for backends that do not return document text by default.
+    ```json
+    {
+      "top_n": 2
+    }
+    ```
 
-Use each result’s `index` to retrieve the original document from the input array.
+    returns at most two results, even when the request contains more documents.
 
-### Results do not contain every document
+    When `top_n` is omitted, the documented Infinity behavior is to return all ranked documents.
+  </Accordion>
 
-Check `top_n`.
+  <Accordion title="Requests time out">
+    Reduce the number or size of candidate documents, or increase the agent’s backend timeout:
 
-For example:
+    ```bash
+    --http-timeout 10m
+    ```
 
-```json
-{
-  "top_n": 2
-}
-```
+    Also check:
 
-returns at most two results, even when the request contains more documents.
+    - backend model loading state
+    - declared agent capacity
+    - accelerator memory
+    - competing embedding or reranking traffic
+    - backend batch configuration
+  </Accordion>
 
-When `top_n` is omitted, the documented Infinity behavior is to return all ranked documents.
+  <Accordion title="The request is rate-limited">
+    Check:
 
-### Requests time out
+    ```text
+    X-RateLimit-Remaining-Requests
+    ```
 
-Reduce the number or size of candidate documents, or increase the agent’s backend timeout:
-
-```bash
---http-timeout 10m
-```
-
-Also check:
-
-- backend model loading state
-- declared agent capacity
-- accelerator memory
-- competing embedding or reranking traffic
-- backend batch configuration
-
-### The request is rate-limited
-
-Check:
-
-```text
-X-RateLimit-Remaining-Requests
-```
-
-Review the API key’s request-rate quota and any per-model quota configuration.
+    Review the API key’s request-rate quota and any per-model quota configuration.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Models" href="/use-the-api/models">
+<Columns cols={3}>
+  <Card title="Models" icon="list" href="/use-the-api/models">
     Discover available models, capabilities, engines, and healthy capacity.
   </Card>
 
-  <Card title="Infinity agent" href="/deploy/agents/infinity">
+  <Card title="Infinity agent" icon="microchip" href="/deploy/agents/infinity">
     Configure embedding and reranking models through Infinity.
   </Card>
 
-  <Card title="Routing concepts" href="/routing/routing-concepts">
+  <Card title="Routing concepts" icon="route" href="/routing/routing-concepts">
     Learn how reranking agents are filtered, ranked, and used in fallback chains.
   </Card>
-</CardGroup>
+</Columns>


### PR DESCRIPTION
## Summary

Apply the approved Mintlify presentation system across the complete Hivenet Router documentation site.

This is a presentation-only pass. It improves hierarchy and scanning with Columns, icons, Steps, accordions, callouts, navigation group icons, and breadcrumb cues while preserving verified technical content, compatibility identifiers, commands, endpoints, defaults, limitations, links, frontmatter, and code examples.

All 55 navigated pages were reviewed. 53 MDX pages received presentation improvements; `observability/admission-control-metrics` and `project/security-policy` were intentionally left unchanged because their existing presentation was already appropriate.

## Related issues

None.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How has this been tested?

- Mintlify branch deployment completed successfully at commit `2069a95`.
- Verified all 55 navigation entries have corresponding files.
- Verified internal page-link targets resolve.
- Verified MDX frontmatter and fenced code blocks were preserved.
- Verified new Mintlify component tags are balanced.
- Confirmed no deprecated `CardGroup` components remain.
- Manually checked representative direct routes across every documentation section.

Go tests were not run because this PR changes documentation presentation only.

## Checklist

- [ ] `go test ./...` passes locally
- [ ] `go vet ./...` and `golangci-lint run` are clean
- [ ] Tests added/updated for the change
- [x] Docs updated (README / docs/) if behavior or flags changed
- [x] No secrets, credentials, or tokens committed
- [ ] Commits follow Conventional Commits

## Additional notes

- Production remains unchanged until this PR is merged.
- The review preview is available at https://mycoroute-docs-visual-polish-pilot.mintlify.site/.
- No changelog was added because the repository does not yet have tagged releases or authoritative release notes.
