### PR TITLE
metrics: rename Prometheus prefix hivenet_router_* → hivenet_*

### DIFF
--- a/deploy/grafana/provisioning/dashboards/hivenet-router.json
+++ b/deploy/grafana/provisioning/dashboards/hivenet-router.json
@@ -22,7 +22,7 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(hivenet_router_routing_agent_info, model)",
+        "definition": "label_values(hivenet_routing_agent_info, model)",
         "hide": 0,
         "includeAll": true,
         "allValue": ".*",
@@ -31,7 +31,7 @@
         "name": "model",
         "options": [],
         "query": {
-          "query": "label_values(hivenet_router_routing_agent_info, model)",
+          "query": "label_values(hivenet_routing_agent_info, model)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -49,7 +49,7 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(hivenet_router_routing_agent_info, engine)",
+        "definition": "label_values(hivenet_routing_agent_info, engine)",
         "hide": 0,
         "includeAll": true,
         "allValue": ".*",
@@ -58,7 +58,7 @@
         "name": "engine",
         "options": [],
         "query": {
-          "query": "label_values(hivenet_router_routing_agent_info, engine)",
+          "query": "label_values(hivenet_routing_agent_info, engine)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -76,7 +76,7 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(hivenet_router_routing_agent_info, peer_id)",
+        "definition": "label_values(hivenet_routing_agent_info, peer_id)",
         "hide": 0,
         "includeAll": true,
         "allValue": ".*",
@@ -85,7 +85,7 @@
         "name": "peer_id",
         "options": [],
         "query": {
-          "query": "label_values(hivenet_router_routing_agent_info, peer_id)",
+          "query": "label_values(hivenet_routing_agent_info, peer_id)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -103,7 +103,7 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(hivenet_router_routing_agent_info, organization)",
+        "definition": "label_values(hivenet_routing_agent_info, organization)",
         "hide": 0,
         "includeAll": true,
         "allValue": ".*",
@@ -112,7 +112,7 @@
         "name": "organization",
         "options": [],
         "query": {
-          "query": "label_values(hivenet_router_routing_agent_info, organization)",
+          "query": "label_values(hivenet_routing_agent_info, organization)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -130,7 +130,7 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(hivenet_router_routing_agent_info, machine)",
+        "definition": "label_values(hivenet_routing_agent_info, machine)",
         "hide": 0,
         "includeAll": true,
         "allValue": ".*",
@@ -139,7 +139,7 @@
         "name": "machine",
         "options": [],
         "query": {
-          "query": "label_values(hivenet_router_routing_agent_info, machine)",
+          "query": "label_values(hivenet_routing_agent_info, machine)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -200,7 +200,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "count(hivenet_router_routing_agent_info{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}) or vector(0)",
+          "expr": "count(hivenet_routing_agent_info{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}) or vector(0)",
           "legendFormat": "agents",
           "refId": "A"
         }
@@ -256,7 +256,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(hivenet_router_routing_agent_healthy{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}) or vector(0)",
+          "expr": "sum(hivenet_routing_agent_healthy{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}) or vector(0)",
           "legendFormat": "healthy",
           "refId": "A"
         }
@@ -291,7 +291,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum(hivenet_router_policy_primary_routed_total{model=~\"$model\"}) or vector(0)",
+          "expr": "sum(hivenet_policy_primary_routed_total{model=~\"$model\"}) or vector(0)",
           "legendFormat": "primary",
           "refId": "A"
         }
@@ -327,7 +327,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum(hivenet_router_policy_fallback_routed_total{model=~\"$model\"}) or vector(0)",
+          "expr": "sum(hivenet_policy_fallback_routed_total{model=~\"$model\"}) or vector(0)",
           "legendFormat": "fallback",
           "refId": "A"
         }
@@ -363,7 +363,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum(hivenet_router_policy_exhausted_total{model=~\"$model\"}) or vector(0)",
+          "expr": "sum(hivenet_policy_exhausted_total{model=~\"$model\"}) or vector(0)",
           "legendFormat": "exhausted",
           "refId": "A"
         }
@@ -396,7 +396,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum(hivenet_router_policy_provider_fallback_total{model=~\"$model\"}) or vector(0)",
+          "expr": "sum(hivenet_policy_provider_fallback_total{model=~\"$model\"}) or vector(0)",
           "legendFormat": "provider fallback",
           "refId": "A"
         }
@@ -558,7 +558,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_routing_agent_info{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_routing_agent_info{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -569,7 +569,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_routing_agent_healthy{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_routing_agent_healthy{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -580,7 +580,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_routing_agent_last_seen_timestamp{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_routing_agent_last_seen_timestamp{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -591,7 +591,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_failure_total{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"} or on(peer_id,model,engine) 0 * hivenet_router_agent_success_rate{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_failure_total{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"} or on(peer_id,model,engine) 0 * hivenet_agent_success_rate{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -602,7 +602,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_model_backend_failure_total{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"} or on(peer_id,model,engine) 0 * hivenet_router_agent_success_rate{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_model_backend_failure_total{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"} or on(peer_id,model,engine) 0 * hivenet_agent_success_rate{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -613,7 +613,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_disconnections_total{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"} or on(peer_id,model,engine) 0 * hivenet_router_agent_success_rate{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_disconnections_total{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"} or on(peer_id,model,engine) 0 * hivenet_agent_success_rate{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -926,7 +926,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_success_rate{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_success_rate{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -937,7 +937,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_capacity_utilization{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_capacity_utilization{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -948,7 +948,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_srtt_ms{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_srtt_ms{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -959,7 +959,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_rttvar_ms{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_rttvar_ms{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -970,7 +970,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_requests_success_total{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"} or on(peer_id,model,engine) 0 * hivenet_router_agent_success_rate{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_requests_success_total{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"} or on(peer_id,model,engine) 0 * hivenet_agent_success_rate{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "instant": true,
           "legendFormat": "",
           "refId": "F",
@@ -981,7 +981,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_requests_failed_total{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"} or on(peer_id,model,engine) 0 * hivenet_router_agent_success_rate{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_requests_failed_total{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"} or on(peer_id,model,engine) 0 * hivenet_agent_success_rate{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "instant": true,
           "legendFormat": "",
           "refId": "G",
@@ -992,7 +992,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_input_tokens_total{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"} or on(peer_id,model,engine) 0 * hivenet_router_agent_success_rate{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_input_tokens_total{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"} or on(peer_id,model,engine) 0 * hivenet_agent_success_rate{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "instant": true,
           "legendFormat": "",
           "refId": "H",
@@ -1003,7 +1003,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_output_tokens_total{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"} or on(peer_id,model,engine) 0 * hivenet_router_agent_success_rate{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_output_tokens_total{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"} or on(peer_id,model,engine) 0 * hivenet_agent_success_rate{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "instant": true,
           "legendFormat": "",
           "refId": "I",
@@ -1014,7 +1014,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_rejected_requests_total{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"} or on(peer_id,model,engine) 0 * hivenet_router_agent_success_rate{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_rejected_requests_total{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"} or on(peer_id,model,engine) 0 * hivenet_agent_success_rate{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "instant": true,
           "legendFormat": "",
           "refId": "J",
@@ -1317,7 +1317,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_cpu_usage_percent{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_cpu_usage_percent{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -1328,7 +1328,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_memory_used_percent{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_memory_used_percent{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -1339,7 +1339,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_memory_available_bytes{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_memory_available_bytes{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -1350,7 +1350,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_memory_total_bytes{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_memory_total_bytes{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -1649,7 +1649,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_gpu_utilization_percent{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_gpu_utilization_percent{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -1660,7 +1660,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_gpu_vram_used_bytes{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_gpu_vram_used_bytes{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -1671,7 +1671,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_gpu_vram_free_bytes{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_gpu_vram_free_bytes{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -1682,7 +1682,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_gpu_vram_total_bytes{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_gpu_vram_total_bytes{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -1693,7 +1693,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_gpu_temperature_celsius{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_gpu_temperature_celsius{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -1704,7 +1704,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_gpu_power_watts{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_gpu_power_watts{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -1886,7 +1886,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_gpu_utilization_percent{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_gpu_utilization_percent{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "legendFormat": "{{peer_id}} [GPU{{gpu_index}}]",
           "refId": "A"
         }
@@ -1944,7 +1944,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_gpu_vram_used_bytes{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_gpu_vram_used_bytes{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "legendFormat": "{{peer_id}} [GPU{{gpu_index}}]",
           "refId": "A"
         }
@@ -2019,7 +2019,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_gpu_temperature_celsius{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_gpu_temperature_celsius{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "legendFormat": "{{peer_id}} [GPU{{gpu_index}}]",
           "refId": "A"
         }
@@ -2078,7 +2078,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_gpu_power_watts{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_gpu_power_watts{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "legendFormat": "{{peer_id}} [GPU{{gpu_index}}]",
           "refId": "A"
         }
@@ -2154,7 +2154,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_cpu_usage_percent{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_cpu_usage_percent{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "legendFormat": "{{peer_id}}",
           "refId": "A"
         }
@@ -2212,7 +2212,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_memory_available_bytes{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_memory_available_bytes{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "legendFormat": "{{peer_id}}",
           "refId": "A"
         }
@@ -2566,7 +2566,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_engine_kv_cache_utilization{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_engine_kv_cache_utilization{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -2577,7 +2577,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_engine_running_requests{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_engine_running_requests{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -2588,7 +2588,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_engine_waiting_requests{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_engine_waiting_requests{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -2599,7 +2599,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_engine_preemptions_total{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_engine_preemptions_total{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -2610,7 +2610,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_engine_avg_ttft_seconds{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_engine_avg_ttft_seconds{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -2621,7 +2621,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_engine_avg_itl_seconds{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_engine_avg_itl_seconds{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -2632,7 +2632,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_engine_p90_ttft_seconds{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_engine_p90_ttft_seconds{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -2643,7 +2643,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_engine_p90_itl_seconds{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_engine_p90_itl_seconds{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -2654,7 +2654,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_engine_predicted_tps{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_engine_predicted_tps{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -2665,7 +2665,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_engine_prompt_tps{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_engine_prompt_tps{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -2852,7 +2852,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_engine_kv_cache_utilization{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_engine_kv_cache_utilization{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "legendFormat": "{{peer_id}}",
           "refId": "A"
         }
@@ -2910,7 +2910,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_engine_running_requests{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_engine_running_requests{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "legendFormat": "Running \u2014 {{peer_id}}",
           "refId": "A"
         },
@@ -2919,7 +2919,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_engine_waiting_requests{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_engine_waiting_requests{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "legendFormat": "Waiting \u2014 {{peer_id}}",
           "refId": "B"
         }
@@ -2977,7 +2977,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(hivenet_router_agent_engine_preemptions_total{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}[5m])",
+          "expr": "rate(hivenet_agent_engine_preemptions_total{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}[5m])",
           "legendFormat": "{{peer_id}}",
           "refId": "A"
         }
@@ -3053,7 +3053,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_engine_avg_ttft_seconds{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_engine_avg_ttft_seconds{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "legendFormat": "Avg TTFT \u2014 {{peer_id}}",
           "refId": "A"
         },
@@ -3062,7 +3062,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_engine_p90_ttft_seconds{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_engine_p90_ttft_seconds{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "legendFormat": "P90 TTFT \u2014 {{peer_id}}",
           "refId": "B"
         }
@@ -3121,7 +3121,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_engine_avg_itl_seconds{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_engine_avg_itl_seconds{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "legendFormat": "Avg ITL \u2014 {{peer_id}}",
           "refId": "A"
         },
@@ -3130,7 +3130,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_engine_p90_itl_seconds{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_engine_p90_itl_seconds{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "legendFormat": "P90 ITL \u2014 {{peer_id}}",
           "refId": "B"
         }
@@ -3189,7 +3189,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_engine_predicted_tps{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_engine_predicted_tps{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "legendFormat": "Pred t/s \u2014 {{peer_id}}",
           "refId": "A"
         },
@@ -3198,7 +3198,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_agent_engine_prompt_tps{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
+          "expr": "hivenet_agent_engine_prompt_tps{model=~\"$model\",engine=~\"$engine\",peer_id=~\"$peer_id\",organization=~\"$organization\",machine=~\"$machine\"}",
           "legendFormat": "Prompt t/s \u2014 {{peer_id}}",
           "refId": "B"
         }

--- a/deploy/grafana/provisioning/dashboards/tenants.json
+++ b/deploy/grafana/provisioning/dashboards/tenants.json
@@ -49,7 +49,7 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(hivenet_router_tenant_quota_rpm_limit, tenant_id)",
+        "definition": "label_values(hivenet_tenant_quota_rpm_limit, tenant_id)",
         "hide": 0,
         "includeAll": false,
         "label": "Tenant",
@@ -57,7 +57,7 @@
         "name": "tenant_id",
         "options": [],
         "query": {
-          "query": "label_values(hivenet_router_tenant_quota_rpm_limit, tenant_id)",
+          "query": "label_values(hivenet_tenant_quota_rpm_limit, tenant_id)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -75,7 +75,7 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values({__name__=~\"hivenet_router_tenant_requests_success_total|hivenet_router_tenant_requests_failed_total\",tenant_id=~\"$tenant_id\", model!=\"\"}, model)",
+        "definition": "label_values({__name__=~\"hivenet_tenant_requests_success_total|hivenet_tenant_requests_failed_total\",tenant_id=~\"$tenant_id\", model!=\"\"}, model)",
         "hide": 0,
         "includeAll": true,
         "allValue": ".*",
@@ -84,7 +84,7 @@
         "name": "model",
         "options": [],
         "query": {
-          "query": "label_values({__name__=~\"hivenet_router_tenant_requests_success_total|hivenet_router_tenant_requests_failed_total\",tenant_id=~\"$tenant_id\", model!=\"\"}, model)",
+          "query": "label_values({__name__=~\"hivenet_tenant_requests_success_total|hivenet_tenant_requests_failed_total\",tenant_id=~\"$tenant_id\", model!=\"\"}, model)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -164,7 +164,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "max(hivenet_router_tenant_quota_rpm_limit{tenant_id=~\"$tenant_id\"})",
+          "expr": "max(hivenet_tenant_quota_rpm_limit{tenant_id=~\"$tenant_id\"})",
           "instant": true,
           "legendFormat": "",
           "refId": "A"
@@ -228,7 +228,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "max(hivenet_router_tenant_quota_tpd_limit{tenant_id=~\"$tenant_id\"})",
+          "expr": "max(hivenet_tenant_quota_tpd_limit{tenant_id=~\"$tenant_id\"})",
           "instant": true,
           "legendFormat": "",
           "refId": "A"
@@ -282,7 +282,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "(sum(hivenet_router_tenant_requests_success_total{tenant_id=~\"$tenant_id\", model=~\"$model\"}) or vector(0)) + (sum(hivenet_router_tenant_requests_failed_total{tenant_id=~\"$tenant_id\", model=~\"$model\"}) or vector(0))",
+          "expr": "(sum(hivenet_tenant_requests_success_total{tenant_id=~\"$tenant_id\", model=~\"$model\"}) or vector(0)) + (sum(hivenet_tenant_requests_failed_total{tenant_id=~\"$tenant_id\", model=~\"$model\"}) or vector(0))",
           "instant": true,
           "legendFormat": "",
           "refId": "A"
@@ -346,7 +346,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "(sum(hivenet_router_tenant_requests_success_total{tenant_id=~\"$tenant_id\", model=~\"$model\"}) or vector(0)) / clamp_min((sum(hivenet_router_tenant_requests_success_total{tenant_id=~\"$tenant_id\", model=~\"$model\"}) or vector(0)) + (sum(hivenet_router_tenant_requests_failed_total{tenant_id=~\"$tenant_id\", model=~\"$model\"}) or vector(0)), 1)",
+          "expr": "(sum(hivenet_tenant_requests_success_total{tenant_id=~\"$tenant_id\", model=~\"$model\"}) or vector(0)) / clamp_min((sum(hivenet_tenant_requests_success_total{tenant_id=~\"$tenant_id\", model=~\"$model\"}) or vector(0)) + (sum(hivenet_tenant_requests_failed_total{tenant_id=~\"$tenant_id\", model=~\"$model\"}) or vector(0)), 1)",
           "instant": true,
           "legendFormat": "",
           "refId": "A"
@@ -408,7 +408,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "(sum(hivenet_router_tenant_rate_limited_total{tenant_id=~\"$tenant_id\"}) or vector(0))",
+          "expr": "(sum(hivenet_tenant_rate_limited_total{tenant_id=~\"$tenant_id\"}) or vector(0))",
           "instant": true,
           "legendFormat": "",
           "refId": "A"
@@ -470,7 +470,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "(sum(hivenet_router_tenant_token_limited_total{tenant_id=~\"$tenant_id\"}) or vector(0))",
+          "expr": "(sum(hivenet_tenant_token_limited_total{tenant_id=~\"$tenant_id\"}) or vector(0))",
           "instant": true,
           "legendFormat": "",
           "refId": "A"
@@ -524,7 +524,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hivenet_router_tenant_last_request_timestamp{tenant_id=~\"$tenant_id\"} * 1000",
+          "expr": "hivenet_tenant_last_request_timestamp{tenant_id=~\"$tenant_id\"} * 1000",
           "legendFormat": "Last request",
           "refId": "A"
         }
@@ -668,7 +668,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "((sum(rate(hivenet_router_tenant_requests_success_total{tenant_id=~\"$tenant_id\", model=~\"$model\"}[$__rate_interval])) or vector(0)) + (sum(rate(hivenet_router_tenant_requests_failed_total{tenant_id=~\"$tenant_id\", model=~\"$model\"}[$__rate_interval])) or vector(0))) * 60",
+          "expr": "((sum(rate(hivenet_tenant_requests_success_total{tenant_id=~\"$tenant_id\", model=~\"$model\"}[$__rate_interval])) or vector(0)) + (sum(rate(hivenet_tenant_requests_failed_total{tenant_id=~\"$tenant_id\", model=~\"$model\"}[$__rate_interval])) or vector(0))) * 60",
           "legendFormat": "Actual req/min",
           "refId": "A"
         },
@@ -677,7 +677,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "max(hivenet_router_tenant_quota_rpm_limit{tenant_id=~\"$tenant_id\"}) > 0",
+          "expr": "max(hivenet_tenant_quota_rpm_limit{tenant_id=~\"$tenant_id\"}) > 0",
           "legendFormat": "RPM Limit",
           "refId": "B"
         }
@@ -769,7 +769,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "(sum(hivenet_router_tenant_tokens_used_today{tenant_id=~\"$tenant_id\"}) / sum(hivenet_router_tenant_quota_tpd_limit{tenant_id=~\"$tenant_id\"})) and on() (sum(hivenet_router_tenant_quota_tpd_limit{tenant_id=~\"$tenant_id\"}) > 0)",
+          "expr": "(sum(hivenet_tenant_tokens_used_today{tenant_id=~\"$tenant_id\"}) / sum(hivenet_tenant_quota_tpd_limit{tenant_id=~\"$tenant_id\"})) and on() (sum(hivenet_tenant_quota_tpd_limit{tenant_id=~\"$tenant_id\"}) > 0)",
           "instant": true,
           "legendFormat": "",
           "refId": "A"
@@ -823,7 +823,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(hivenet_router_tenant_tokens_used_today{tenant_id=~\"$tenant_id\"})",
+          "expr": "sum(hivenet_tenant_tokens_used_today{tenant_id=~\"$tenant_id\"})",
           "instant": true,
           "legendFormat": "",
           "refId": "A"
@@ -902,7 +902,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(hivenet_router_tenant_input_tokens_total{tenant_id=~\"$tenant_id\", model=~\"$model\"})",
+          "expr": "sum(hivenet_tenant_input_tokens_total{tenant_id=~\"$tenant_id\", model=~\"$model\"})",
           "instant": true,
           "legendFormat": "Prompt",
           "refId": "A"
@@ -912,7 +912,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(hivenet_router_tenant_output_tokens_total{tenant_id=~\"$tenant_id\", model=~\"$model\"})",
+          "expr": "sum(hivenet_tenant_output_tokens_total{tenant_id=~\"$tenant_id\", model=~\"$model\"})",
           "instant": true,
           "legendFormat": "Completion",
           "refId": "B"
@@ -965,7 +965,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "(sum(rate(hivenet_router_tenant_input_tokens_total{tenant_id=~\"$tenant_id\", model=~\"$model\"}[$__rate_interval])) + sum(rate(hivenet_router_tenant_output_tokens_total{tenant_id=~\"$tenant_id\", model=~\"$model\"}[$__rate_interval]))) / clamp_min(sum(rate(hivenet_router_tenant_requests_success_total{tenant_id=~\"$tenant_id\", model=~\"$model\"}[$__rate_interval])), 0.0001)",
+          "expr": "(sum(rate(hivenet_tenant_input_tokens_total{tenant_id=~\"$tenant_id\", model=~\"$model\"}[$__rate_interval])) + sum(rate(hivenet_tenant_output_tokens_total{tenant_id=~\"$tenant_id\", model=~\"$model\"}[$__rate_interval]))) / clamp_min(sum(rate(hivenet_tenant_requests_success_total{tenant_id=~\"$tenant_id\", model=~\"$model\"}[$__rate_interval])), 0.0001)",
           "legendFormat": "tokens/req",
           "refId": "A"
         }
@@ -1027,7 +1027,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "((sum(hivenet_router_tenant_quota_tpd_limit{tenant_id=~\"$tenant_id\"}) - sum(hivenet_router_tenant_tokens_used_today{tenant_id=~\"$tenant_id\"})) / clamp_min(sum(rate(hivenet_router_tenant_input_tokens_total{tenant_id=~\"$tenant_id\"}[10m])) + sum(rate(hivenet_router_tenant_output_tokens_total{tenant_id=~\"$tenant_id\"}[10m])), 0.001) / 3600) and on() (sum(hivenet_router_tenant_quota_tpd_limit{tenant_id=~\"$tenant_id\"}) > 0)",
+          "expr": "((sum(hivenet_tenant_quota_tpd_limit{tenant_id=~\"$tenant_id\"}) - sum(hivenet_tenant_tokens_used_today{tenant_id=~\"$tenant_id\"})) / clamp_min(sum(rate(hivenet_tenant_input_tokens_total{tenant_id=~\"$tenant_id\"}[10m])) + sum(rate(hivenet_tenant_output_tokens_total{tenant_id=~\"$tenant_id\"}[10m])), 0.001) / 3600) and on() (sum(hivenet_tenant_quota_tpd_limit{tenant_id=~\"$tenant_id\"}) > 0)",
           "legendFormat": "Hours remaining",
           "refId": "A"
         }
@@ -1099,7 +1099,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "clamp_min(sum(hivenet_router_tenant_quota_tpd_limit{tenant_id=~\"$tenant_id\"}) - sum(hivenet_router_tenant_tokens_used_today{tenant_id=~\"$tenant_id\"}), 0) and on() sum(hivenet_router_tenant_quota_tpd_limit{tenant_id=~\"$tenant_id\"}) > 0",
+          "expr": "clamp_min(sum(hivenet_tenant_quota_tpd_limit{tenant_id=~\"$tenant_id\"}) - sum(hivenet_tenant_tokens_used_today{tenant_id=~\"$tenant_id\"}), 0) and on() sum(hivenet_tenant_quota_tpd_limit{tenant_id=~\"$tenant_id\"}) > 0",
           "instant": true,
           "legendFormat": "",
           "refId": "A"
@@ -1156,7 +1156,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(hivenet_router_tenant_input_tokens_total{tenant_id=~\"$tenant_id\", model=~\"$model\"}[$__rate_interval]))",
+          "expr": "sum(rate(hivenet_tenant_input_tokens_total{tenant_id=~\"$tenant_id\", model=~\"$model\"}[$__rate_interval]))",
           "legendFormat": "Prompt tokens/s",
           "refId": "A"
         },
@@ -1165,7 +1165,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(hivenet_router_tenant_output_tokens_total{tenant_id=~\"$tenant_id\", model=~\"$model\"}[$__rate_interval]))",
+          "expr": "sum(rate(hivenet_tenant_output_tokens_total{tenant_id=~\"$tenant_id\", model=~\"$model\"}[$__rate_interval]))",
           "legendFormat": "Completion tokens/s",
           "refId": "B"
         }
@@ -1225,7 +1225,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(hivenet_router_tenant_request_duration_seconds_bucket{tenant_id=~\"$tenant_id\", model=~\"$model\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(hivenet_tenant_request_duration_seconds_bucket{tenant_id=~\"$tenant_id\", model=~\"$model\"}[$__rate_interval])))",
           "legendFormat": "P50",
           "refId": "A"
         },
@@ -1234,7 +1234,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(hivenet_router_tenant_request_duration_seconds_bucket{tenant_id=~\"$tenant_id\", model=~\"$model\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(hivenet_tenant_request_duration_seconds_bucket{tenant_id=~\"$tenant_id\", model=~\"$model\"}[$__rate_interval])))",
           "legendFormat": "P95",
           "refId": "B"
         },
@@ -1243,7 +1243,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(hivenet_router_tenant_request_duration_seconds_bucket{tenant_id=~\"$tenant_id\", model=~\"$model\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(hivenet_tenant_request_duration_seconds_bucket{tenant_id=~\"$tenant_id\", model=~\"$model\"}[$__rate_interval])))",
           "legendFormat": "P99",
           "refId": "C"
         }
@@ -1304,7 +1304,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "(\n  (sum by (model) (hivenet_router_tenant_requests_success_total{tenant_id=~\"$tenant_id\"}) or 0 * sum by (model) (hivenet_router_tenant_requests_failed_total{tenant_id=~\"$tenant_id\"}))\n  + on(model) group_left()\n  (sum by (model) (hivenet_router_tenant_requests_failed_total{tenant_id=~\"$tenant_id\"}) or 0 * sum by (model) (hivenet_router_tenant_requests_success_total{tenant_id=~\"$tenant_id\"}))\n) / on() group_left() (\n  (sum(hivenet_router_tenant_requests_success_total{tenant_id=~\"$tenant_id\"}) or vector(0)) + (sum(hivenet_router_tenant_requests_failed_total{tenant_id=~\"$tenant_id\"}) or vector(0))\n) * 100",
+          "expr": "(\n  (sum by (model) (hivenet_tenant_requests_success_total{tenant_id=~\"$tenant_id\"}) or 0 * sum by (model) (hivenet_tenant_requests_failed_total{tenant_id=~\"$tenant_id\"}))\n  + on(model) group_left()\n  (sum by (model) (hivenet_tenant_requests_failed_total{tenant_id=~\"$tenant_id\"}) or 0 * sum by (model) (hivenet_tenant_requests_success_total{tenant_id=~\"$tenant_id\"}))\n) / on() group_left() (\n  (sum(hivenet_tenant_requests_success_total{tenant_id=~\"$tenant_id\"}) or vector(0)) + (sum(hivenet_tenant_requests_failed_total{tenant_id=~\"$tenant_id\"}) or vector(0))\n) * 100",
           "legendFormat": "{{model}}",
           "refId": "A"
         }

--- a/docs/deploy/agents/infinity.mdx
+++ b/docs/deploy/agents/infinity.mdx
@@ -560,7 +560,7 @@ Embedding request rate:
 
 ```promql
 rate(
-  hivenet_router_routing_requests_routed_total{
+  hivenet_routing_requests_routed_total{
     engine="infinity",
     model="bge-m3"
   }[5m]
@@ -571,7 +571,7 @@ Reranking request rate:
 
 ```promql
 rate(
-  hivenet_router_routing_requests_routed_total{
+  hivenet_routing_requests_routed_total{
     engine="infinity",
     model="bge-reranker-large"
   }[5m]
@@ -581,7 +581,7 @@ rate(
 Smoothed round-trip time:
 
 ```promql
-hivenet_router_agent_srtt_ms{
+hivenet_agent_srtt_ms{
   engine="infinity"
 }
 ```

--- a/docs/deploy/agents/llama-cpp.mdx
+++ b/docs/deploy/agents/llama-cpp.mdx
@@ -374,21 +374,21 @@ View all engine metrics through the router:
 
 ```bash
 curl http://192.168.1.100:2112/metrics \
-  | grep hivenet_router_agent_engine
+  | grep hivenet_agent_engine
 ```
 
 Useful exported metrics include:
 
 ```text
-hivenet_router_agent_engine_kv_cache_utilization
-hivenet_router_agent_engine_running_requests
-hivenet_router_agent_engine_waiting_requests
-hivenet_router_agent_engine_avg_ttft_seconds
-hivenet_router_agent_engine_p90_ttft_seconds
-hivenet_router_agent_engine_avg_itl_seconds
-hivenet_router_agent_engine_p90_itl_seconds
-hivenet_router_agent_engine_predicted_tps
-hivenet_router_agent_engine_prompt_tps
+hivenet_agent_engine_kv_cache_utilization
+hivenet_agent_engine_running_requests
+hivenet_agent_engine_waiting_requests
+hivenet_agent_engine_avg_ttft_seconds
+hivenet_agent_engine_p90_ttft_seconds
+hivenet_agent_engine_avg_itl_seconds
+hivenet_agent_engine_p90_itl_seconds
+hivenet_agent_engine_predicted_tps
+hivenet_agent_engine_prompt_tps
 ```
 
 View current values through the routing table:

--- a/docs/deploy/agents/sglang.mdx
+++ b/docs/deploy/agents/sglang.mdx
@@ -365,17 +365,17 @@ View engine metrics on the router:
 
 ```bash
 curl http://192.168.1.100:2112/metrics \
-  | grep hivenet_router_agent_engine
+  | grep hivenet_agent_engine
 ```
 
 Useful exported metrics include:
 
 ```text
-hivenet_router_agent_engine_kv_cache_utilization
-hivenet_router_agent_engine_running_requests
-hivenet_router_agent_engine_waiting_requests
-hivenet_router_agent_engine_avg_ttft_seconds
-hivenet_router_agent_engine_p90_ttft_seconds
+hivenet_agent_engine_kv_cache_utilization
+hivenet_agent_engine_running_requests
+hivenet_agent_engine_waiting_requests
+hivenet_agent_engine_avg_ttft_seconds
+hivenet_agent_engine_p90_ttft_seconds
 ```
 
 View current values through the routing table:

--- a/docs/deploy/agents/vllm.mdx
+++ b/docs/deploy/agents/vllm.mdx
@@ -380,20 +380,20 @@ View all engine metrics on the router:
 
 ```bash
 curl http://192.168.1.100:2112/metrics \
-  | grep hivenet_router_agent_engine
+  | grep hivenet_agent_engine
 ```
 
 Useful exported metrics include:
 
 ```text
-hivenet_router_agent_engine_kv_cache_utilization
-hivenet_router_agent_engine_running_requests
-hivenet_router_agent_engine_waiting_requests
-hivenet_router_agent_engine_preemptions_total
-hivenet_router_agent_engine_avg_ttft_seconds
-hivenet_router_agent_engine_p90_ttft_seconds
-hivenet_router_agent_engine_avg_itl_seconds
-hivenet_router_agent_engine_p90_itl_seconds
+hivenet_agent_engine_kv_cache_utilization
+hivenet_agent_engine_running_requests
+hivenet_agent_engine_waiting_requests
+hivenet_agent_engine_preemptions_total
+hivenet_agent_engine_avg_ttft_seconds
+hivenet_agent_engine_p90_ttft_seconds
+hivenet_agent_engine_avg_itl_seconds
+hivenet_agent_engine_p90_itl_seconds
 ```
 
 View live values through the routing table:

--- a/docs/deploy/bare-metal.mdx
+++ b/docs/deploy/bare-metal.mdx
@@ -820,7 +820,7 @@ When the router itself is behind NAT or another translated network, configure th
 
     ```bash
     curl http://192.168.1.100:2112/metrics \
-      | grep hivenet_router_routing_requests_routed_total
+      | grep hivenet_routing_requests_routed_total
     ```
   </Accordion>
 </AccordionGroup>

--- a/docs/deploy/docker-compose.mdx
+++ b/docs/deploy/docker-compose.mdx
@@ -541,26 +541,26 @@ http://localhost:9090
 Active agents:
 
 ```promql
-count(hivenet_router_routing_agent_info)
+count(hivenet_routing_agent_info)
 ```
 
 Request routing rate:
 
 ```promql
-rate(hivenet_router_routing_requests_routed_total[5m])
+rate(hivenet_routing_requests_routed_total[5m])
 ```
 
 Failed routing rate:
 
 ```promql
-rate(hivenet_router_routing_requests_failed_total[5m])
+rate(hivenet_routing_requests_failed_total[5m])
 ```
 
 Smoothed round-trip time by model:
 
 ```promql
 avg by (model) (
-  hivenet_router_agent_srtt_ms
+  hivenet_agent_srtt_ms
 )
 ```
 
@@ -605,7 +605,7 @@ Back up the router database:
 
 ```bash
 docker run --rm \
-  -v hivenet_router_badger_data:/data:ro \
+  -v hivenet_badger_data:/data:ro \
   -v "$PWD/backup:/backup" \
   alpine \
   tar czf /backup/badger-$(date +%Y%m%d).tar.gz -C /data .
@@ -615,7 +615,7 @@ Back up Prometheus:
 
 ```bash
 docker run --rm \
-  -v hivenet_router_prometheus_data:/data:ro \
+  -v hivenet_prometheus_data:/data:ro \
   -v "$PWD/backup:/backup" \
   alpine \
   tar czf /backup/prometheus-$(date +%Y%m%d).tar.gz -C /data .
@@ -625,7 +625,7 @@ Back up Grafana:
 
 ```bash
 docker run --rm \
-  -v hivenet_router_grafana_data:/data:ro \
+  -v hivenet_grafana_data:/data:ro \
   -v "$PWD/backup:/backup" \
   alpine \
   tar czf /backup/grafana-$(date +%Y%m%d).tar.gz -C /data .
@@ -649,7 +649,7 @@ Clear the existing contents and restore the archive:
 
 ```bash
 docker run --rm \
-  -v hivenet_router_badger_data:/data \
+  -v hivenet_badger_data:/data \
   -v "$PWD/backup:/backup:ro" \
   alpine \
   sh -c 'rm -rf /data/* && tar xzf /backup/badger-<date>.tar.gz -C /data'
@@ -724,7 +724,7 @@ docker compose --env-file .env up -d
     ```bash
     docker compose exec prometheus \
       wget -qO- \
-      'http://localhost:9090/api/v1/query?query=hivenet_router_routing_agent_info' \
+      'http://localhost:9090/api/v1/query?query=hivenet_routing_agent_info' \
       | jq .
     ```
 

--- a/docs/deploy/docker-quickstart.mdx
+++ b/docs/deploy/docker-quickstart.mdx
@@ -422,7 +422,7 @@ This guide uses Docker host networking and is intended for Linux hosts.
 
     ```bash
     curl -s http://192.168.1.100:2112/metrics \
-      | grep hivenet_router_routing_requests_routed_total
+      | grep hivenet_routing_requests_routed_total
     ```
   </Step>
 </Steps>

--- a/docs/integrations/claude-code.mdx
+++ b/docs/integrations/claude-code.mdx
@@ -766,7 +766,7 @@ Request rate:
 ```promql
 sum by (tenant_id, model) (
   rate(
-    hivenet_router_routing_requests_routed_total[5m]
+    hivenet_routing_requests_routed_total[5m]
   )
 )
 ```

--- a/docs/integrations/open-code.mdx
+++ b/docs/integrations/open-code.mdx
@@ -332,7 +332,7 @@ This is the authentication header Hivenet Router expects.
 <Note>
   `HIVENET_ROUTER_API_KEY` is an environment variable used by the OpenCode client.
 
-  It does not need to follow the lower-case `hivenet_router_*` convention used by the Hivenet Router router process.
+  It does not need to follow the lower-case `hivenet_*` convention used by the Hivenet Router router process.
 </Note>
 
 ## Read the key from a file
@@ -1010,7 +1010,7 @@ Request rate by model:
 ```promql
 sum by (tenant_id, model) (
   rate(
-    hivenet_router_routing_requests_routed_total[5m]
+    hivenet_routing_requests_routed_total[5m]
   )
 )
 ```
@@ -1020,7 +1020,7 @@ Failed requests:
 ```promql
 sum by (tenant_id, model) (
   rate(
-    hivenet_router_tenant_requests_failed_total[5m]
+    hivenet_tenant_requests_failed_total[5m]
   )
 )
 ```

--- a/docs/integrations/open-web-ui.mdx
+++ b/docs/integrations/open-web-ui.mdx
@@ -961,7 +961,7 @@ Request rate by model:
 ```promql
 sum by (model) (
   rate(
-    hivenet_router_routing_requests_routed_total{
+    hivenet_routing_requests_routed_total{
       tenant_id="open-webui"
     }[5m]
   )
@@ -973,7 +973,7 @@ Failed requests:
 ```promql
 sum by (model) (
   rate(
-    hivenet_router_tenant_requests_failed_total{
+    hivenet_tenant_requests_failed_total{
       tenant_id="open-webui"
     }[5m]
   )

--- a/docs/integrations/pi.mdx
+++ b/docs/integrations/pi.mdx
@@ -1174,7 +1174,7 @@ Request rate by model:
 ```promql
 sum by (tenant_id, model) (
   rate(
-    hivenet_router_routing_requests_routed_total[5m]
+    hivenet_routing_requests_routed_total[5m]
   )
 )
 ```
@@ -1184,7 +1184,7 @@ Failed requests:
 ```promql
 sum by (tenant_id, model) (
   rate(
-    hivenet_router_tenant_requests_failed_total[5m]
+    hivenet_tenant_requests_failed_total[5m]
   )
 )
 ```

--- a/docs/observability/admission-control-metrics.mdx
+++ b/docs/observability/admission-control-metrics.mdx
@@ -10,15 +10,15 @@ The admission-control metrics show why requests are rejected and how close each 
 
 | Metric | Type | Labels | Meaning |
 | --- | --- | --- | --- |
-| `hivenet_router_admission_rejections_total` | Counter | `reason`, `model` | Requests rejected by an admission gate |
-| `hivenet_router_admission_occupancy_tokens` | Gauge | `model` | Current weighted in-flight token sum |
-| `hivenet_router_admission_budget_tokens` | Gauge | `model` | Effective global budget: `HIVENET_ROUTER_ADMIT_FRACTION × admit_budget_tokens × healthy_replicas` |
-| `hivenet_router_admission_inflight_requests` | Gauge | `model` | Current in-flight request count |
-| `hivenet_router_admission_max_inflight` | Gauge | `model` | Effective `max_inflight × healthy_replicas`; `0` means no count backstop |
+| `hivenet_admission_rejections_total` | Counter | `reason`, `model` | Requests rejected by an admission gate |
+| `hivenet_admission_occupancy_tokens` | Gauge | `model` | Current weighted in-flight token sum |
+| `hivenet_admission_budget_tokens` | Gauge | `model` | Effective global budget: `HIVENET_ROUTER_ADMIT_FRACTION × admit_budget_tokens × healthy_replicas` |
+| `hivenet_admission_inflight_requests` | Gauge | `model` | Current in-flight request count |
+| `hivenet_admission_max_inflight` | Gauge | `model` | Effective `max_inflight × healthy_replicas`; `0` means no count backstop |
 
 The global occupancy controller updates all four gauges when a request is admitted, released, adjusted to exact input usage, or grown by streamed output. The healthy-replica count is recomputed for each admission and floored at `1`, so the budget and backstop gauges follow the live serving pool.
 
-Per-tenant RPM rejects also increment `hivenet_router_tenant_rate_limited_total` in addition to the unified `b4_rpm` reason below.
+Per-tenant RPM rejects also increment `hivenet_tenant_rate_limited_total` in addition to the unified `b4_rpm` reason below.
 
 ### Rejection reasons
 
@@ -37,37 +37,37 @@ Per-tenant RPM rejects also increment `hivenet_router_tenant_rate_limited_total`
 ### Occupancy utilization
 
 ```promql
-hivenet_router_admission_occupancy_tokens
-  / hivenet_router_admission_budget_tokens
+hivenet_admission_occupancy_tokens
+  / hivenet_admission_budget_tokens
 ```
 
 Exclude a zero or unset budget when using this expression in an alert:
 
 ```promql
 (
-  hivenet_router_admission_occupancy_tokens
-    / hivenet_router_admission_budget_tokens
+  hivenet_admission_occupancy_tokens
+    / hivenet_admission_budget_tokens
 )
 and on (model)
-hivenet_router_admission_budget_tokens > 0
+hivenet_admission_budget_tokens > 0
 ```
 
 ### In-flight concurrency utilization
 
 ```promql
 (
-  hivenet_router_admission_inflight_requests
-    / hivenet_router_admission_max_inflight
+  hivenet_admission_inflight_requests
+    / hivenet_admission_max_inflight
 )
 and on (model)
-hivenet_router_admission_max_inflight > 0
+hivenet_admission_max_inflight > 0
 ```
 
 ### Rejections by gate
 
 ```promql
 sum by (reason, model) (
-  rate(hivenet_router_admission_rejections_total[5m])
+  rate(hivenet_admission_rejections_total[5m])
 )
 ```
 
@@ -75,7 +75,7 @@ sum by (reason, model) (
 
 ```promql
 sum by (model) (
-  rate(hivenet_router_admission_rejections_total{reason="b3"}[5m])
+  rate(hivenet_admission_rejections_total{reason="b3"}[5m])
 )
 ```
 
@@ -83,7 +83,7 @@ sum by (model) (
 
 ```promql
 sum by (reason, model) (
-  rate(hivenet_router_admission_rejections_total{reason=~"b4_.*"}[5m])
+  rate(hivenet_admission_rejections_total{reason=~"b4_.*"}[5m])
 )
 ```
 

--- a/docs/observability/engine-metrics.mdx
+++ b/docs/observability/engine-metrics.mdx
@@ -240,7 +240,7 @@ as their common labels.
 For example:
 
 ```promql
-hivenet_router_agent_engine_waiting_requests{
+hivenet_agent_engine_waiting_requests{
   model="meta-llama/Llama-3.1-8B-Instruct",
   engine="vllm"
 }
@@ -301,7 +301,7 @@ The routing table currently exposes scalar engine values. Raw histograms, finish
 ## KV-cache utilization
 
 ```text
-hivenet_router_agent_engine_kv_cache_utilization
+hivenet_agent_engine_kv_cache_utilization
 ```
 
 KV-cache utilization is the fraction of the engine’s preallocated KV or token cache currently in use.
@@ -323,20 +323,20 @@ Backend sources are:
 View current cache use:
 
 ```promql
-hivenet_router_agent_engine_kv_cache_utilization
+hivenet_agent_engine_kv_cache_utilization
 ```
 
 Find agents above 85%:
 
 ```promql
-hivenet_router_agent_engine_kv_cache_utilization > 0.85
+hivenet_agent_engine_kv_cache_utilization > 0.85
 ```
 
 Average by model and engine:
 
 ```promql
 avg by (model, engine) (
-  hivenet_router_agent_engine_kv_cache_utilization
+  hivenet_agent_engine_kv_cache_utilization
 )
 ```
 
@@ -355,7 +355,7 @@ Avoid treating one threshold as universal across every deployment.
 ## Running requests
 
 ```text
-hivenet_router_agent_engine_running_requests
+hivenet_agent_engine_running_requests
 ```
 
 This is the number of requests currently being processed by the inference engine.
@@ -371,14 +371,14 @@ Backend sources are:
 View running requests:
 
 ```promql
-hivenet_router_agent_engine_running_requests
+hivenet_agent_engine_running_requests
 ```
 
 Total by model:
 
 ```promql
 sum by (model) (
-  hivenet_router_agent_engine_running_requests
+  hivenet_agent_engine_running_requests
 )
 ```
 
@@ -402,7 +402,7 @@ For example:
 ## Waiting requests
 
 ```text
-hivenet_router_agent_engine_waiting_requests
+hivenet_agent_engine_waiting_requests
 ```
 
 Waiting requests are queued inside the inference-engine scheduler.
@@ -418,20 +418,20 @@ Backend sources are:
 View backend queues:
 
 ```promql
-hivenet_router_agent_engine_waiting_requests
+hivenet_agent_engine_waiting_requests
 ```
 
 Find agents with queued requests:
 
 ```promql
-hivenet_router_agent_engine_waiting_requests > 0
+hivenet_agent_engine_waiting_requests > 0
 ```
 
 Total waiting work by model:
 
 ```promql
 sum by (model) (
-  hivenet_router_agent_engine_waiting_requests
+  hivenet_agent_engine_waiting_requests
 )
 ```
 
@@ -449,7 +449,7 @@ It is separate from Hivenet Router’s per-model capacity wait queue. One queue 
 ## Preemptions
 
 ```text
-hivenet_router_agent_engine_preemptions_total
+hivenet_agent_engine_preemptions_total
 ```
 
 vLLM reports a cumulative count of requests preempted because of scheduler and KV-cache pressure.
@@ -465,14 +465,14 @@ vllm:num_preemptions_total
 View the current cumulative value:
 
 ```promql
-hivenet_router_agent_engine_preemptions_total
+hivenet_agent_engine_preemptions_total
 ```
 
 Detect growth over a period:
 
 ```promql
 delta(
-  hivenet_router_agent_engine_preemptions_total[5m]
+  hivenet_agent_engine_preemptions_total[5m]
 ) > 0
 ```
 
@@ -482,7 +482,7 @@ Show increases by agent:
 sum by (peer_id, model) (
   clamp_min(
     delta(
-      hivenet_router_agent_engine_preemptions_total[5m]
+      hivenet_agent_engine_preemptions_total[5m]
     ),
     0
   )
@@ -504,8 +504,8 @@ Time to first token, or TTFT, is the time between a request entering the inferen
 Hivenet Router exposes two per-agent gauges:
 
 ```text
-hivenet_router_agent_engine_avg_ttft_seconds
-hivenet_router_agent_engine_p90_ttft_seconds
+hivenet_agent_engine_avg_ttft_seconds
+hivenet_agent_engine_p90_ttft_seconds
 ```
 
 Both are measured in seconds.
@@ -513,7 +513,7 @@ Both are measured in seconds.
 ### Average TTFT
 
 ```promql
-hivenet_router_agent_engine_avg_ttft_seconds
+hivenet_agent_engine_avg_ttft_seconds
 ```
 
 This is calculated from the backend histogram’s cumulative sum and count.
@@ -521,7 +521,7 @@ This is calculated from the backend histogram’s cumulative sum and count.
 ### P90 TTFT
 
 ```promql
-hivenet_router_agent_engine_p90_ttft_seconds
+hivenet_agent_engine_p90_ttft_seconds
 ```
 
 The agent estimates this value from the backend histogram buckets.
@@ -533,15 +533,15 @@ Hivenet Router keeps it as a scalar because routing policies need to read a curr
 For vLLM agents, Hivenet Router also exports:
 
 ```text
-hivenet_router_agent_engine_ttft_seconds
+hivenet_agent_engine_ttft_seconds
 ```
 
 Prometheus exposes:
 
 ```text
-hivenet_router_agent_engine_ttft_seconds_bucket
-hivenet_router_agent_engine_ttft_seconds_sum
-hivenet_router_agent_engine_ttft_seconds_count
+hivenet_agent_engine_ttft_seconds_bucket
+hivenet_agent_engine_ttft_seconds_sum
+hivenet_agent_engine_ttft_seconds_count
 ```
 
 Fleet-wide P90 for vLLM:
@@ -551,7 +551,7 @@ histogram_quantile(
   0.90,
   sum by (le) (
     rate(
-      hivenet_router_agent_engine_ttft_seconds_bucket[5m]
+      hivenet_agent_engine_ttft_seconds_bucket[5m]
     )
   )
 )
@@ -564,7 +564,7 @@ histogram_quantile(
   0.90,
   sum by (le, model) (
     rate(
-      hivenet_router_agent_engine_ttft_seconds_bucket[5m]
+      hivenet_agent_engine_ttft_seconds_bucket[5m]
     )
   )
 )
@@ -595,8 +595,8 @@ Inter-token latency, or ITL, is the time between generated output tokens during 
 Hivenet Router exposes:
 
 ```text
-hivenet_router_agent_engine_avg_itl_seconds
-hivenet_router_agent_engine_p90_itl_seconds
+hivenet_agent_engine_avg_itl_seconds
+hivenet_agent_engine_p90_itl_seconds
 ```
 
 for:
@@ -609,19 +609,19 @@ SGLang does not currently supply ITL through this integration.
 Average ITL:
 
 ```promql
-hivenet_router_agent_engine_avg_itl_seconds
+hivenet_agent_engine_avg_itl_seconds
 ```
 
 P90 ITL:
 
 ```promql
-hivenet_router_agent_engine_p90_itl_seconds
+hivenet_agent_engine_p90_itl_seconds
 ```
 
 For vLLM, Hivenet Router also exports the raw histogram:
 
 ```text
-hivenet_router_agent_engine_itl_seconds
+hivenet_agent_engine_itl_seconds
 ```
 
 Fleet-wide vLLM P90:
@@ -631,7 +631,7 @@ histogram_quantile(
   0.90,
   sum by (le) (
     rate(
-      hivenet_router_agent_engine_itl_seconds_bucket[5m]
+      hivenet_agent_engine_itl_seconds_bucket[5m]
     )
   )
 )
@@ -653,15 +653,15 @@ Possible causes include:
 vLLM supplies a histogram of prompt sizes:
 
 ```text
-hivenet_router_agent_engine_request_prompt_tokens
+hivenet_agent_engine_request_prompt_tokens
 ```
 
 Prometheus exposes:
 
 ```text
-hivenet_router_agent_engine_request_prompt_tokens_bucket
-hivenet_router_agent_engine_request_prompt_tokens_sum
-hivenet_router_agent_engine_request_prompt_tokens_count
+hivenet_agent_engine_request_prompt_tokens_bucket
+hivenet_agent_engine_request_prompt_tokens_sum
+hivenet_agent_engine_request_prompt_tokens_count
 ```
 
 P50 prompt length:
@@ -671,7 +671,7 @@ histogram_quantile(
   0.50,
   sum by (le) (
     rate(
-      hivenet_router_agent_engine_request_prompt_tokens_bucket[5m]
+      hivenet_agent_engine_request_prompt_tokens_bucket[5m]
     )
   )
 )
@@ -684,7 +684,7 @@ histogram_quantile(
   0.90,
   sum by (le, model) (
     rate(
-      hivenet_router_agent_engine_request_prompt_tokens_bucket[5m]
+      hivenet_agent_engine_request_prompt_tokens_bucket[5m]
     )
   )
 )
@@ -703,7 +703,7 @@ Long prompts can increase:
 vLLM also supplies a distribution of generated output lengths:
 
 ```text
-hivenet_router_agent_engine_request_generation_tokens
+hivenet_agent_engine_request_generation_tokens
 ```
 
 P90 generation length:
@@ -713,7 +713,7 @@ histogram_quantile(
   0.90,
   sum by (le, model) (
     rate(
-      hivenet_router_agent_engine_request_generation_tokens_bucket[5m]
+      hivenet_agent_engine_request_generation_tokens_bucket[5m]
     )
   )
 )
@@ -735,7 +735,7 @@ vLLM reports cumulative completion counts grouped by finish reason.
 Hivenet Router converts changes between backend snapshots into the counter:
 
 ```text
-hivenet_router_agent_engine_request_success_total
+hivenet_agent_engine_request_success_total
 ```
 
 Additional label:
@@ -757,7 +757,7 @@ Completion rate by reason:
 ```promql
 sum by (finished_reason) (
   rate(
-    hivenet_router_agent_engine_request_success_total[5m]
+    hivenet_agent_engine_request_success_total[5m]
   )
 )
 ```
@@ -767,7 +767,7 @@ Length-limited completions:
 ```promql
 sum by (model) (
   rate(
-    hivenet_router_agent_engine_request_success_total{
+    hivenet_agent_engine_request_success_total{
       finished_reason="length"
     }[5m]
   )
@@ -779,7 +779,7 @@ Aborted completions:
 ```promql
 sum by (model) (
   rate(
-    hivenet_router_agent_engine_request_success_total{
+    hivenet_agent_engine_request_success_total{
       finished_reason="abort"
     }[5m]
   )
@@ -797,40 +797,40 @@ If the backend count decreases after a restart, Hivenet Router treats the new va
 llama.cpp exposes two current throughput gauges:
 
 ```text
-hivenet_router_agent_engine_predicted_tps
-hivenet_router_agent_engine_prompt_tps
+hivenet_agent_engine_predicted_tps
+hivenet_agent_engine_prompt_tps
 ```
 
 ### Generation throughput
 
 ```text
-hivenet_router_agent_engine_predicted_tps
+hivenet_agent_engine_predicted_tps
 ```
 
 This is the backend’s recent generated-token rate.
 
 ```promql
-hivenet_router_agent_engine_predicted_tps
+hivenet_agent_engine_predicted_tps
 ```
 
 Average by model:
 
 ```promql
 avg by (model) (
-  hivenet_router_agent_engine_predicted_tps
+  hivenet_agent_engine_predicted_tps
 )
 ```
 
 ### Prompt throughput
 
 ```text
-hivenet_router_agent_engine_prompt_tps
+hivenet_agent_engine_prompt_tps
 ```
 
 This is the backend’s recent prompt-ingestion rate.
 
 ```promql
-hivenet_router_agent_engine_prompt_tps
+hivenet_agent_engine_prompt_tps
 ```
 
 These values are currently available through Prometheus but not through the administration routing-table response.
@@ -1005,7 +1005,7 @@ groups:
       - alert: HivenetRouterKVCachePressure
 
         expr: |
-          hivenet_router_agent_engine_kv_cache_utilization > 0.90
+          hivenet_agent_engine_kv_cache_utilization > 0.90
 
         for: 2m
 
@@ -1023,7 +1023,7 @@ groups:
       - alert: HivenetRouterEngineQueue
 
         expr: |
-          hivenet_router_agent_engine_waiting_requests > 10
+          hivenet_agent_engine_waiting_requests > 10
 
         for: 2m
 
@@ -1041,7 +1041,7 @@ groups:
       - alert: HivenetRouterTTFTDegradation
 
         expr: |
-          hivenet_router_agent_engine_p90_ttft_seconds > 0.5
+          hivenet_agent_engine_p90_ttft_seconds > 0.5
 
         for: 5m
 
@@ -1061,7 +1061,7 @@ groups:
         expr: |
           clamp_min(
             delta(
-              hivenet_router_agent_engine_preemptions_total[5m]
+              hivenet_agent_engine_preemptions_total[5m]
             ),
             0
           ) > 0
@@ -1180,7 +1180,7 @@ groups:
     Filter for vLLM:
 
     ```promql
-    hivenet_router_agent_engine_ttft_seconds_count{
+    hivenet_agent_engine_ttft_seconds_count{
       engine="vllm"
     }
     ```
@@ -1194,7 +1194,7 @@ groups:
     ```promql
     clamp_min(
       delta(
-        hivenet_router_agent_engine_preemptions_total[5m]
+        hivenet_agent_engine_preemptions_total[5m]
       ),
       0
     )

--- a/docs/observability/grafana-dashboards.mdx
+++ b/docs/observability/grafana-dashboards.mdx
@@ -159,7 +159,7 @@ For example, primary requests during the last hour:
 ```promql
 sum(
   increase(
-    hivenet_router_policy_primary_routed_total[1h]
+    hivenet_policy_primary_routed_total[1h]
   )
 )
 ```
@@ -207,7 +207,7 @@ These values come from Hivenet Router’s universal per-agent history and can ap
 ### Success rate
 
 ```text
-hivenet_router_agent_success_rate
+hivenet_agent_success_rate
 ```
 
 A value below your normal baseline may indicate backend errors, request incompatibility, or connection instability.
@@ -215,7 +215,7 @@ A value below your normal baseline may indicate backend errors, request incompat
 ### Capacity utilization
 
 ```text
-hivenet_router_agent_capacity_utilization
+hivenet_agent_capacity_utilization
 ```
 
 This is:
@@ -231,8 +231,8 @@ For streaming requests, the current implementation releases the agent slot when 
 ### SRTT and RTTVAR
 
 ```text
-hivenet_router_agent_srtt_ms
-hivenet_router_agent_rttvar_ms
+hivenet_agent_srtt_ms
+hivenet_agent_rttvar_ms
 ```
 
 SRTT represents smoothed request time observed by Hivenet Router.
@@ -339,7 +339,7 @@ Use this in Explore when you need recent positive growth:
 ```promql
 clamp_min(
   delta(
-    hivenet_router_agent_engine_preemptions_total[5m]
+    hivenet_agent_engine_preemptions_total[5m]
   ),
   0
 )
@@ -360,7 +360,7 @@ histogram_quantile(
   0.95,
   sum by (le, model) (
     rate(
-      hivenet_router_agent_engine_ttft_seconds_bucket[5m]
+      hivenet_agent_engine_ttft_seconds_bucket[5m]
     )
   )
 )
@@ -413,8 +413,8 @@ The time-series panels use Grafana’s selected rate interval and respond more d
 Daily token panels use:
 
 ```text
-hivenet_router_tenant_tokens_used_today
-hivenet_router_tenant_quota_tpd_limit
+hivenet_tenant_tokens_used_today
+hivenet_tenant_quota_tpd_limit
 ```
 
 The budget resets at midnight UTC.
@@ -435,14 +435,14 @@ A quota limit of `0` means unlimited. Panels that depend on a finite budget may 
 The current tenant selector is populated from:
 
 ```text
-hivenet_router_tenant_quota_rpm_limit
+hivenet_tenant_quota_rpm_limit
 ```
 
 and several limit panels use the flat quota gauges:
 
 ```text
-hivenet_router_tenant_quota_rpm_limit
-hivenet_router_tenant_quota_tpd_limit
+hivenet_tenant_quota_rpm_limit
+hivenet_tenant_quota_tpd_limit
 ```
 
 Tenants using only `quota.per_model` may therefore be missing from the selector or may not have their limits represented fully in this dashboard.
@@ -450,8 +450,8 @@ Tenants using only `quota.per_model` may therefore be missing from the selector 
 Per-model quota metrics are still available in Prometheus:
 
 ```text
-hivenet_router_tenant_per_model_quota_rpm_limit
-hivenet_router_tenant_per_model_quota_tpd_limit
+hivenet_tenant_per_model_quota_rpm_limit
+hivenet_tenant_per_model_quota_tpd_limit
 ```
 
 Use Grafana Explore or create additional panels when per-model quota visibility is required.
@@ -622,7 +622,7 @@ The current dashboards define these variables.
 
 | Variable | Source |
 | --- | --- |
-| `$model` | Models from `hivenet_router_routing_agent_info` |
+| `$model` | Models from `hivenet_routing_agent_info` |
 | `$engine` | Engine values from agent registrations |
 | `$peer_id` | Agent peer IDs |
 | `$organization` | Agent organization metadata |
@@ -655,7 +655,7 @@ For example, request rate by model:
 ```promql
 sum by (model) (
   rate(
-    hivenet_router_routing_requests_routed_total[5m]
+    hivenet_routing_requests_routed_total[5m]
   )
 )
 ```
@@ -665,7 +665,7 @@ Policy exhaustion by model:
 ```promql
 sum by (model) (
   rate(
-    hivenet_router_policy_exhausted_total[5m]
+    hivenet_policy_exhausted_total[5m]
   )
 )
 ```
@@ -677,7 +677,7 @@ histogram_quantile(
   0.95,
   sum by (le, tenant_id, model) (
     rate(
-      hivenet_router_tenant_request_duration_seconds_bucket[5m]
+      hivenet_tenant_request_duration_seconds_bucket[5m]
     )
   )
 )
@@ -801,7 +801,7 @@ See [Prometheus metrics](/observability/prometheus-metrics#alerting-examples) fo
     ```bash
     docker compose exec prometheus \
       wget -qO- \
-      'http://localhost:9090/api/v1/query?query=hivenet_router_routing_agent_info' \
+      'http://localhost:9090/api/v1/query?query=hivenet_routing_agent_info' \
       | jq .
     ```
 
@@ -861,7 +861,7 @@ See [Prometheus metrics](/observability/prometheus-metrics#alerting-examples) fo
     ```bash
     curl -s \
       http://localhost:2112/metrics \
-      | grep hivenet_router_tenant
+      | grep hivenet_tenant
     ```
 
     A tenant using only per-model quota gauges may not appear in the current selector. Query the per-model metrics directly in Explore when necessary.

--- a/docs/observability/hardware-aware-routing.mdx
+++ b/docs/observability/hardware-aware-routing.mdx
@@ -318,7 +318,7 @@ Policy utilization values use fractions:
 Prometheus exposes the corresponding hardware value on a `0` to `100` scale:
 
 ```promql
-hivenet_router_agent_gpu_utilization_percent > 95
+hivenet_agent_gpu_utilization_percent > 95
 ```
 
 <Note>
@@ -662,14 +662,14 @@ This routes according to the metadata you supplied. Hivenet Router does not inde
 GPU power is available through Prometheus:
 
 ```text
-hivenet_router_agent_gpu_power_watts
+hivenet_agent_gpu_power_watts
 ```
 
 Total current GPU power by machine:
 
 ```promql
 sum by (machine) (
-  hivenet_router_agent_gpu_power_watts
+  hivenet_agent_gpu_power_watts
 )
 ```
 
@@ -677,7 +677,7 @@ Power by region:
 
 ```promql
 sum by (region) (
-  hivenet_router_agent_gpu_power_watts
+  hivenet_agent_gpu_power_watts
 )
 ```
 
@@ -696,13 +696,13 @@ A ratio such as requests per watt can be useful as a rough dashboard signal:
 ```promql
 sum(
   rate(
-    hivenet_router_routing_requests_routed_total[5m]
+    hivenet_routing_requests_routed_total[5m]
   )
 )
 /
 clamp_min(
   sum(
-    hivenet_router_agent_gpu_power_watts
+    hivenet_agent_gpu_power_watts
   ),
   1
 )
@@ -801,42 +801,42 @@ A long list of gates can drain the candidate pool more often than expected. Add 
 ### Current GPU state
 
 ```promql
-hivenet_router_agent_gpu_utilization_percent
+hivenet_agent_gpu_utilization_percent
 ```
 
 ```promql
 100
 *
-hivenet_router_agent_gpu_vram_used_bytes
+hivenet_agent_gpu_vram_used_bytes
 /
 clamp_min(
-  hivenet_router_agent_gpu_vram_total_bytes,
+  hivenet_agent_gpu_vram_total_bytes,
   1
 )
 ```
 
 ```promql
-hivenet_router_agent_gpu_temperature_celsius
+hivenet_agent_gpu_temperature_celsius
 ```
 
 ### Current host state
 
 ```promql
-hivenet_router_agent_cpu_usage_percent
+hivenet_agent_cpu_usage_percent
 ```
 
 ```promql
-hivenet_router_agent_memory_used_percent
+hivenet_agent_memory_used_percent
 ```
 
 ### Engine pressure
 
 ```promql
-hivenet_router_agent_engine_kv_cache_utilization
+hivenet_agent_engine_kv_cache_utilization
 ```
 
 ```promql
-hivenet_router_agent_engine_waiting_requests
+hivenet_agent_engine_waiting_requests
 ```
 
 ### Routing outcomes
@@ -844,7 +844,7 @@ hivenet_router_agent_engine_waiting_requests
 ```promql
 sum by (model) (
   rate(
-    hivenet_router_policy_primary_routed_total[5m]
+    hivenet_policy_primary_routed_total[5m]
   )
 )
 ```
@@ -852,7 +852,7 @@ sum by (model) (
 ```promql
 sum by (model) (
   rate(
-    hivenet_router_policy_fallback_routed_total[5m]
+    hivenet_policy_fallback_routed_total[5m]
   )
 )
 ```
@@ -860,7 +860,7 @@ sum by (model) (
 ```promql
 sum by (model) (
   rate(
-    hivenet_router_policy_exhausted_total[5m]
+    hivenet_policy_exhausted_total[5m]
   )
 )
 ```

--- a/docs/observability/hardware-metrics.mdx
+++ b/docs/observability/hardware-metrics.mdx
@@ -149,7 +149,7 @@ It is not the NVIDIA GPU UUID.
 ## GPU utilization
 
 ```text
-hivenet_router_agent_gpu_utilization_percent
+hivenet_agent_gpu_utilization_percent
 ```
 
 GPU utilization is the percentage of the recent NVML sampling window during which the GPU’s compute engine was active.
@@ -163,14 +163,14 @@ The Prometheus value uses:
 Examples:
 
 ```promql
-hivenet_router_agent_gpu_utilization_percent
+hivenet_agent_gpu_utilization_percent
 ```
 
 Average utilization by model:
 
 ```promql
 avg by (model) (
-  hivenet_router_agent_gpu_utilization_percent
+  hivenet_agent_gpu_utilization_percent
 )
 ```
 
@@ -178,7 +178,7 @@ Maximum utilization on each agent:
 
 ```promql
 max by (peer_id, model) (
-  hivenet_router_agent_gpu_utilization_percent
+  hivenet_agent_gpu_utilization_percent
 )
 ```
 
@@ -199,9 +199,9 @@ Hivenet Router’s hard routing-capacity gate uses the agent’s declared capaci
 Hivenet Router exports:
 
 ```text
-hivenet_router_agent_gpu_vram_used_bytes
-hivenet_router_agent_gpu_vram_free_bytes
-hivenet_router_agent_gpu_vram_total_bytes
+hivenet_agent_gpu_vram_used_bytes
+hivenet_agent_gpu_vram_free_bytes
+hivenet_agent_gpu_vram_total_bytes
 ```
 
 | Metric | Meaning |
@@ -213,7 +213,7 @@ hivenet_router_agent_gpu_vram_total_bytes
 Show VRAM in GiB:
 
 ```promql
-hivenet_router_agent_gpu_vram_used_bytes
+hivenet_agent_gpu_vram_used_bytes
 /
 1024
 /
@@ -225,10 +225,10 @@ hivenet_router_agent_gpu_vram_used_bytes
 Calculate the fraction in use:
 
 ```promql
-hivenet_router_agent_gpu_vram_used_bytes
+hivenet_agent_gpu_vram_used_bytes
 /
 clamp_min(
-  hivenet_router_agent_gpu_vram_total_bytes,
+  hivenet_agent_gpu_vram_total_bytes,
   1
 )
 ```
@@ -238,10 +238,10 @@ Calculate the percentage in use:
 ```promql
 100
 *
-hivenet_router_agent_gpu_vram_used_bytes
+hivenet_agent_gpu_vram_used_bytes
 /
 clamp_min(
-  hivenet_router_agent_gpu_vram_total_bytes,
+  hivenet_agent_gpu_vram_total_bytes,
   1
 )
 ```
@@ -265,20 +265,20 @@ VRAM can contain:
 ## GPU temperature
 
 ```text
-hivenet_router_agent_gpu_temperature_celsius
+hivenet_agent_gpu_temperature_celsius
 ```
 
 The value comes from the GPU’s NVML temperature sensor and is expressed in degrees Celsius.
 
 ```promql
-hivenet_router_agent_gpu_temperature_celsius
+hivenet_agent_gpu_temperature_celsius
 ```
 
 Maximum temperature by agent:
 
 ```promql
 max by (peer_id, model) (
-  hivenet_router_agent_gpu_temperature_celsius
+  hivenet_agent_gpu_temperature_celsius
 )
 ```
 
@@ -305,20 +305,20 @@ The value above is an example, not a universal safe limit.
 ## GPU power
 
 ```text
-hivenet_router_agent_gpu_power_watts
+hivenet_agent_gpu_power_watts
 ```
 
 NVML reports power in milliwatts. The agent converts it to watts before sending the snapshot.
 
 ```promql
-hivenet_router_agent_gpu_power_watts
+hivenet_agent_gpu_power_watts
 ```
 
 Total reported GPU power by machine:
 
 ```promql
 sum by (machine) (
-  hivenet_router_agent_gpu_power_watts
+  hivenet_agent_gpu_power_watts
 )
 ```
 
@@ -326,7 +326,7 @@ Total reported GPU power by region:
 
 ```promql
 sum by (region) (
-  hivenet_router_agent_gpu_power_watts
+  hivenet_agent_gpu_power_watts
 )
 ```
 
@@ -456,7 +456,7 @@ are different exact-match values.
 ## CPU usage
 
 ```text
-hivenet_router_agent_cpu_usage_percent
+hivenet_agent_cpu_usage_percent
 ```
 
 The agent uses gopsutil to collect node-wide CPU utilization.
@@ -470,14 +470,14 @@ The Prometheus value uses:
 It represents the combined utilization across the machine rather than one series per CPU core.
 
 ```promql
-hivenet_router_agent_cpu_usage_percent
+hivenet_agent_cpu_usage_percent
 ```
 
 Average CPU use by engine:
 
 ```promql
 avg by (engine) (
-  hivenet_router_agent_cpu_usage_percent
+  hivenet_agent_cpu_usage_percent
 )
 ```
 
@@ -485,7 +485,7 @@ Maximum CPU use by machine:
 
 ```promql
 max by (machine) (
-  hivenet_router_agent_cpu_usage_percent
+  hivenet_agent_cpu_usage_percent
 )
 ```
 
@@ -506,9 +506,9 @@ The collector seeds its CPU baseline when it starts so the first reported sample
 Hivenet Router exports:
 
 ```text
-hivenet_router_agent_memory_used_percent
-hivenet_router_agent_memory_available_bytes
-hivenet_router_agent_memory_total_bytes
+hivenet_agent_memory_used_percent
+hivenet_agent_memory_available_bytes
+hivenet_agent_memory_total_bytes
 ```
 
 | Metric | Unit | Meaning |
@@ -520,7 +520,7 @@ hivenet_router_agent_memory_total_bytes
 Show available memory in GiB:
 
 ```promql
-hivenet_router_agent_memory_available_bytes
+hivenet_agent_memory_available_bytes
 /
 1024
 /
@@ -532,7 +532,7 @@ hivenet_router_agent_memory_available_bytes
 Show used memory by agent:
 
 ```promql
-hivenet_router_agent_memory_used_percent
+hivenet_agent_memory_used_percent
 ```
 
 System-memory pressure can cause:
@@ -660,7 +660,7 @@ Policy YAML uses:
 For example, Prometheus:
 
 ```promql
-hivenet_router_agent_gpu_utilization_percent > 90
+hivenet_agent_gpu_utilization_percent > 90
 ```
 
 corresponds to:
@@ -741,7 +741,7 @@ groups:
       - alert: HivenetRouterGPUHighTemperature
 
         expr: |
-          hivenet_router_agent_gpu_temperature_celsius > 85
+          hivenet_agent_gpu_temperature_celsius > 85
 
         for: 5m
 
@@ -760,10 +760,10 @@ groups:
 
         expr: |
           (
-            hivenet_router_agent_gpu_vram_used_bytes
+            hivenet_agent_gpu_vram_used_bytes
             /
             clamp_min(
-              hivenet_router_agent_gpu_vram_total_bytes,
+              hivenet_agent_gpu_vram_total_bytes,
               1
             )
           ) > 0.9
@@ -784,7 +784,7 @@ groups:
       - alert: HivenetRouterHostHighMemory
 
         expr: |
-          hivenet_router_agent_memory_used_percent > 90
+          hivenet_agent_memory_used_percent > 90
 
         for: 5m
 
@@ -806,7 +806,7 @@ Use agent heartbeat age as the nearest fleet-health indicator:
 time()
 -
 (
-  hivenet_router_routing_agent_last_seen_timestamp
+  hivenet_routing_agent_last_seen_timestamp
   / 1000
 )
 > 15
@@ -963,7 +963,7 @@ Increase declared capacity gradually rather than deriving it from one hardware m
     ```bash
     curl -s \
       http://localhost:2112/metrics \
-      | grep hivenet_router_agent_gpu
+      | grep hivenet_agent_gpu
     ```
 
     Then check Prometheus’s router target.

--- a/docs/observability/latency-tracking.mdx
+++ b/docs/observability/latency-tracking.mdx
@@ -442,8 +442,8 @@ Before the agent has a sample:
 Hivenet Router exports:
 
 ```text
-hivenet_router_agent_srtt_ms
-hivenet_router_agent_rttvar_ms
+hivenet_agent_srtt_ms
+hivenet_agent_rttvar_ms
 ```
 
 Labels:
@@ -459,14 +459,14 @@ machine
 ### SRTT by agent
 
 ```promql
-hivenet_router_agent_srtt_ms
+hivenet_agent_srtt_ms
 ```
 
 ### Average SRTT by model
 
 ```promql
 avg by (model) (
-  hivenet_router_agent_srtt_ms
+  hivenet_agent_srtt_ms
 )
 ```
 
@@ -474,30 +474,30 @@ avg by (model) (
 
 ```promql
 avg by (engine) (
-  hivenet_router_agent_srtt_ms
+  hivenet_agent_srtt_ms
 )
 ```
 
 ### Agents above 500 milliseconds
 
 ```promql
-hivenet_router_agent_srtt_ms > 500
+hivenet_agent_srtt_ms > 500
 ```
 
 ### High variation
 
 ```promql
-hivenet_router_agent_rttvar_ms > 300
+hivenet_agent_rttvar_ms > 300
 ```
 
 ### SRTT compared with variation
 
 ```promql
-hivenet_router_agent_srtt_ms
+hivenet_agent_srtt_ms
 +
 4
 *
-hivenet_router_agent_rttvar_ms
+hivenet_agent_rttvar_ms
 ```
 
 This final query can be useful for visualization, but Hivenet Router does not use it as a TCP-style retransmission timeout.
@@ -655,7 +655,7 @@ groups:
       - alert: HivenetRouterHighSRTT
 
         expr: |
-          hivenet_router_agent_srtt_ms > 500
+          hivenet_agent_srtt_ms > 500
 
         for: 5m
 
@@ -673,7 +673,7 @@ groups:
       - alert: HivenetRouterUnstableLatency
 
         expr: |
-          hivenet_router_agent_rttvar_ms > 300
+          hivenet_agent_rttvar_ms > 300
 
         for: 10m
 
@@ -692,7 +692,7 @@ groups:
 
         expr: |
           avg by (model) (
-            hivenet_router_agent_srtt_ms
+            hivenet_agent_srtt_ms
           ) > 750
 
         for: 5m

--- a/docs/observability/prometheus-metrics.mdx
+++ b/docs/observability/prometheus-metrics.mdx
@@ -112,7 +112,7 @@ Check that Hivenet Router metrics exist:
 ```bash
 curl -s \
   http://localhost:2112/metrics \
-  | grep '^hivenet_router_'
+  | grep '^hivenet_'
 ```
 
 ## How metrics reach the router
@@ -188,7 +188,7 @@ machine
 as labels.
 
 ```promql
-hivenet_router_routing_agent_info
+hivenet_routing_agent_info
 ```
 
 The value is `1` while an agent is registered.
@@ -197,7 +197,7 @@ Count registered agents:
 
 ```promql
 count(
-  hivenet_router_routing_agent_info
+  hivenet_routing_agent_info
 )
 ```
 
@@ -205,14 +205,14 @@ Count agents by model:
 
 ```promql
 count by (model) (
-  hivenet_router_routing_agent_info
+  hivenet_routing_agent_info
 )
 ```
 
 ### Agent health
 
 ```promql
-hivenet_router_routing_agent_healthy
+hivenet_routing_agent_healthy
 ```
 
 Values are:
@@ -226,20 +226,20 @@ Count healthy agents by model:
 
 ```promql
 sum by (model) (
-  hivenet_router_routing_agent_healthy
+  hivenet_routing_agent_healthy
 )
 ```
 
 Find unhealthy agents:
 
 ```promql
-hivenet_router_routing_agent_healthy == 0
+hivenet_routing_agent_healthy == 0
 ```
 
 ### Last heartbeat
 
 ```promql
-hivenet_router_routing_agent_last_seen_timestamp
+hivenet_routing_agent_last_seen_timestamp
 ```
 
 The value is a Unix timestamp in **milliseconds**.
@@ -250,7 +250,7 @@ Show seconds since the most recent heartbeat:
 time()
 -
 (
-  hivenet_router_routing_agent_last_seen_timestamp
+  hivenet_routing_agent_last_seen_timestamp
   / 1000
 )
 ```
@@ -258,7 +258,7 @@ time()
 ### Routed requests
 
 ```promql
-hivenet_router_routing_requests_routed_total
+hivenet_routing_requests_routed_total
 ```
 
 Labels:
@@ -275,7 +275,7 @@ Request rate by model:
 ```promql
 sum by (model) (
   rate(
-    hivenet_router_routing_requests_routed_total[5m]
+    hivenet_routing_requests_routed_total[5m]
   )
 )
 ```
@@ -285,7 +285,7 @@ Request rate by region and engine:
 ```promql
 sum by (region, engine) (
   rate(
-    hivenet_router_routing_requests_routed_total[5m]
+    hivenet_routing_requests_routed_total[5m]
   )
 )
 ```
@@ -293,7 +293,7 @@ sum by (region, engine) (
 ### Failed routing
 
 ```promql
-hivenet_router_routing_requests_failed_total
+hivenet_routing_requests_failed_total
 ```
 
 This counts inference requests that the router could not forward successfully.
@@ -303,20 +303,20 @@ Failure rate:
 ```promql
 sum(
   rate(
-    hivenet_router_routing_requests_failed_total[5m]
+    hivenet_routing_requests_failed_total[5m]
   )
 )
 /
 clamp_min(
   sum(
     rate(
-      hivenet_router_routing_requests_routed_total[5m]
+      hivenet_routing_requests_routed_total[5m]
     )
   )
   +
   sum(
     rate(
-      hivenet_router_routing_requests_failed_total[5m]
+      hivenet_routing_requests_failed_total[5m]
     )
   ),
   0.000001
@@ -340,8 +340,8 @@ as labels.
 ### Successful and failed requests
 
 ```promql
-hivenet_router_agent_requests_success_total
-hivenet_router_agent_requests_failed_total
+hivenet_agent_requests_success_total
+hivenet_agent_requests_failed_total
 ```
 
 Request rate by agent:
@@ -349,7 +349,7 @@ Request rate by agent:
 ```promql
 sum by (peer_id, model) (
   rate(
-    hivenet_router_agent_requests_success_total[5m]
+    hivenet_agent_requests_success_total[5m]
   )
 )
 ```
@@ -357,7 +357,7 @@ sum by (peer_id, model) (
 ### Success rate
 
 ```promql
-hivenet_router_agent_success_rate
+hivenet_agent_success_rate
 ```
 
 The value ranges from `0.0` to `1.0`.
@@ -365,7 +365,7 @@ The value ranges from `0.0` to `1.0`.
 Find agents below 95%:
 
 ```promql
-hivenet_router_agent_success_rate < 0.95
+hivenet_agent_success_rate < 0.95
 ```
 
 A new agent may not expose a meaningful success rate until it has completed requests.
@@ -373,7 +373,7 @@ A new agent may not expose a meaningful success rate until it has completed requ
 ### Capacity utilization
 
 ```promql
-hivenet_router_agent_capacity_utilization
+hivenet_agent_capacity_utilization
 ```
 
 The value is:
@@ -385,7 +385,7 @@ active requests / declared capacity
 For non-streaming requests, the slot normally remains occupied until the response completes. For streaming requests, the current implementation releases the agent capacity slot when response headers arrive and streaming begins, while backend generation can continue.
 
 <Warning>
-  Do not use `hivenet_router_agent_capacity_utilization` as the authoritative count of ongoing streaming generations.
+  Do not use `hivenet_agent_capacity_utilization` as the authoritative count of ongoing streaming generations.
 
   For streaming-heavy workloads, compare it with engine running and waiting requests, KV-cache pressure, TTFT, and ITL.
 </Warning>
@@ -393,14 +393,14 @@ For non-streaming requests, the slot normally remains occupied until the respons
 Show agents above 80%:
 
 ```promql
-hivenet_router_agent_capacity_utilization > 0.8
+hivenet_agent_capacity_utilization > 0.8
 ```
 
 ### Tokens
 
 ```promql
-hivenet_router_agent_input_tokens_total
-hivenet_router_agent_output_tokens_total
+hivenet_agent_input_tokens_total
+hivenet_agent_output_tokens_total
 ```
 
 Token rate by model:
@@ -408,11 +408,11 @@ Token rate by model:
 ```promql
 sum by (model) (
   rate(
-    hivenet_router_agent_input_tokens_total[5m]
+    hivenet_agent_input_tokens_total[5m]
   )
   +
   rate(
-    hivenet_router_agent_output_tokens_total[5m]
+    hivenet_agent_output_tokens_total[5m]
   )
 )
 ```
@@ -420,7 +420,7 @@ sum by (model) (
 ### Capacity rejections
 
 ```promql
-hivenet_router_agent_rejected_requests_total
+hivenet_agent_rejected_requests_total
 ```
 
 This increases when Hivenet Router tries to acquire a capacity slot and the agent is already full.
@@ -428,7 +428,7 @@ This increases when Hivenet Router tries to acquire a capacity slot and the agen
 ```promql
 sum by (peer_id, model) (
   rate(
-    hivenet_router_agent_rejected_requests_total[5m]
+    hivenet_agent_rejected_requests_total[5m]
   )
 )
 ```
@@ -436,23 +436,23 @@ sum by (peer_id, model) (
 ### Disconnections and health failures
 
 ```promql
-hivenet_router_agent_disconnections_total
-hivenet_router_agent_failure_total
-hivenet_router_model_backend_failure_total
+hivenet_agent_disconnections_total
+hivenet_agent_failure_total
+hivenet_model_backend_failure_total
 ```
 
 | Metric | Meaning |
 | --- | --- |
-| `hivenet_router_agent_disconnections_total` | Agent disconnection history |
-| `hivenet_router_agent_failure_total` | Agent marked unhealthy after missed heartbeats |
-| `hivenet_router_model_backend_failure_total` | Agent reported its inference backend as unhealthy |
+| `hivenet_agent_disconnections_total` | Agent disconnection history |
+| `hivenet_agent_failure_total` | Agent marked unhealthy after missed heartbeats |
+| `hivenet_model_backend_failure_total` | Agent reported its inference backend as unhealthy |
 
 Compare agent-process and backend failures:
 
 ```promql
 sum by (peer_id, model) (
   rate(
-    hivenet_router_agent_failure_total[1h]
+    hivenet_agent_failure_total[1h]
   )
 )
 ```
@@ -460,7 +460,7 @@ sum by (peer_id, model) (
 ```promql
 sum by (peer_id, model) (
   rate(
-    hivenet_router_model_backend_failure_total[1h]
+    hivenet_model_backend_failure_total[1h]
   )
 )
 ```
@@ -468,8 +468,8 @@ sum by (peer_id, model) (
 ### Smoothed latency
 
 ```promql
-hivenet_router_agent_srtt_ms
-hivenet_router_agent_rttvar_ms
+hivenet_agent_srtt_ms
+hivenet_agent_rttvar_ms
 ```
 
 These follow the RFC 6298 smoothed round-trip-time calculation.
@@ -477,17 +477,17 @@ These follow the RFC 6298 smoothed round-trip-time calculation.
 Show SRTT by agent:
 
 ```promql
-hivenet_router_agent_srtt_ms
+hivenet_agent_srtt_ms
 ```
 
 Find high or unstable latency:
 
 ```promql
-hivenet_router_agent_srtt_ms > 5000
+hivenet_agent_srtt_ms > 5000
 ```
 
 ```promql
-hivenet_router_agent_rttvar_ms > 2000
+hivenet_agent_rttvar_ms > 2000
 ```
 
 <Note>
@@ -556,27 +556,27 @@ A metric is absent until the agent reports it.
 ### Cache and queue state
 
 ```promql
-hivenet_router_agent_engine_kv_cache_utilization
-hivenet_router_agent_engine_running_requests
-hivenet_router_agent_engine_waiting_requests
+hivenet_agent_engine_kv_cache_utilization
+hivenet_agent_engine_running_requests
+hivenet_agent_engine_waiting_requests
 ```
 
 Agents under cache pressure:
 
 ```promql
-hivenet_router_agent_engine_kv_cache_utilization > 0.9
+hivenet_agent_engine_kv_cache_utilization > 0.9
 ```
 
 Agents with backend queues:
 
 ```promql
-hivenet_router_agent_engine_waiting_requests > 0
+hivenet_agent_engine_waiting_requests > 0
 ```
 
 ### Preemptions
 
 ```promql
-hivenet_router_agent_engine_preemptions_total
+hivenet_agent_engine_preemptions_total
 ```
 
 Despite the `_total` suffix, this series is exported as a gauge representing the backend’s latest cumulative value.
@@ -585,7 +585,7 @@ Use a change function to detect growth:
 
 ```promql
 delta(
-  hivenet_router_agent_engine_preemptions_total[5m]
+  hivenet_agent_engine_preemptions_total[5m]
 ) > 0
 ```
 
@@ -594,10 +594,10 @@ Do not assume ordinary counter-reset behavior across every backend restart.
 ### Per-agent TTFT and ITL gauges
 
 ```promql
-hivenet_router_agent_engine_avg_ttft_seconds
-hivenet_router_agent_engine_p90_ttft_seconds
-hivenet_router_agent_engine_avg_itl_seconds
-hivenet_router_agent_engine_p90_itl_seconds
+hivenet_agent_engine_avg_ttft_seconds
+hivenet_agent_engine_p90_ttft_seconds
+hivenet_agent_engine_avg_itl_seconds
+hivenet_agent_engine_p90_itl_seconds
 ```
 
 These are convenient for viewing one agent.
@@ -607,7 +607,7 @@ For fleet-wide percentiles, use the histogram metrics instead of averaging per-a
 ### Finish reasons
 
 ```promql
-hivenet_router_agent_engine_request_success_total
+hivenet_agent_engine_request_success_total
 ```
 
 Additional label:
@@ -629,7 +629,7 @@ Completion rate by finish reason:
 ```promql
 sum by (finished_reason) (
   rate(
-    hivenet_router_agent_engine_request_success_total[5m]
+    hivenet_agent_engine_request_success_total[5m]
   )
 )
 ```
@@ -637,8 +637,8 @@ sum by (finished_reason) (
 ### llama.cpp throughput
 
 ```promql
-hivenet_router_agent_engine_predicted_tps
-hivenet_router_agent_engine_prompt_tps
+hivenet_agent_engine_predicted_tps
+hivenet_agent_engine_prompt_tps
 ```
 
 These expose the latest reported generation and prompt-ingestion throughput from llama.cpp.
@@ -650,10 +650,10 @@ The current router re-exports raw engine histogram buckets for vLLM agents. SGLa
 The vLLM-backed histogram families are:
 
 ```text
-hivenet_router_agent_engine_ttft_seconds
-hivenet_router_agent_engine_itl_seconds
-hivenet_router_agent_engine_request_prompt_tokens
-hivenet_router_agent_engine_request_generation_tokens
+hivenet_agent_engine_ttft_seconds
+hivenet_agent_engine_itl_seconds
+hivenet_agent_engine_request_prompt_tokens
+hivenet_agent_engine_request_generation_tokens
 ```
 
 Prometheus exposes each histogram as:
@@ -671,7 +671,7 @@ histogram_quantile(
   0.90,
   sum by (le) (
     rate(
-      hivenet_router_agent_engine_ttft_seconds_bucket[5m]
+      hivenet_agent_engine_ttft_seconds_bucket[5m]
     )
   )
 )
@@ -684,7 +684,7 @@ histogram_quantile(
   0.90,
   sum by (le, model) (
     rate(
-      hivenet_router_agent_engine_ttft_seconds_bucket[5m]
+      hivenet_agent_engine_ttft_seconds_bucket[5m]
     )
   )
 )
@@ -697,7 +697,7 @@ histogram_quantile(
   0.90,
   sum by (le) (
     rate(
-      hivenet_router_agent_engine_itl_seconds_bucket[5m]
+      hivenet_agent_engine_itl_seconds_bucket[5m]
     )
   )
 )
@@ -710,7 +710,7 @@ histogram_quantile(
   0.90,
   sum by (le) (
     rate(
-      hivenet_router_agent_engine_request_prompt_tokens_bucket[5m]
+      hivenet_agent_engine_request_prompt_tokens_bucket[5m]
     )
   )
 )
@@ -723,7 +723,7 @@ histogram_quantile(
   0.90,
   sum by (le) (
     rate(
-      hivenet_router_agent_engine_request_generation_tokens_bucket[5m]
+      hivenet_agent_engine_request_generation_tokens_bucket[5m]
     )
   )
 )
@@ -753,12 +753,12 @@ machine
 as labels.
 
 ```promql
-hivenet_router_agent_gpu_utilization_percent
-hivenet_router_agent_gpu_vram_used_bytes
-hivenet_router_agent_gpu_vram_free_bytes
-hivenet_router_agent_gpu_vram_total_bytes
-hivenet_router_agent_gpu_temperature_celsius
-hivenet_router_agent_gpu_power_watts
+hivenet_agent_gpu_utilization_percent
+hivenet_agent_gpu_vram_used_bytes
+hivenet_agent_gpu_vram_free_bytes
+hivenet_agent_gpu_vram_total_bytes
+hivenet_agent_gpu_temperature_celsius
+hivenet_agent_gpu_power_watts
 ```
 
 Unlike policy gates, the Prometheus utilization value uses a `0` to `100` scale.
@@ -766,14 +766,14 @@ Unlike policy gates, the Prometheus utilization value uses a `0` to `100` scale.
 ### GPU utilization
 
 ```promql
-hivenet_router_agent_gpu_utilization_percent
+hivenet_agent_gpu_utilization_percent
 ```
 
 Average utilization by model:
 
 ```promql
 avg by (model) (
-  hivenet_router_agent_gpu_utilization_percent
+  hivenet_agent_gpu_utilization_percent
 )
 ```
 
@@ -782,10 +782,10 @@ avg by (model) (
 ```promql
 100
 *
-hivenet_router_agent_gpu_vram_used_bytes
+hivenet_agent_gpu_vram_used_bytes
 /
 clamp_min(
-  hivenet_router_agent_gpu_vram_total_bytes,
+  hivenet_agent_gpu_vram_total_bytes,
   1
 )
 ```
@@ -794,7 +794,7 @@ clamp_min(
 
 ```promql
 max by (peer_id, model) (
-  hivenet_router_agent_gpu_temperature_celsius
+  hivenet_agent_gpu_temperature_celsius
 )
 ```
 
@@ -802,7 +802,7 @@ max by (peer_id, model) (
 
 ```promql
 sum by (peer_id, model) (
-  hivenet_router_agent_gpu_power_watts
+  hivenet_agent_gpu_power_watts
 )
 ```
 
@@ -822,28 +822,28 @@ machine
 ```
 
 ```promql
-hivenet_router_agent_cpu_usage_percent
-hivenet_router_agent_memory_used_percent
-hivenet_router_agent_memory_available_bytes
-hivenet_router_agent_memory_total_bytes
+hivenet_agent_cpu_usage_percent
+hivenet_agent_memory_used_percent
+hivenet_agent_memory_available_bytes
+hivenet_agent_memory_total_bytes
 ```
 
 CPU usage:
 
 ```promql
-hivenet_router_agent_cpu_usage_percent
+hivenet_agent_cpu_usage_percent
 ```
 
 Memory use:
 
 ```promql
-hivenet_router_agent_memory_used_percent
+hivenet_agent_memory_used_percent
 ```
 
 Available GiB:
 
 ```promql
-hivenet_router_agent_memory_available_bytes
+hivenet_agent_memory_available_bytes
 /
 1024
 /
@@ -857,10 +857,10 @@ hivenet_router_agent_memory_available_bytes
 ### Primary and fallback routing
 
 ```promql
-hivenet_router_policy_primary_routed_total
-hivenet_router_policy_fallback_routed_total
-hivenet_router_policy_provider_fallback_total
-hivenet_router_policy_exhausted_total
+hivenet_policy_primary_routed_total
+hivenet_policy_fallback_routed_total
+hivenet_policy_provider_fallback_total
+hivenet_policy_exhausted_total
 ```
 
 All use the `model` label.
@@ -870,7 +870,7 @@ Local fallback rate by model:
 ```promql
 sum by (model) (
   rate(
-    hivenet_router_policy_fallback_routed_total[5m]
+    hivenet_policy_fallback_routed_total[5m]
   )
 )
 ```
@@ -880,7 +880,7 @@ Provider fallback rate:
 ```promql
 sum by (model) (
   rate(
-    hivenet_router_policy_provider_fallback_total[5m]
+    hivenet_policy_provider_fallback_total[5m]
   )
 )
 ```
@@ -890,7 +890,7 @@ Policy exhaustion:
 ```promql
 sum by (model) (
   rate(
-    hivenet_router_policy_exhausted_total[5m]
+    hivenet_policy_exhausted_total[5m]
   )
 )
 ```
@@ -900,7 +900,7 @@ This counter describes an exhausted policy path, not one guaranteed final HTTP s
 ### Stale connection resets
 
 ```promql
-hivenet_router_agent_connection_resets_total
+hivenet_agent_connection_resets_total
 ```
 
 Labels:
@@ -915,7 +915,7 @@ A sustained rate can indicate repeated router-agent connection loss:
 ```promql
 sum by (model, reason) (
   rate(
-    hivenet_router_agent_connection_resets_total[5m]
+    hivenet_agent_connection_resets_total[5m]
   )
 )
 ```
@@ -923,7 +923,7 @@ sum by (model, reason) (
 ### Policy reloads
 
 ```promql
-hivenet_router_policy_reload_total
+hivenet_policy_reload_total
 ```
 
 Labels:
@@ -948,7 +948,7 @@ Failed reloads:
 ```promql
 sum by (trigger) (
   increase(
-    hivenet_router_policy_reload_total{
+    hivenet_policy_reload_total{
       result="error"
     }[1h]
   )
@@ -962,7 +962,7 @@ These metrics describe the per-model queue used when eligible agents exist but a
 ### Current queue depth
 
 ```promql
-hivenet_router_queue_depth
+hivenet_queue_depth
 ```
 
 Label:
@@ -972,13 +972,13 @@ model
 ```
 
 ```promql
-hivenet_router_queue_depth > 0
+hivenet_queue_depth > 0
 ```
 
 ### Queue wait duration
 
 ```promql
-hivenet_router_queue_wait_seconds
+hivenet_queue_wait_seconds
 ```
 
 P95 queue wait by model:
@@ -988,7 +988,7 @@ histogram_quantile(
   0.95,
   sum by (le, model) (
     rate(
-      hivenet_router_queue_wait_seconds_bucket[5m]
+      hivenet_queue_wait_seconds_bucket[5m]
     )
   )
 )
@@ -1016,8 +1016,8 @@ unset
 ### Successful and failed requests
 
 ```promql
-hivenet_router_tenant_requests_success_total
-hivenet_router_tenant_requests_failed_total
+hivenet_tenant_requests_success_total
+hivenet_tenant_requests_failed_total
 ```
 
 Labels:
@@ -1034,7 +1034,7 @@ Request count by tenant and deployment:
 ```promql
 sum by (tenant_id, deployment_id) (
   increase(
-    hivenet_router_tenant_requests_success_total[7d]
+    hivenet_tenant_requests_success_total[7d]
   )
 )
 ```
@@ -1042,8 +1042,8 @@ sum by (tenant_id, deployment_id) (
 ### Token use
 
 ```promql
-hivenet_router_tenant_input_tokens_total
-hivenet_router_tenant_output_tokens_total
+hivenet_tenant_input_tokens_total
+hivenet_tenant_output_tokens_total
 ```
 
 Token rate by tenant and model:
@@ -1051,11 +1051,11 @@ Token rate by tenant and model:
 ```promql
 sum by (tenant_id, model) (
   rate(
-    hivenet_router_tenant_input_tokens_total[5m]
+    hivenet_tenant_input_tokens_total[5m]
   )
   +
   rate(
-    hivenet_router_tenant_output_tokens_total[5m]
+    hivenet_tenant_output_tokens_total[5m]
   )
 )
 ```
@@ -1063,7 +1063,7 @@ sum by (tenant_id, model) (
 ### Request-rate rejection
 
 ```promql
-hivenet_router_tenant_rate_limited_total
+hivenet_tenant_rate_limited_total
 ```
 
 Labels:
@@ -1076,7 +1076,7 @@ key_id
 ```promql
 sum by (tenant_id, key_id) (
   rate(
-    hivenet_router_tenant_rate_limited_total[5m]
+    hivenet_tenant_rate_limited_total[5m]
   )
 )
 ```
@@ -1084,7 +1084,7 @@ sum by (tenant_id, key_id) (
 ### Token-budget rejection
 
 ```promql
-hivenet_router_tenant_token_limited_total
+hivenet_tenant_token_limited_total
 ```
 
 Labels:
@@ -1106,7 +1106,7 @@ output
 ```promql
 sum by (tenant_id, phase) (
   rate(
-    hivenet_router_tenant_token_limited_total[5m]
+    hivenet_tenant_token_limited_total[5m]
   )
 )
 ```
@@ -1114,8 +1114,8 @@ sum by (tenant_id, phase) (
 ### Flat quota limits
 
 ```promql
-hivenet_router_tenant_quota_rpm_limit
-hivenet_router_tenant_quota_tpd_limit
+hivenet_tenant_quota_rpm_limit
+hivenet_tenant_quota_tpd_limit
 ```
 
 Label:
@@ -1131,8 +1131,8 @@ These gauges describe keys using the flat quota shape.
 ### Per-model quota limits
 
 ```promql
-hivenet_router_tenant_per_model_quota_rpm_limit
-hivenet_router_tenant_per_model_quota_tpd_limit
+hivenet_tenant_per_model_quota_rpm_limit
+hivenet_tenant_per_model_quota_tpd_limit
 ```
 
 Labels:
@@ -1154,7 +1154,7 @@ It can change as agent health and fleet size change.
 ### Tokens used today
 
 ```promql
-hivenet_router_tenant_tokens_used_today
+hivenet_tenant_tokens_used_today
 ```
 
 Label:
@@ -1168,10 +1168,10 @@ The value resets at midnight UTC.
 Token-budget utilization for flat quotas:
 
 ```promql
-hivenet_router_tenant_tokens_used_today
+hivenet_tenant_tokens_used_today
 /
 clamp_min(
-  hivenet_router_tenant_quota_tpd_limit,
+  hivenet_tenant_quota_tpd_limit,
   1
 )
 ```
@@ -1179,7 +1179,7 @@ clamp_min(
 ### Last request timestamp
 
 ```promql
-hivenet_router_tenant_last_request_timestamp
+hivenet_tenant_last_request_timestamp
 ```
 
 Labels:
@@ -1194,7 +1194,7 @@ Most recent request per API key:
 
 ```promql
 max by (tenant_id, key_id) (
-  hivenet_router_tenant_last_request_timestamp
+  hivenet_tenant_last_request_timestamp
 )
 ```
 
@@ -1204,14 +1204,14 @@ Seconds since last request:
 time()
 -
 max by (tenant_id, key_id) (
-  hivenet_router_tenant_last_request_timestamp
+  hivenet_tenant_last_request_timestamp
 )
 ```
 
 ### Tenant request duration
 
 ```promql
-hivenet_router_tenant_request_duration_seconds
+hivenet_tenant_request_duration_seconds
 ```
 
 Labels:
@@ -1230,7 +1230,7 @@ histogram_quantile(
   0.95,
   sum by (le, tenant_id, model) (
     rate(
-      hivenet_router_tenant_request_duration_seconds_bucket[5m]
+      hivenet_tenant_request_duration_seconds_bucket[5m]
     )
   )
 )
@@ -1239,14 +1239,14 @@ histogram_quantile(
 ### Quota persistence errors
 
 ```promql
-hivenet_router_quota_backend_errors_total
+hivenet_quota_backend_errors_total
 ```
 
 This increases when the Badger-backed daily token limiter cannot flush quota state to disk.
 
 ```promql
 increase(
-  hivenet_router_quota_backend_errors_total[15m]
+  hivenet_quota_backend_errors_total[15m]
 ) > 0
 ```
 
@@ -1262,11 +1262,11 @@ The LLM admission gates publish one rejection counter and four live pool gauges:
 
 | Metric | Type | Labels | Meaning |
 | --- | --- | --- | --- |
-| `hivenet_router_admission_rejections_total` | Counter | `reason`, `model` | Requests rejected by B1 through B4 |
-| `hivenet_router_admission_occupancy_tokens` | Gauge | `model` | Current token-weighted in-flight sum |
-| `hivenet_router_admission_budget_tokens` | Gauge | `model` | Effective B2 budget after admit fraction and healthy-replica scaling |
-| `hivenet_router_admission_inflight_requests` | Gauge | `model` | Current in-flight request count |
-| `hivenet_router_admission_max_inflight` | Gauge | `model` | Effective `max_inflight × healthy_replicas` backstop |
+| `hivenet_admission_rejections_total` | Counter | `reason`, `model` | Requests rejected by B1 through B4 |
+| `hivenet_admission_occupancy_tokens` | Gauge | `model` | Current token-weighted in-flight sum |
+| `hivenet_admission_budget_tokens` | Gauge | `model` | Effective B2 budget after admit fraction and healthy-replica scaling |
+| `hivenet_admission_inflight_requests` | Gauge | `model` | Current in-flight request count |
+| `hivenet_admission_max_inflight` | Gauge | `model` | Effective `max_inflight × healthy_replicas` backstop |
 
 The `reason` label identifies the gate:
 
@@ -1287,7 +1287,7 @@ The budget and backstop gauges can change as healthy replicas join or leave. Exi
 ## Per-request duration by agent
 
 ```promql
-hivenet_router_request_duration_seconds
+hivenet_request_duration_seconds
 ```
 
 Labels:
@@ -1306,7 +1306,7 @@ histogram_quantile(
   0.95,
   sum by (le, peer_id, model) (
     rate(
-      hivenet_router_request_duration_seconds_bucket[5m]
+      hivenet_request_duration_seconds_bucket[5m]
     )
   )
 )
@@ -1429,7 +1429,7 @@ groups:
       - alert: HivenetRouterAgentUnhealthy
 
         expr: |
-          hivenet_router_routing_agent_healthy == 0
+          hivenet_routing_agent_healthy == 0
 
         for: 1m
 
@@ -1450,20 +1450,20 @@ groups:
           (
             sum(
               rate(
-                hivenet_router_routing_requests_failed_total[5m]
+                hivenet_routing_requests_failed_total[5m]
               )
             )
             /
             clamp_min(
               sum(
                 rate(
-                  hivenet_router_routing_requests_routed_total[5m]
+                  hivenet_routing_requests_routed_total[5m]
                 )
               )
               +
               sum(
                 rate(
-                  hivenet_router_routing_requests_failed_total[5m]
+                  hivenet_routing_requests_failed_total[5m]
                 )
               ),
               0.000001
@@ -1486,7 +1486,7 @@ groups:
       - alert: HivenetRouterKVCachePressure
 
         expr: |
-          hivenet_router_agent_engine_kv_cache_utilization > 0.90
+          hivenet_agent_engine_kv_cache_utilization > 0.90
 
         for: 2m
 
@@ -1504,7 +1504,7 @@ groups:
       - alert: HivenetRouterGPUHighTemperature
 
         expr: |
-          hivenet_router_agent_gpu_temperature_celsius > 85
+          hivenet_agent_gpu_temperature_celsius > 85
 
         for: 5m
 
@@ -1524,7 +1524,7 @@ groups:
         expr: |
           sum by (model) (
             rate(
-              hivenet_router_policy_exhausted_total[5m]
+              hivenet_policy_exhausted_total[5m]
             )
           ) > 0
 
@@ -1545,7 +1545,7 @@ groups:
 
         expr: |
           increase(
-            hivenet_router_quota_backend_errors_total[15m]
+            hivenet_quota_backend_errors_total[15m]
           ) > 0
 
         labels:
@@ -1572,7 +1572,7 @@ groups:
         expr: |
           sum by (model) (
             rate(
-              hivenet_router_routing_requests_routed_total[5m]
+              hivenet_routing_requests_routed_total[5m]
             )
           )
 
@@ -1581,7 +1581,7 @@ groups:
         expr: |
           sum by (model) (
             rate(
-              hivenet_router_routing_requests_failed_total[5m]
+              hivenet_routing_requests_failed_total[5m]
             )
           )
 
@@ -1592,7 +1592,7 @@ groups:
             0.95,
             sum by (le, model) (
               rate(
-                hivenet_router_agent_engine_ttft_seconds_bucket[5m]
+                hivenet_agent_engine_ttft_seconds_bucket[5m]
               )
             )
           )
@@ -1646,7 +1646,7 @@ groups:
     ```bash
     curl -s \
       http://localhost:2112/metrics \
-      | grep 'hivenet_router_agent_engine'
+      | grep 'hivenet_agent_engine'
     ```
   </Accordion>
 
@@ -1710,7 +1710,7 @@ groups:
     curl -s \
       http://localhost:2112/metrics \
       | grep \
-        'hivenet_router_agent_engine_ttft_seconds_bucket'
+        'hivenet_agent_engine_ttft_seconds_bucket'
     ```
 
     Use `rate()` over a window that contains completed observations.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -439,7 +439,7 @@ Inspect the routing counter:
 
 ```bash
 curl -s http://192.168.1.100:2112/metrics \
-  | grep hivenet_router_routing_requests_routed_total
+  | grep hivenet_routing_requests_routed_total
 ```
 
 ## Troubleshooting

--- a/docs/reference/configuration-reference.mdx
+++ b/docs/reference/configuration-reference.mdx
@@ -64,7 +64,7 @@ Use the binary’s built-in help to confirm the options available in the version
   The environment-variable prefix is exactly:
 
   ```text
-  hivenet_router_
+  hivenet_
   ```
 
   Environment-variable names are case-sensitive on Linux. Use the capitalization shown in this reference.

--- a/docs/reference/performance-characteristics.mdx
+++ b/docs/reference/performance-characteristics.mdx
@@ -74,7 +74,7 @@ Different observability signals cover different parts of this path.
 | Client-observed latency | Client request start to completed response | Yes |
 | Audit `latency_ms` | Router middleware entry to handler completion | Yes |
 | `http_server_request_duration_seconds` | Complete router HTTP handling | Yes |
-| `hivenet_router_tenant_request_duration_seconds` | Successful tenant request through the router | Yes |
+| `hivenet_tenant_request_duration_seconds` | Successful tenant request through the router | Yes |
 | `queue_wait` trace span | Time in the per-model capacity queue | No |
 | `dispatch` trace span | Policy selection and router-to-agent forwarding until the processor receives a response | Depends on response mode |
 | `forward_to_agent` trace span | Router request to agent response headers or completed non-streaming body | Depends on response mode |
@@ -874,7 +874,7 @@ That interval can include:
 It is not the same as the explicit `queue_wait` trace span or:
 
 ```text
-hivenet_router_queue_wait_seconds
+hivenet_queue_wait_seconds
 ```
 
 Those represent the per-model capacity queue specifically.
@@ -1104,16 +1104,16 @@ A practical tuning order is:
 Monitor:
 
 ```text
-hivenet_router_agent_capacity_utilization
-hivenet_router_agent_engine_running_requests
-hivenet_router_agent_engine_waiting_requests
-hivenet_router_agent_engine_kv_cache_utilization
-hivenet_router_agent_engine_p90_ttft_seconds
-hivenet_router_agent_engine_p90_itl_seconds
-hivenet_router_queue_depth
-hivenet_router_queue_wait_seconds
-hivenet_router_policy_fallback_routed_total
-hivenet_router_policy_exhausted_total
+hivenet_agent_capacity_utilization
+hivenet_agent_engine_running_requests
+hivenet_agent_engine_waiting_requests
+hivenet_agent_engine_kv_cache_utilization
+hivenet_agent_engine_p90_ttft_seconds
+hivenet_agent_engine_p90_itl_seconds
+hivenet_queue_depth
+hivenet_queue_wait_seconds
+hivenet_policy_fallback_routed_total
+hivenet_policy_exhausted_total
 ```
 
 For streaming workloads, give engine-level concurrency and queue metrics more weight than Hivenet Router’s agent active-request count.
@@ -1181,7 +1181,7 @@ histogram_quantile(
   0.95,
   sum by (le, model) (
     rate(
-      hivenet_router_queue_wait_seconds_bucket[5m]
+      hivenet_queue_wait_seconds_bucket[5m]
     )
   )
 )
@@ -1191,7 +1191,7 @@ histogram_quantile(
 
 ```promql
 sum by (model) (
-  hivenet_router_agent_engine_waiting_requests
+  hivenet_agent_engine_waiting_requests
 )
 ```
 
@@ -1200,7 +1200,7 @@ sum by (model) (
 ```promql
 sum by (model) (
   rate(
-    hivenet_router_routing_requests_failed_total[5m]
+    hivenet_routing_requests_failed_total[5m]
   )
 )
 ```
@@ -1210,7 +1210,7 @@ sum by (model) (
 ```promql
 sum by (model) (
   rate(
-    hivenet_router_policy_fallback_routed_total[5m]
+    hivenet_policy_fallback_routed_total[5m]
   )
 )
 ```

--- a/docs/routing/fallback-chains.mdx
+++ b/docs/routing/fallback-chains.mdx
@@ -234,7 +234,7 @@ This behavior is limited to connection-level failures. A backend error returned 
 Connection resets are counted in:
 
 ```text
-hivenet_router_agent_connection_resets_total
+hivenet_agent_connection_resets_total
 ```
 
 ## Capacity and the wait queue
@@ -603,7 +603,7 @@ Primary-step requests:
 
 ```promql
 rate(
-  hivenet_router_policy_primary_routed_total[5m]
+  hivenet_policy_primary_routed_total[5m]
 )
 ```
 
@@ -611,7 +611,7 @@ Requests served by any local fallback step:
 
 ```promql
 rate(
-  hivenet_router_policy_fallback_routed_total[5m]
+  hivenet_policy_fallback_routed_total[5m]
 )
 ```
 
@@ -619,7 +619,7 @@ Requests served by the external provider fallback:
 
 ```promql
 rate(
-  hivenet_router_policy_provider_fallback_total[5m]
+  hivenet_policy_provider_fallback_total[5m]
 )
 ```
 
@@ -627,7 +627,7 @@ Requests where the local chain was exhausted and no successful result followed:
 
 ```promql
 rate(
-  hivenet_router_policy_exhausted_total[5m]
+  hivenet_policy_exhausted_total[5m]
 )
 ```
 
@@ -636,13 +636,13 @@ Fallback as a proportion of all locally routed requests:
 ```promql
 sum(
   rate(
-    hivenet_router_policy_fallback_routed_total[5m]
+    hivenet_policy_fallback_routed_total[5m]
   )
 )
 /
 sum(
   rate(
-    hivenet_router_routing_requests_routed_total[5m]
+    hivenet_routing_requests_routed_total[5m]
   )
 )
 ```
@@ -650,7 +650,7 @@ sum(
 These policy counters are labeled by model.
 
 <Note>
-  `hivenet_router_policy_fallback_routed_total` aggregates every local fallback step. It does not currently include the individual fallback-step name as a Prometheus label.
+  `hivenet_policy_fallback_routed_total` aggregates every local fallback step. It does not currently include the individual fallback-step name as a Prometheus label.
 
   Use router logs and request diagnostics when you need to know which named step was used or exhausted.
 </Note>
@@ -888,7 +888,7 @@ Fallback is a continuity mechanism. It should not quietly become the normal rout
   </Accordion>
 
   <Accordion title="The exhausted metric increases despite provider fallback">
-    `hivenet_router_policy_exhausted_total` also increases when the local chain is exhausted and the configured provider fallback fails.
+    `hivenet_policy_exhausted_total` also increases when the local chain is exhausted and the configured provider fallback fails.
 
     Check provider logs and outbound HTTP metrics before assuming the router returned a normal local-capacity error.
   </Accordion>

--- a/docs/routing/policy-gates.mdx
+++ b/docs/routing/policy-gates.mdx
@@ -876,7 +876,7 @@ Inspect the policy-exhaustion counter:
 
 ```bash
 curl http://localhost:2112/metrics \
-  | grep hivenet_router_policy_exhausted_total
+  | grep hivenet_policy_exhausted_total
 ```
 
 PromQL:
@@ -884,7 +884,7 @@ PromQL:
 ```promql
 sum by (model) (
   rate(
-    hivenet_router_policy_exhausted_total[5m]
+    hivenet_policy_exhausted_total[5m]
   )
 )
 ```

--- a/docs/routing/provider-fallback.mdx
+++ b/docs/routing/provider-fallback.mdx
@@ -685,7 +685,7 @@ Successful provider fallbacks:
 
 ```promql
 rate(
-  hivenet_router_policy_provider_fallback_total[5m]
+  hivenet_policy_provider_fallback_total[5m]
 )
 ```
 
@@ -696,7 +696,7 @@ Successful fallbacks by original model:
 ```promql
 sum by (model) (
   rate(
-    hivenet_router_policy_provider_fallback_total[5m]
+    hivenet_policy_provider_fallback_total[5m]
   )
 )
 ```
@@ -733,13 +733,13 @@ status_code="0"
 Provider failures also increase:
 
 ```text
-hivenet_router_policy_exhausted_total
+hivenet_policy_exhausted_total
 ```
 
 and the corresponding failed-request metrics.
 
 <Note>
-  `hivenet_router_policy_provider_fallback_total` counts successful provider responses, not every attempted provider call.
+  `hivenet_policy_provider_fallback_total` counts successful provider responses, not every attempted provider call.
 
   Use the outbound HTTP histogram and router logs to observe failed attempts.
 </Note>

--- a/docs/routing/routing-concepts.mdx
+++ b/docs/routing/routing-concepts.mdx
@@ -468,7 +468,7 @@ Application-level errors do not trigger connection recovery because the agent re
 Connection resets increment:
 
 ```text
-hivenet_router_agent_connection_resets_total
+hivenet_agent_connection_resets_total
 ```
 
 A sustained increase may indicate repeated network interruption or agent reconnects.
@@ -685,21 +685,21 @@ Inspect policy-related metrics:
 
 ```bash
 curl http://localhost:2112/metrics \
-  | grep hivenet_router_policy
+  | grep hivenet_policy
 ```
 
 Inspect routed requests:
 
 ```bash
 curl http://localhost:2112/metrics \
-  | grep hivenet_router_routing_requests_routed_total
+  | grep hivenet_routing_requests_routed_total
 ```
 
 Inspect stale-connection resets:
 
 ```bash
 curl http://localhost:2112/metrics \
-  | grep hivenet_router_agent_connection_resets_total
+  | grep hivenet_agent_connection_resets_total
 ```
 
 When a complete policy chain is exhausted, the router logs which gate drained each step’s candidate pool.

--- a/docs/security/model-restrictions.mdx
+++ b/docs/security/model-restrictions.mdx
@@ -760,7 +760,7 @@ Inspect successful routed traffic by tenant and model:
 ```promql
 sum by (tenant_id, model) (
   rate(
-    hivenet_router_routing_requests_routed_total[1h]
+    hivenet_routing_requests_routed_total[1h]
   )
 )
 ```
@@ -770,7 +770,7 @@ Inspect all failed or rejected tenant requests:
 ```promql
 sum by (tenant_id, key_id, model) (
   rate(
-    hivenet_router_tenant_requests_failed_total[5m]
+    hivenet_tenant_requests_failed_total[5m]
   )
 )
 ```

--- a/internal/api/audit.go
+++ b/internal/api/audit.go
@@ -195,7 +195,7 @@ func int64Default(v interface{}, def int64) int64 {
 // statusToErrorCode maps HTTP status codes to human-readable error codes.
 // Both RPM and token-budget rejections return HTTP 429; the audit log uses
 // a single "rate_limit_exceeded" code to keep cardinality low. The distinction
-// is visible in Prometheus counters (hivenet_router_tenant_rate_limited_total vs hivenet_router_tenant_token_limited_total).
+// is visible in Prometheus counters (hivenet_tenant_rate_limited_total vs hivenet_tenant_token_limited_total).
 func statusToErrorCode(status int) string {
 	switch status {
 	case http.StatusBadRequest:

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -64,7 +64,7 @@ type AgentStatusView struct {
 }
 
 // AgentUniversalView holds engine-agnostic lifetime counters and latency
-// (matching hivenet_router_agent_* Prometheus metrics).
+// (matching hivenet_agent_* Prometheus metrics).
 type AgentUniversalView struct {
 	SuccessfulRequestsTotal int64    `json:"successful_requests_total"`
 	FailedRequestsTotal     int64    `json:"failed_requests_total"`
@@ -81,7 +81,7 @@ type AgentUniversalView struct {
 }
 
 // AgentEngineView holds real-time engine backend metrics
-// (matching hivenet_router_agent_engine_* Prometheus metrics).
+// (matching hivenet_agent_engine_* Prometheus metrics).
 // Nil when no engine snapshot has been received yet (e.g. Ollama/custom engines).
 type AgentEngineView struct {
 	KVCacheUtilization *float64 `json:"kv_cache_utilization,omitempty"`

--- a/internal/auth/quota.go
+++ b/internal/auth/quota.go
@@ -146,7 +146,7 @@ func (l *InMemoryLimiter) rpmBurst(rpm int) int {
 
 // SetOnTokensUsed registers a callback that fires after every successful token
 // deduction. The callback receives the tenant ID and the cumulative tokens used
-// today. Intended for updating the hivenet_router_tenant_tokens_used_today gauge.
+// today. Intended for updating the hivenet_tenant_tokens_used_today gauge.
 // Must be called before the limiter handles any requests.
 func (l *InMemoryLimiter) SetOnTokensUsed(fn func(tenantID string, used int)) {
 	l.onTokensUsed = fn
@@ -365,7 +365,7 @@ func NewBadgerLimiter(store DailyQuotaStore) *BadgerLimiter {
 }
 
 // SetOnFlushError registers a callback that fires on every diskDB write failure
-// inside Flush. Intended for incrementing the hivenet_router_quota_backend_errors_total
+// inside Flush. Intended for incrementing the hivenet_quota_backend_errors_total
 // Prometheus counter. Must be called before the limiter handles any requests.
 func (l *BadgerLimiter) SetOnFlushError(fn func()) {
 	l.onFlushError = fn

--- a/internal/domain/agent.go
+++ b/internal/domain/agent.go
@@ -282,28 +282,28 @@ type BackendMetrics struct {
 
 	// TTFTHistogram is the raw time-to-first-token histogram snapshot from the
 	// engine. Re-exported by the router via a custom Prometheus collector as
-	// hivenet_router_agent_engine_ttft_seconds_{bucket,sum,count}. Enables correct
+	// hivenet_agent_engine_ttft_seconds_{bucket,sum,count}. Enables correct
 	// fleet-wide percentile aggregation (histogram_quantile on the sum of rates)
 	// and heatmap visualisation — neither of which is possible with scalar gauges.
 	TTFTHistogram *HistogramSnapshot `json:"ttft_histogram,omitempty"`
 
 	// ITLHistogram is the raw inter-token latency histogram snapshot.
-	// Re-exported as hivenet_router_agent_engine_itl_seconds_{bucket,sum,count}.
+	// Re-exported as hivenet_agent_engine_itl_seconds_{bucket,sum,count}.
 	ITLHistogram *HistogramSnapshot `json:"itl_histogram,omitempty"`
 
 	// PromptTokensHistogram is the per-request prompt-length histogram (in tokens).
-	// Re-exported as hivenet_router_agent_engine_request_prompt_tokens_{bucket,sum,count}.
+	// Re-exported as hivenet_agent_engine_request_prompt_tokens_{bucket,sum,count}.
 	// Drives the workload-shape heatmap on the Inference Engine dashboard.
 	PromptTokensHistogram *HistogramSnapshot `json:"prompt_tokens_histogram,omitempty"`
 
 	// GenerationTokensHistogram is the per-request generation-length histogram (in tokens).
-	// Re-exported as hivenet_router_agent_engine_request_generation_tokens_{bucket,sum,count}.
+	// Re-exported as hivenet_agent_engine_request_generation_tokens_{bucket,sum,count}.
 	GenerationTokensHistogram *HistogramSnapshot `json:"generation_tokens_histogram,omitempty"`
 
 	// FinishReasonCounts maps vLLM finished_reason label values (stop, length,
 	// abort, etc.) to cumulative request counts observed on the engine since it
 	// last restarted. The router computes deltas across snapshots and increments
-	// hivenet_router_agent_engine_request_success_total{finished_reason=...}. Pod
+	// hivenet_agent_engine_request_success_total{finished_reason=...}. Pod
 	// restarts are detected as a decrease (new < prev) and the new value is
 	// treated as the post-restart delta.
 	FinishReasonCounts map[string]uint64 `json:"finish_reason_counts,omitempty"`

--- a/internal/metrics/engine_histograms.go
+++ b/internal/metrics/engine_histograms.go
@@ -56,22 +56,22 @@ type engineHistSnapshot struct {
 func newEngineHistogramCollector() *engineHistogramCollector {
 	return &engineHistogramCollector{
 		ttftDesc: prometheus.NewDesc(
-			"hivenet_router_agent_engine_ttft_seconds",
+			"hivenet_agent_engine_ttft_seconds",
 			"Time-to-first-token latency histogram (seconds). Re-exported from the engine's TTFT histogram with the router's label set. Use histogram_quantile() for correct fleet-wide percentiles.",
 			engineHistogramLabels, nil,
 		),
 		itlDesc: prometheus.NewDesc(
-			"hivenet_router_agent_engine_itl_seconds",
+			"hivenet_agent_engine_itl_seconds",
 			"Inter-token latency histogram (seconds). Re-exported from the engine's ITL histogram with the router's label set.",
 			engineHistogramLabels, nil,
 		),
 		promptDesc: prometheus.NewDesc(
-			"hivenet_router_agent_engine_request_prompt_tokens",
+			"hivenet_agent_engine_request_prompt_tokens",
 			"Per-request prompt length histogram (tokens). Drives the prompt-length workload-shape heatmap on the Inference Engine dashboard.",
 			engineHistogramLabels, nil,
 		),
 		genDesc: prometheus.NewDesc(
-			"hivenet_router_agent_engine_request_generation_tokens",
+			"hivenet_agent_engine_request_generation_tokens",
 			"Per-request generation length histogram (tokens). Drives the generation-length workload-shape heatmap on the Inference Engine dashboard.",
 			engineHistogramLabels, nil,
 		),
@@ -203,7 +203,7 @@ func newEngineFinishReasonTracker() *engineFinishReasonTracker {
 // the internal state with the current cumulative counts.
 //
 // First observation for a peer records a baseline and emits no deltas. This
-// prevents a day-zero spike on hivenet_router_agent_engine_request_success_total —
+// prevents a day-zero spike on hivenet_agent_engine_request_success_total —
 // otherwise the vLLM pod's cumulative-since-its-own-startup count would be
 // Add()ed as a single delta on the first scrape, inflating rate() for a full
 // window. After the baseline is recorded, subsequent scrapes compute real

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -302,7 +302,7 @@ type RouterMetrics struct {
 	engineAvgTTFT *prometheus.GaugeVec
 
 	// engineP90TTFT is the 90th-percentile TTFT. Kept as a scalar gauge
-	// alongside the hivenet_router_agent_engine_ttft_seconds histogram because the
+	// alongside the hivenet_agent_engine_ttft_seconds histogram because the
 	// Inference Engine dashboard's per-peer status-history panels read it
 	// directly (one value per peer, no aggregation needed). For fleet-wide
 	// percentiles use histogram_quantile() on the histogram instead.
@@ -349,35 +349,35 @@ func NewRouterMetrics() *RouterMetrics {
 		registry: prometheus.NewRegistry(),
 		agentInfo: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_routing_agent_info",
+				Name: "hivenet_routing_agent_info",
 				Help: "Constant 1 for each agent currently registered in the routing table.",
 			},
 			agentLabels,
 		),
 		agentHealthy: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_routing_agent_healthy",
+				Name: "hivenet_routing_agent_healthy",
 				Help: "1 if the agent is healthy, 0 if the health monitor has marked it unhealthy.",
 			},
 			agentLabels,
 		),
 		agentLastSeen: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_routing_agent_last_seen_timestamp",
+				Name: "hivenet_routing_agent_last_seen_timestamp",
 				Help: "Unix timestamp of the last heartbeat received from the agent.",
 			},
 			agentLabels,
 		),
 		requestsRouted: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_routing_requests_routed_total",
+				Name: "hivenet_routing_requests_routed_total",
 				Help: "Total number of inference requests successfully forwarded to an agent.",
 			},
 			[]string{"region", "engine", "model", "tenant_id"},
 		),
 		requestsFailed: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_routing_requests_failed_total",
+				Name: "hivenet_routing_requests_failed_total",
 				Help: "Total number of inference requests that could not be forwarded.",
 			},
 			[]string{"region", "engine", "model", "tenant_id"},
@@ -385,195 +385,195 @@ func NewRouterMetrics() *RouterMetrics {
 		// Per-tenant billing metrics
 		tenantInputTokens: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_tenant_input_tokens_total",
+				Name: "hivenet_tenant_input_tokens_total",
 				Help: "Lifetime prompt tokens per tenant, API key, and deployment.",
 			},
 			[]string{"tenant_id", "key_id", "deployment_id", "model"},
 		),
 		tenantOutputTokens: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_tenant_output_tokens_total",
+				Name: "hivenet_tenant_output_tokens_total",
 				Help: "Lifetime completion tokens per tenant, API key, and deployment.",
 			},
 			[]string{"tenant_id", "key_id", "deployment_id", "model"},
 		),
 		tenantRequestSuccess: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_tenant_requests_success_total",
+				Name: "hivenet_tenant_requests_success_total",
 				Help: "Successfully served requests per tenant, API key, and deployment.",
 			},
 			[]string{"tenant_id", "key_id", "deployment_id", "model"},
 		),
 		tenantRequestFailed: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_tenant_requests_failed_total",
+				Name: "hivenet_tenant_requests_failed_total",
 				Help: "Failed or rejected requests per tenant, API key, and deployment.",
 			},
 			[]string{"tenant_id", "key_id", "deployment_id", "model"},
 		),
 		tenantRateLimited: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_tenant_rate_limited_total",
+				Name: "hivenet_tenant_rate_limited_total",
 				Help: "Requests rejected due to RPM quota per tenant and API key.",
 			},
 			[]string{"tenant_id", "key_id"},
 		),
 		tenantQuotaRPMLimit: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_tenant_quota_rpm_limit",
+				Name: "hivenet_tenant_quota_rpm_limit",
 				Help: "Configured RPM limit per tenant (0 = unlimited).",
 			},
 			[]string{"tenant_id"},
 		),
 		tenantQuotaTPDLimit: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_tenant_quota_tpd_limit",
-				Help: "Configured tokens-per-day limit per tenant (0 = unlimited). Flat-shape keys only — per-model keys are reported via hivenet_router_tenant_per_model_quota_tpd_limit.",
+				Name: "hivenet_tenant_quota_tpd_limit",
+				Help: "Configured tokens-per-day limit per tenant (0 = unlimited). Flat-shape keys only — per-model keys are reported via hivenet_tenant_per_model_quota_tpd_limit.",
 			},
 			[]string{"tenant_id"},
 		),
 		tenantPerModelQuotaRPMLimit: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_tenant_per_model_quota_rpm_limit",
+				Name: "hivenet_tenant_per_model_quota_rpm_limit",
 				Help: "Effective per-minute RPM ceiling for a (tenant, model) pair on a per-model quota key. For per-replica quotas this is per_replica × live_healthy_replicas, refreshed on admission. 0 = unlimited.",
 			},
 			[]string{"tenant_id", "model"},
 		),
 		tenantPerModelQuotaTPDLimit: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_tenant_per_model_quota_tpd_limit",
+				Name: "hivenet_tenant_per_model_quota_tpd_limit",
 				Help: "Configured tokens-per-day budget for a (tenant, model) pair on a per-model quota key (0 = unlimited).",
 			},
 			[]string{"tenant_id", "model"},
 		),
 		tenantTokensUsedToday: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_tenant_tokens_used_today",
+				Name: "hivenet_tenant_tokens_used_today",
 				Help: "Tokens consumed by the tenant so far today (UTC calendar day). Resets at midnight UTC.",
 			},
 			[]string{"tenant_id"},
 		),
 		tenantTokenLimited: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_tenant_token_limited_total",
+				Name: "hivenet_tenant_token_limited_total",
 				Help: "Requests rejected due to daily token budget per tenant, API key, and deployment, by phase (input|output).",
 			},
 			[]string{"tenant_id", "key_id", "deployment_id", "phase"},
 		),
 		quotaBackendErrors: prometheus.NewCounter(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_quota_backend_errors_total",
+				Name: "hivenet_quota_backend_errors_total",
 				Help: "Redis quota backend call failures (fail-open events).",
 			},
 		),
 		admissionRejections: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_admission_rejections_total",
+				Name: "hivenet_admission_rejections_total",
 				Help: "Requests rejected by an admission gate, by gate/reason (b1, b2, b3, b4_occupancy, b4_itpm, b4_otpm) and model.",
 			},
 			[]string{"reason", "model"},
 		),
 		admissionOccupancyTokens: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_admission_occupancy_tokens",
+				Name: "hivenet_admission_occupancy_tokens",
 				Help: "Current weighted in-flight token sum (Σw) per model — the occupancy-budget numerator.",
 			},
 			[]string{"model"},
 		),
 		admissionBudgetTokens: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_admission_budget_tokens",
+				Name: "hivenet_admission_budget_tokens",
 				Help: "Effective occupancy admit budget (admit_fraction × admit_budget_tokens) per model — the occupancy-budget denominator.",
 			},
 			[]string{"model"},
 		),
 		admissionInflightRequests: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_admission_inflight_requests",
+				Name: "hivenet_admission_inflight_requests",
 				Help: "Current in-flight request count per model, against the max_inflight backstop.",
 			},
 			[]string{"model"},
 		),
 		admissionMaxInflight: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_admission_max_inflight",
+				Name: "hivenet_admission_max_inflight",
 				Help: "Configured max_inflight backstop per model — the concurrency-utilization denominator. 0 = no backstop.",
 			},
 			[]string{"model"},
 		),
 		agentSuccessTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_agent_requests_success_total",
+				Name: "hivenet_agent_requests_success_total",
 				Help: "Lifetime successful requests (HTTP 200) per agent.",
 			},
 			[]string{"peer_id", "model", "engine", "organization", "machine"},
 		),
 		agentFailedTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_agent_requests_failed_total",
+				Name: "hivenet_agent_requests_failed_total",
 				Help: "Lifetime failed requests per agent.",
 			},
 			[]string{"peer_id", "model", "engine", "organization", "machine"},
 		),
 		agentSuccessRate: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_agent_success_rate",
+				Name: "hivenet_agent_success_rate",
 				Help: "Derived success rate (0–1.0) per agent; recomputed on every write.",
 			},
 			[]string{"peer_id", "model", "engine", "organization", "machine"},
 		),
 		agentCapacityUtil: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_agent_capacity_utilization",
+				Name: "hivenet_agent_capacity_utilization",
 				Help: "Real-time ActiveRequests/Capacity ratio per agent.",
 			},
 			[]string{"peer_id", "model", "engine", "organization", "machine"},
 		),
 		agentInputTokens: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_agent_input_tokens_total",
+				Name: "hivenet_agent_input_tokens_total",
 				Help: "Lifetime prompt tokens consumed per agent.",
 			},
 			[]string{"peer_id", "model", "engine", "organization", "machine"},
 		),
 		agentOutputTokens: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_agent_output_tokens_total",
+				Name: "hivenet_agent_output_tokens_total",
 				Help: "Lifetime completion tokens produced per agent.",
 			},
 			[]string{"peer_id", "model", "engine", "organization", "machine"},
 		),
 		agentRejectedTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_agent_rejected_requests_total",
+				Name: "hivenet_agent_rejected_requests_total",
 				Help: "Times TryAcquireSlot returned false (agent at full capacity) per agent.",
 			},
 			[]string{"peer_id", "model", "engine", "organization", "machine"},
 		),
 		agentDisconnections: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_agent_disconnections_total",
+				Name: "hivenet_agent_disconnections_total",
 				Help: "Lifetime disconnection count per agent.",
 			},
 			[]string{"peer_id", "model", "engine", "organization", "machine"},
 		),
 		agentConnectionResets: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_agent_connection_resets_total",
+				Name: "hivenet_agent_connection_resets_total",
 				Help: "Stale-connection evictions performed by the dispatcher on a connection-level forward failure.",
 			},
 			[]string{"model", "reason"},
 		),
 		agentSRTT: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_agent_srtt_ms",
+				Name: "hivenet_agent_srtt_ms",
 				Help: "RFC 6298 smoothed RTT in milliseconds per agent.",
 			},
 			[]string{"peer_id", "model", "engine", "organization", "machine"},
 		),
 		agentRTTVAR: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_agent_rttvar_ms",
+				Name: "hivenet_agent_rttvar_ms",
 				Help: "RFC 6298 RTT variance in milliseconds per agent.",
 			},
 			[]string{"peer_id", "model", "engine", "organization", "machine"},
@@ -582,70 +582,70 @@ func NewRouterMetrics() *RouterMetrics {
 		// Hardware metrics — HAI-65
 		gpuUtil: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_agent_gpu_utilization_percent",
+				Name: "hivenet_agent_gpu_utilization_percent",
 				Help: "GPU compute utilization percent per device.",
 			},
 			[]string{"peer_id", "region", "model", "engine", "gpu_index", "gpu_id", "organization", "machine"},
 		),
 		gpuVRAMUsed: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_agent_gpu_vram_used_bytes",
+				Name: "hivenet_agent_gpu_vram_used_bytes",
 				Help: "VRAM currently in use per device (bytes).",
 			},
 			[]string{"peer_id", "region", "model", "engine", "gpu_index", "gpu_id", "organization", "machine"},
 		),
 		gpuVRAMFree: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_agent_gpu_vram_free_bytes",
+				Name: "hivenet_agent_gpu_vram_free_bytes",
 				Help: "VRAM available per device (bytes).",
 			},
 			[]string{"peer_id", "region", "model", "engine", "gpu_index", "gpu_id", "organization", "machine"},
 		),
 		gpuVRAMTotal: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_agent_gpu_vram_total_bytes",
+				Name: "hivenet_agent_gpu_vram_total_bytes",
 				Help: "Total VRAM capacity per device (bytes).",
 			},
 			[]string{"peer_id", "region", "model", "engine", "gpu_index", "gpu_id", "organization", "machine"},
 		),
 		gpuTemp: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_agent_gpu_temperature_celsius",
+				Name: "hivenet_agent_gpu_temperature_celsius",
 				Help: "GPU die temperature in Celsius per device.",
 			},
 			[]string{"peer_id", "region", "model", "engine", "gpu_index", "gpu_id", "organization", "machine"},
 		),
 		gpuPower: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_agent_gpu_power_watts",
+				Name: "hivenet_agent_gpu_power_watts",
 				Help: "GPU power draw in watts per device.",
 			},
 			[]string{"peer_id", "region", "model", "engine", "gpu_index", "gpu_id", "organization", "machine"},
 		),
 		cpuUsage: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_agent_cpu_usage_percent",
+				Name: "hivenet_agent_cpu_usage_percent",
 				Help: "Node-level CPU utilization percent.",
 			},
 			[]string{"peer_id", "region", "model", "engine", "organization", "machine"},
 		),
 		memUsedPct: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_agent_memory_used_percent",
+				Name: "hivenet_agent_memory_used_percent",
 				Help: "System memory used as a percentage.",
 			},
 			[]string{"peer_id", "region", "model", "engine", "organization", "machine"},
 		),
 		memAvailable: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_agent_memory_available_bytes",
+				Name: "hivenet_agent_memory_available_bytes",
 				Help: "System memory available in bytes.",
 			},
 			[]string{"peer_id", "region", "model", "engine", "organization", "machine"},
 		),
 		memTotal: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_agent_memory_total_bytes",
+				Name: "hivenet_agent_memory_total_bytes",
 				Help: "Total system memory in bytes.",
 			},
 			[]string{"peer_id", "region", "model", "engine", "organization", "machine"},
@@ -654,56 +654,56 @@ func NewRouterMetrics() *RouterMetrics {
 		// Engine punctual metrics — HAI-60
 		engineKVCache: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_agent_engine_kv_cache_utilization",
+				Name: "hivenet_agent_engine_kv_cache_utilization",
 				Help: "Fraction of pre-allocated GPU KV-cache in use (0.0–1.0). Near 1.0 signals imminent preemptions.",
 			},
 			[]string{"peer_id", "model", "engine", "organization", "machine"},
 		),
 		engineRunning: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_agent_engine_running_requests",
+				Name: "hivenet_agent_engine_running_requests",
 				Help: "Number of requests currently being processed by the inference engine.",
 			},
 			[]string{"peer_id", "model", "engine", "organization", "machine"},
 		),
 		engineWaiting: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_agent_engine_waiting_requests",
+				Name: "hivenet_agent_engine_waiting_requests",
 				Help: "Number of requests queued in the engine scheduler. Non-zero means the scheduler is saturated.",
 			},
 			[]string{"peer_id", "model", "engine", "organization", "machine"},
 		),
 		enginePreemptions: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_agent_engine_preemptions_total",
+				Name: "hivenet_agent_engine_preemptions_total",
 				Help: "Cumulative count of requests preempted by the engine. Use rate() in Prometheus to detect KV-cache thrashing.",
 			},
 			[]string{"peer_id", "model", "engine", "organization", "machine"},
 		),
 		engineAvgTTFT: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_agent_engine_avg_ttft_seconds",
+				Name: "hivenet_agent_engine_avg_ttft_seconds",
 				Help: "Running average time-to-first-token in seconds (histogram sum/count). Absent when no requests have completed.",
 			},
 			[]string{"peer_id", "model", "engine", "organization", "machine"},
 		),
 		engineP90TTFT: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_agent_engine_p90_ttft_seconds",
+				Name: "hivenet_agent_engine_p90_ttft_seconds",
 				Help: "P90 time-to-first-token in seconds (histogram quantile). Absent when no requests have completed.",
 			},
 			[]string{"peer_id", "model", "engine", "organization", "machine"},
 		),
 		engineAvgITL: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_agent_engine_avg_itl_seconds",
+				Name: "hivenet_agent_engine_avg_itl_seconds",
 				Help: "Running average inter-token latency in seconds (histogram sum/count). Absent when no tokens have been generated.",
 			},
 			[]string{"peer_id", "model", "engine", "organization", "machine"},
 		),
 		engineP90ITL: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_agent_engine_p90_itl_seconds",
+				Name: "hivenet_agent_engine_p90_itl_seconds",
 				Help: "P90 inter-token latency in seconds (histogram quantile). Absent when no tokens have been generated.",
 			},
 			[]string{"peer_id", "model", "engine", "organization", "machine"},
@@ -711,7 +711,7 @@ func NewRouterMetrics() *RouterMetrics {
 		engineHistograms: newEngineHistogramCollector(),
 		engineFinishReason: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_agent_engine_request_success_total",
+				Name: "hivenet_agent_engine_request_success_total",
 				Help: "Requests completed on the inference engine, partitioned by vLLM finished_reason (stop|length|abort|...). Incremented from cumulative-count deltas observed across scrapes; pod restarts are handled as counter resets.",
 			},
 			[]string{"peer_id", "model", "engine", "organization", "machine", "finished_reason"},
@@ -719,28 +719,28 @@ func NewRouterMetrics() *RouterMetrics {
 		engineFinishState: newEngineFinishReasonTracker(),
 		enginePredictedTPS: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_agent_engine_predicted_tps",
+				Name: "hivenet_agent_engine_predicted_tps",
 				Help: "Token generation throughput in tokens/sec (last-second average). Source: llamacpp:predicted_tokens_seconds.",
 			},
 			[]string{"peer_id", "model", "engine", "organization", "machine"},
 		),
 		enginePromptTPS: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_agent_engine_prompt_tps",
+				Name: "hivenet_agent_engine_prompt_tps",
 				Help: "Prompt ingestion throughput in tokens/sec (last-second average). Source: llamacpp:prompt_tokens_seconds.",
 			},
 			[]string{"peer_id", "model", "engine", "organization", "machine"},
 		),
 		agentFailureTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_agent_failure_total",
+				Name: "hivenet_agent_failure_total",
 				Help: "Total number of times an agent was marked unhealthy due to missed heartbeats (network/process death).",
 			},
 			[]string{"peer_id", "model", "engine", "organization", "machine"},
 		),
 		modelBackendFailureTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_model_backend_failure_total",
+				Name: "hivenet_model_backend_failure_total",
 				Help: "Total number of times an agent reported its inference backend as unhealthy via heartbeat health check.",
 			},
 			[]string{"peer_id", "model", "engine", "organization", "machine"},
@@ -771,42 +771,42 @@ func NewRouterMetrics() *RouterMetrics {
 		),
 		policyPrimaryRouted: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_policy_primary_routed_total",
+				Name: "hivenet_policy_primary_routed_total",
 				Help: "Total requests served by the primary routing_policy step.",
 			},
 			[]string{"model"},
 		),
 		policyFallbackRouted: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_policy_fallback_routed_total",
+				Name: "hivenet_policy_fallback_routed_total",
 				Help: "Total requests served by a fallback chain step (primary step was skipped or exhausted).",
 			},
 			[]string{"model"},
 		),
 		policyExhausted: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_policy_exhausted_total",
+				Name: "hivenet_policy_exhausted_total",
 				Help: "Total requests where all policy steps were exhausted and the client received a 503.",
 			},
 			[]string{"model"},
 		),
 		policyProviderFallbackRouted: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_policy_provider_fallback_total",
+				Name: "hivenet_policy_provider_fallback_total",
 				Help: "Total requests served by the closed-source provider fallback after all local steps were exhausted.",
 			},
 			[]string{"model"},
 		),
 		queueDepth: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_queue_depth",
+				Name: "hivenet_queue_depth",
 				Help: "Current number of requests waiting for a concurrency slot per model.",
 			},
 			[]string{"model"},
 		),
 		queueWaitSeconds: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Name:    "hivenet_router_queue_wait_seconds",
+				Name:    "hivenet_queue_wait_seconds",
 				Help:    "Time requests spend waiting in the per-model capacity queue before being dispatched.",
 				Buckets: prometheus.ExponentialBuckets(0.01, 2, 13), // 10ms to ~40s (0.01 × 2^12 = 40.96s)
 			},
@@ -814,7 +814,7 @@ func NewRouterMetrics() *RouterMetrics {
 		),
 		tenantRequestDuration: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Name:    "hivenet_router_tenant_request_duration_seconds",
+				Name:    "hivenet_tenant_request_duration_seconds",
 				Help:    "End-to-end request duration in seconds per tenant, API key, deployment, and model (handler entry to response written).",
 				Buckets: []float64{0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60},
 			},
@@ -822,7 +822,7 @@ func NewRouterMetrics() *RouterMetrics {
 		),
 		requestDuration: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Name:    "hivenet_router_request_duration_seconds",
+				Name:    "hivenet_request_duration_seconds",
 				Help:    "End-to-end request duration from handler entry to response, labeled by tenant, agent, model, and status.",
 				Buckets: []float64{0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60},
 			},
@@ -830,14 +830,14 @@ func NewRouterMetrics() *RouterMetrics {
 		),
 		tenantLastRequestTimestamp: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "hivenet_router_tenant_last_request_timestamp",
+				Name: "hivenet_tenant_last_request_timestamp",
 				Help: "Unix timestamp (seconds) of the most recent request per tenant, API key, and deployment. Use max() to get last-used time per key.",
 			},
 			[]string{"tenant_id", "key_id", "deployment_id"},
 		),
 		policyReloadTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "hivenet_router_policy_reload_total",
+				Name: "hivenet_policy_reload_total",
 				Help: "Total number of routing policy reload attempts, partitioned by trigger (api|sighup) and result (success|error).",
 			},
 			[]string{"trigger", "result"},
@@ -1137,7 +1137,7 @@ func (m *RouterMetrics) TenantSetTPDLimit(tenantID string, tpd int) {
 // a (tenant, model) pair on a per-model quota key. The value already includes
 // the replica multiplication (per_replica × live_healthy_replicas), so the
 // gauge reflects the actual ceiling admission would apply at this moment —
-// dashboards can compare it against hivenet_router_tenant_per_model_request_total to
+// dashboards can compare it against hivenet_tenant_per_model_request_total to
 // derive utilization. Idempotent to call on every request; pure overwrite.
 func (m *RouterMetrics) TenantSetPerModelQuotaLimit(tenantID, model string, rpm int) {
 	m.tenantPerModelQuotaRPMLimit.With(prometheus.Labels{"tenant_id": tenantID, "model": model}).Set(float64(rpm))

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -271,14 +271,14 @@ func New(cfg *config.Config) (*Router, error) {
 		store.Close() //nolint:errcheck
 		return nil, fmt.Errorf("rate limiter: %w", err)
 	}
-	// Wire the today-usage gauge so hivenet_router_tenant_tokens_used_today is updated
+	// Wire the today-usage gauge so hivenet_tenant_tokens_used_today is updated
 	// on every successful token deduction, regardless of backend strategy.
 	type tokenUsageReporter interface{ SetOnTokensUsed(func(string, int)) }
 	if r, ok := rateLimiter.(tokenUsageReporter); ok {
 		r.SetOnTokensUsed(routerMetrics.TenantSetTokensUsedToday)
 	}
 	// Wire the flush-error counter so diskDB write failures increment
-	// hivenet_router_quota_backend_errors_total instead of being silently dropped.
+	// hivenet_quota_backend_errors_total instead of being silently dropped.
 	type flushErrorReporter interface{ SetOnFlushError(func()) }
 	if r, ok := rateLimiter.(flushErrorReporter); ok {
 		r.SetOnFlushError(routerMetrics.QuotaBackendError)

--- a/test/metrics/admission_metrics_test.go
+++ b/test/metrics/admission_metrics_test.go
@@ -75,7 +75,7 @@ func TestAdmissionRejectionsCounter(t *testing.T) {
 		{"b4_rpm", "qwen", 1},
 	}
 	for _, tc := range cases {
-		got, ok := metricValue(t, m, "hivenet_router_admission_rejections_total",
+		got, ok := metricValue(t, m, "hivenet_admission_rejections_total",
 			map[string]string{"reason": tc.reason, "model": tc.model})
 		if !ok {
 			t.Errorf("no series for reason=%s model=%s", tc.reason, tc.model)
@@ -86,7 +86,7 @@ func TestAdmissionRejectionsCounter(t *testing.T) {
 		}
 	}
 	// A reason that never fired has no series (rather than a zero we'd have to seed).
-	if _, ok := metricValue(t, m, "hivenet_router_admission_rejections_total",
+	if _, ok := metricValue(t, m, "hivenet_admission_rejections_total",
 		map[string]string{"reason": "b1", "model": "gemma"}); ok {
 		t.Error("expected no b1 series before any b1 rejection")
 	}
@@ -102,10 +102,10 @@ func TestAdmissionOccupancyGauges(t *testing.T) {
 		name string
 		want float64
 	}{
-		{"hivenet_router_admission_occupancy_tokens", 250_000},
-		{"hivenet_router_admission_inflight_requests", 1},
-		{"hivenet_router_admission_budget_tokens", 409_000},
-		{"hivenet_router_admission_max_inflight", 64},
+		{"hivenet_admission_occupancy_tokens", 250_000},
+		{"hivenet_admission_inflight_requests", 1},
+		{"hivenet_admission_budget_tokens", 409_000},
+		{"hivenet_admission_max_inflight", 64},
 	} {
 		got, ok := metricValue(t, m, tc.name, map[string]string{"model": "gemma"})
 		if !ok || got != tc.want {
@@ -116,7 +116,7 @@ func TestAdmissionOccupancyGauges(t *testing.T) {
 	// A later update overwrites the gauges (occupancy drains as requests finish),
 	// and a disabled budget drops to 0 rather than staying stale.
 	m.SetAdmissionOccupancy("gemma", 0, 0, 0, 0)
-	if got, _ := metricValue(t, m, "hivenet_router_admission_budget_tokens", map[string]string{"model": "gemma"}); got != 0 {
+	if got, _ := metricValue(t, m, "hivenet_admission_budget_tokens", map[string]string{"model": "gemma"}); got != 0 {
 		t.Errorf("budget gauge must drop to 0 when disabled, got %v", got)
 	}
 }


### PR DESCRIPTION
## Why

Rename all custom Prometheus metrics from the `hivenet_router_*` prefix back to `hivenet_*`. This keeps the metric names continuous with existing Prometheus history and with the dashboards and alerts that consume them.

## What

A single scoped substitution of the token `hivenet_router_` → `hivenet_` (pure prefix strip), applied to:

- **Metric definitions** — `internal/metrics/metrics.go` (63 names), `internal/metrics/engine_histograms.go` (4 histograms).
- **In-code metric-name references / comments** — `internal/domain/agent.go`, `internal/router/router.go`, `internal/api/handlers.go`, `internal/api/audit.go`, `internal/auth/quota.go`.
- **Bundled Grafana dashboards** — `deploy/grafana/provisioning/dashboards/hivenet-router.json`, `tenants.json` (both `expr` and `label_values(...)`).
- **Docs** — `docs/observability/*.mdx` (metric catalog) and scattered references across `docs/`.
- **Test** — `test/metrics/admission_metrics_test.go`.

The hyphenated `hivenet-router*` tokens (job name, service/image names, doc slugs, the dashboard filename) are a different token and are **not** touched. The unprefixed `http_*`, `go_*`, `process_*` metrics are unchanged.

## Verification

- `go build ./...` and `go test ./...` — all packages pass.
- Zero `hivenet_router_` tokens remain; hyphen forms intact; dashboards are valid JSON.