### PR TITLE
ci: prune old nightly images from GHCR (keep 10 most recent)

### DIFF
--- a/.github/workflows/prune-nightly.yml
+++ b/.github/workflows/prune-nightly.yml
@@ -1,0 +1,52 @@
+name: Prune old nightly images
+
+# GHCR has no automatic retention, so every merge to main leaves behind another
+# immutable ghcr.io/hivenetoss/{hivenet-router,hivenet-agent}:nightly-<shortsha>
+# version. This job trims that accumulation, keeping the 10 most recent nightly
+# builds per image.
+#
+# It ONLY ever considers images whose tag matches `nightly-*` (see image-tags),
+# so release tags (v*), :latest, and the moving :nightly tag are never deletion
+# candidates. keep-n-most-recent then retains the 10 newest of those, which
+# always includes the current :nightly (it carries a nightly-<sha> tag too).
+#
+# Runs automatically after a GitHub Release is published, and on demand via
+# workflow_dispatch — the manual run defaults to dry-run so you can confirm what
+# it would delete before enabling real deletion.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Only log what would be deleted; delete nothing"
+        type: boolean
+        default: true
+
+concurrency:
+  group: ghcr-prune-nightly
+  cancel-in-progress: false
+
+permissions:
+  packages: write  # required for the GITHUB_TOKEN to delete GHCR package versions
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune nightly-<sha> images, keep the 10 most recent
+        uses: snok/container-retention-policy@v3.1.0
+        with:
+          account: ${{ github.repository_owner }}
+          # The built-in GITHUB_TOKEN can delete versions of packages that
+          # "inherit access from repository" with Admin role. If org settings
+          # block that, create a PAT with the `delete:packages` scope and store
+          # it as the GHCR_CLEANUP_TOKEN secret — it is preferred when present.
+          token: ${{ secrets.GHCR_CLEANUP_TOKEN || secrets.GITHUB_TOKEN }}
+          image-names: "hivenet-router hivenet-agent"
+          image-tags: "nightly-*"   # scope: never touch v*, :latest, or :nightly
+          tag-selection: tagged
+          cut-off: 1s               # age gate disabled; keep-n is the real control
+          keep-n-most-recent: 10
+          # release → real deletion; manual dispatch → honor the dry_run input.
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}


### PR DESCRIPTION
## What

GHCR has **no automatic retention**, so every merge to `main` adds another immutable `nightly-<shortsha>` version to the `hivenet-router` and `hivenet-agent` packages — unbounded growth. This adds a workflow that trims them to the **10 most recent per image**.

- **Scoped to `image-tags: nightly-*`** → release tags (`v*`), `:latest`, and the moving `:nightly` tag are **never** deletion candidates. `keep-n-most-recent: 10` retains the 10 newest nightlies (which always includes the current `:nightly`, since it also carries a `nightly-<sha>` tag).
- **Triggers**: automatically on `release: published`, plus `workflow_dispatch` (manual runs **default to dry-run**).
- **Auth**: built-in `GITHUB_TOKEN` (`packages: write`). Works once the packages "inherit access from repository" with Admin role. A `GHCR_CLEANUP_TOKEN` PAT (scope `delete:packages`) is honored if present, for orgs that require it.

## How to validate safely (do this once, before relying on it)
1. Merge this PR (its merge also exercises the **nightly** pipeline — a good end-to-end test of the GHCR publish).
2. After a few nightlies exist, run **Actions → Prune old nightly images → Run workflow** with **dry_run = true**.
3. Confirm the log lists only `nightly-<sha>` versions and would keep 10 — no `v*`/`latest`/`nightly` entries.
4. From then on, each published release prunes for real.

## Notes
- Single-arch (`linux/amd64`) builds, so this doesn't need an untagged-manifest sweep.
- Pinned to `snok/container-retention-policy@v3.1.0`.